### PR TITLE
Add connection timeout to avpipe params and enhance probe API

### DIFF
--- a/avpipe.c
+++ b/avpipe.c
@@ -966,7 +966,7 @@ xc_init(
     avpipe_io_handler_t *in_handlers = NULL;
     avpipe_io_handler_t *out_handlers = NULL;
 
-    if (!params->url || params->url[0] == '\0' )
+    if (!params || !params->url || params->url[0] == '\0' )
         return eav_param;
 
     init_tx_module();
@@ -1048,7 +1048,7 @@ xc(
     avpipe_io_handler_t *in_handlers;
     avpipe_io_handler_t *out_handlers;
 
-    if (!params->url || params->url[0] == '\0' )
+    if (!params || !params->url || params->url[0] == '\0' )
         return eav_param;
 
     // Note: If log handler functions are set, log levels set through
@@ -1351,7 +1351,7 @@ mux(
     avpipe_io_handler_t *in_handlers;
     avpipe_io_handler_t *out_handlers;
 
-    if (!params->url || params->url[0] == '\0' )
+    if (!params || !params->url || params->url[0] == '\0' )
         return eav_param;
 
     connect_ffmpeg_log();
@@ -1395,8 +1395,7 @@ get_profile_name(
 
 int
 probe(
-    char *url,
-    int seekable,
+    xcparams_t *params,
     xcprobe_t **xcprobe,
     int *n_streams)
 {
@@ -1404,18 +1403,21 @@ probe(
     xcprobe_t *probes;
     int rc;
 
-    rc = set_handlers(url, &in_handlers, NULL);
+    if (!params || !params->url || params->url[0] == '\0' )
+        return eav_param;
+
+    rc = set_handlers(params->url, &in_handlers, NULL);
     if (rc != eav_success)
         goto end_probe;
 
-    rc = avpipe_probe(url, in_handlers, seekable, &probes, n_streams);
+    rc = avpipe_probe(in_handlers, params, &probes, n_streams);
     if (rc != eav_success)
         goto end_probe;
 
     *xcprobe = probes;
 
 end_probe:
-    elv_dbg("Releasing probe resources, url=%s", url != NULL ? url : "");
+    elv_dbg("Releasing probe resources, url=%s", params->url);
     free(in_handlers);
     return rc;
 }

--- a/avpipe.c
+++ b/avpipe.c
@@ -879,7 +879,7 @@ static int
 xc_table_cancel(
     int32_t handle)
 {
-    int rc = 0;
+    int rc = eav_success;
     elv_dbg("xc_table_cancel handle=%d", handle);
     pthread_mutex_lock(&tx_mutex);
     for (int i=0; i<MAX_TX; i++) {
@@ -899,7 +899,7 @@ xc_table_cancel(
             } else {
                 elv_err("xc_table_cancel index=%d doesn't match with handle=%d at %d",
                     xc_table[i]->xctx->index, handle, i);
-                rc = -1;
+                rc = eav_xc_table;
             }
             pthread_mutex_unlock(&tx_mutex);
             return rc;

--- a/avpipe.go
+++ b/avpipe.go
@@ -217,6 +217,7 @@ type XcParams struct {
 	ForceEqualFDuration    bool               `json:"force_equal_frame_duration,omitempty"`
 	MuxingSpec             string             `json:"muxing_spec,omitempty"`
 	Listen                 bool               `json:"listen"`
+	ConnectionTimeout      int                `json:"connection_timeout"`
 	FilterDescriptor       string             `json:"filter_descriptor"`
 	SkipDecoding           bool               `json:"skip_decoding"`
 	DebugFrameLevel        bool               `json:"debug_frame_level"`
@@ -1208,6 +1209,7 @@ func getCParams(params *XcParams) (*C.xcparams_t, error) {
 		sync_audio_to_stream_id:   C.int(params.SyncAudioToStreamId),
 		gpu_index:                 C.int(params.GPUIndex),
 		listen:                    C.int(0),
+		connection_timeout:        C.int(params.ConnectionTimeout),
 		filter_descriptor:         C.CString(params.FilterDescriptor),
 		skip_decoding:             C.int(0),
 		extract_image_interval_ts: C.int64_t(params.ExtractImageIntervalTs),

--- a/avpipe.go
+++ b/avpipe.go
@@ -90,6 +90,7 @@ const (
 	XcAudioPan             = 18 // XcAudio | 0x10
 	XcMux                  = 32
 	XcExtractImages        = 65 // XcVideo | 2^6
+	Xcprobe                = 128
 )
 
 type XcProfile int

--- a/avpipe.h
+++ b/avpipe.h
@@ -1,7 +1,7 @@
 /*
  * avpipe.h
  *
- * Defines all the interfaces available to Go layer.
+ * Defines all the interfaces available to the Go layer.
  * There are two sets of API's available for transcoding/probing in this layer:
  * - APIs with handle: these APIs allow the client application to cancel a transcoding if it is necessary.
  *   - xc_init(): to initialize a transcoding and obtain a handle.
@@ -22,7 +22,7 @@
 
 /**
  * @brief   Initializes a transcoding context and returns its handle.
- *          The transcoding context is internal to C/Go layer.
+ *          The transcoding context is internal to the C/Go layer.
  *
  * @param   params          Transcoding parameters.
  * @param   handle          Pointer to the handle of transcoding context.
@@ -38,7 +38,6 @@ xc_init(
  * @brief   Starts the transcoding specified by handle.
  *
  * @param   handle      The handle of transcoding context that is obtained by xc_init().
- *
  * @return  If it is successful it returns eav_success, otherwise corresponding error.
  */
 int
@@ -49,7 +48,6 @@ xc_run(
  * @brief   Cancels or stops the transcoding specified by handle.
  *
  * @param   handle      The handle of transcoding context that is obtained by xc_init().
- *
  * @return  If it is successful it returns eav_success, otherwise eav_xc_table.
  */
 int
@@ -60,7 +58,6 @@ xc_cancel(
  * @brief   Starts a transcoding job.
  *
  * @param   params      Transcoding parameters.
- *
  * @return  If it is successful it returns eav_success, otherwise corresponding error.
  */
 int
@@ -71,7 +68,6 @@ xc(
  * @brief   Starts a muxing job.
  *
  * @param   params      Muxing parameters.
- *
  * @return  If it is successful it returns eav_success, otherwise corresponding error.
  */
 int
@@ -82,7 +78,6 @@ mux(
  * @brief   Returns pixel format name.
  *
  * @param   pix_fmt     pixel format id.
- *
  * @return  Returns pixel format name.
  */
 const char *
@@ -94,7 +89,6 @@ get_pix_fmt_name(
  *
  * @param   codec_id    codec id.
  * @param   profile     profile id.
- *
  * @return  Returns profile name.
  */
 const char *
@@ -108,7 +102,6 @@ get_profile_name(
  * @param   params      Probing parameters.
  * @param   xcprobe     Probing information array, will be allocated inside this API.
  * @param   n_streams   Number of entries/streams in probing information array.
- *
  * @return  If it is successful it returns eav_success and fills xcprobe array and n_streams,
  *          otherwise returns corresponding error.
  */

--- a/avpipe.h
+++ b/avpipe.h
@@ -1,45 +1,126 @@
+/*
+ * avpipe.h
+ *
+ * Defines all the interfaces available to Go layer.
+ * There are two sets of API's available for transcoding/probing in this layer:
+ * - APIs with handle: these APIs allow the client application to cancel a transcoding if it is necessary.
+ *   - xc_init(): to initialize a transcoding and obtain a handle.
+ *   - xc_run(): to start a transcoding with obtained handle.
+ *   - xc_cancel(): to cancel/stop a transcoding with specified handle.
+ * - APIs with no handle: these APIs are very simple to use and just need transcoding/probing params.
+ *   - xc(): starts a transcoding with specified transcoding params.
+ *   - mux(): starts a muxing job with specified params.
+ *   - probe(): probs the specified stream/file.
+ *
+ * Other miscellaneous APIs are:
+ *   - get_pix_fmt_name(): to obtain pixel format name.
+ *   - get_profile_name(): to obtain profile name.
+ */
 #pragma once
 
 #include "avpipe_xc.h"
 
+/**
+ * @brief   Initializes a transcoding context and returns its handle.
+ *          The transcoding context is internal to C/Go layer.
+ *
+ * @param   params          Transcoding parameters.
+ * @param   handle          Pointer to the handle of transcoding context.
+ *
+ * @return  If it is successful it returns eav_success, otherwise corresponding error.
+ */
 int32_t
 xc_init(
     xcparams_t *params,
     int32_t *handle);
 
+/**
+ * @brief   Starts the transcoding specified by handle.
+ *
+ * @param   handle      The handle of transcoding context that is obtained by xc_init().
+ *
+ * @return  If it is successful it returns eav_success, otherwise corresponding error.
+ */
 int
 xc_run(
     int32_t handle);
 
+/**
+ * @brief   Cancels or stops the transcoding specified by handle.
+ *
+ * @param   handle      The handle of transcoding context that is obtained by xc_init().
+ *
+ * @return  If it is successful it returns eav_success, otherwise eav_xc_table.
+ */
 int
 xc_cancel(
     int32_t handle);
 
+/**
+ * @brief   Starts a transcoding job.
+ *
+ * @param   params      Transcoding parameters.
+ *
+ * @return  If it is successful it returns eav_success, otherwise corresponding error.
+ */
 int
 xc(
     xcparams_t *params);
 
+/**
+ * @brief   Starts a muxing job.
+ *
+ * @param   params      Muxing parameters.
+ *
+ * @return  If it is successful it returns eav_success, otherwise corresponding error.
+ */
 int
 mux(
     xcparams_t *params);
 
+/**
+ * @brief   Returns pixel format name.
+ *
+ * @param   pix_fmt     pixel format id.
+ *
+ * @return  Returns pixel format name.
+ */
 const char *
 get_pix_fmt_name(
     int pix_fmt);
 
+/**
+ * @brief   Returns profile name.
+ *
+ * @param   codec_id    codec id.
+ * @param   profile     profile id.
+ *
+ * @return  Returns profile name.
+ */
 const char *
 get_profile_name(
     int codec_id,
     int profile);
 
+/**
+ * @brief   Starts a probing job.
+ *
+ * @param   params      Probing parameters.
+ * @param   xcprobe     Probing information array, will be allocated inside this API.
+ * @param   n_streams   Number of entries/streams in probing information array.
+ *
+ * @return  If it is successful it returns eav_success, otherwise corresponding error.
+ */
 int
 probe(
     xcparams_t *params,
     xcprobe_t **xcprobe,
     int *n_streams);
 
+/**
+ * @brief   Sets the Go loggers.
+ *
+ * @return  void.
+ */
 void
 set_loggers();
-
-int
-version();

--- a/avpipe.h
+++ b/avpipe.h
@@ -109,7 +109,8 @@ get_profile_name(
  * @param   xcprobe     Probing information array, will be allocated inside this API.
  * @param   n_streams   Number of entries/streams in probing information array.
  *
- * @return  If it is successful it returns eav_success, otherwise corresponding error.
+ * @return  If it is successful it returns eav_success and fills xcprobe array and n_streams,
+ *          otherwise returns corresponding error.
  */
 int
 probe(

--- a/avpipe.h
+++ b/avpipe.h
@@ -34,8 +34,7 @@ get_profile_name(
 
 int
 probe(
-    char *filename,
-    int seekable,
+    xcparams_t *params,
     xcprobe_t **xcprobe,
     int *n_streams);
 

--- a/avpipe_test.go
+++ b/avpipe_test.go
@@ -1669,7 +1669,11 @@ func TestProbe(t *testing.T) {
 	filename := videoBigBuckBunnyPath
 
 	avpipe.InitIOHandler(&fileInputOpener{url: filename}, &concurrentOutputOpener{dir: "O"})
-	probe, err := avpipe.Probe(filename, true)
+	xcparams := &avpipe.XcParams{
+		Url:      filename,
+		Seekable: true,
+	}
+	probe, err := avpipe.Probe(xcparams)
 	failNowOnError(t, err)
 	assert.Equal(t, 3, len(probe.StreamInfo))
 
@@ -1719,7 +1723,11 @@ func TestProbeWithData(t *testing.T) {
 	filename := "./media/TOS8_FHD_51-2_PRHQ_60s_CCBYblendercloud.mov"
 
 	avpipe.InitIOHandler(&fileInputOpener{url: filename}, &concurrentOutputOpener{dir: "O"})
-	probe, err := avpipe.Probe(filename, true)
+	xcparams := &avpipe.XcParams{
+		Url:      filename,
+		Seekable: true,
+	}
+	probe, err := avpipe.Probe(xcparams)
 	failNowOnError(t, err)
 	assert.Equal(t, 9, len(probe.StreamInfo))
 
@@ -1990,7 +1998,11 @@ func boilerProbe(t *testing.T, result *XcTestResult) (probeInfoArray []*avpipe.P
 	}
 
 	for _, mezFile := range result.mezFile {
-		probeInfo, err := avpipe.Probe(mezFile, true)
+		xcparams := &avpipe.XcParams{
+			Url:      mezFile,
+			Seekable: true,
+		}
+		probeInfo, err := avpipe.Probe(xcparams)
 		failNowOnError(t, err)
 
 		si := probeInfo.StreamInfo[0]

--- a/avpipe_test.go
+++ b/avpipe_test.go
@@ -1539,7 +1539,9 @@ func TestABRMuxing(t *testing.T) {
 	videoMezDir := path.Join(baseOutPath, f, "VideoMez4Muxing")
 	audioMezDir := path.Join(baseOutPath, f, "AudioMez4Muxing")
 	videoABRDir := path.Join(baseOutPath, f, "VideoABR4Muxing")
+	videoABRDir2 := path.Join(baseOutPath, f, "VideoABR4Muxing2")
 	audioABRDir := path.Join(baseOutPath, f, "AudioABR4Muxing")
+	audioABRDir2 := path.Join(baseOutPath, f, "AudioABR4Muxing2")
 	muxOutDir := path.Join(baseOutPath, f, "MuxingOutput")
 
 	// Create video mez files
@@ -1576,10 +1578,10 @@ func TestABRMuxing(t *testing.T) {
 	avpipe.InitUrlIOHandler(filename, &fileInputOpener{url: filename}, &fileOutputOpener{dir: audioMezDir})
 	boilerXc(t, params)
 
-	// Create video ABR files
+	// Create video ABR files for the first mez segment
 	setupOutDir(t, videoABRDir)
 	filename = videoMezDir + "/vsegment-1.mp4"
-	log.Debug("STARTING video ABR for muxing", "file", filename)
+	log.Debug("STARTING video ABR for muxing (first segment)", "file", filename)
 	params.XcType = avpipe.XcVideo
 	params.Format = "dash"
 	params.VideoSegDurationTs = 48000
@@ -1587,7 +1589,20 @@ func TestABRMuxing(t *testing.T) {
 	avpipe.InitUrlIOHandler(filename, &fileInputOpener{url: filename}, &fileOutputOpener{dir: videoABRDir})
 	boilerXc(t, params)
 
-	// Create audio ABR files
+	// Create video ABR files for the second mez segment
+	setupOutDir(t, videoABRDir2)
+	filename = videoMezDir + "/vsegment-2.mp4"
+	log.Debug("STARTING video ABR for muxing (second segment)", "file", filename)
+	params.XcType = avpipe.XcVideo
+	params.Format = "dash"
+	params.VideoSegDurationTs = 48000
+	params.Url = filename
+	params.StartSegmentStr = "16"
+	params.StartPts = 721720
+	avpipe.InitUrlIOHandler(filename, &fileInputOpener{url: filename}, &fileOutputOpener{dir: videoABRDir2})
+	boilerXc(t, params)
+
+	// Create audio ABR files for the first mez segment
 	setupOutDir(t, audioABRDir)
 	filename = audioMezDir + "/asegment-1.mp4"
 	log.Debug("STARTING audio ABR for muxing", "file", filename)
@@ -1596,7 +1611,23 @@ func TestABRMuxing(t *testing.T) {
 	params.Ecodec2 = "aac"
 	params.AudioSegDurationTs = 96000
 	params.Url = filename
+	params.StartSegmentStr = "1"
+	params.StartPts = 0
 	avpipe.InitUrlIOHandler(filename, &fileInputOpener{url: filename}, &fileOutputOpener{dir: audioABRDir})
+	boilerXc(t, params)
+
+	// Create audio ABR files for the second mez segment
+	setupOutDir(t, audioABRDir2)
+	filename = audioMezDir + "/asegment-2.mp4"
+	log.Debug("STARTING audio ABR for muxing (first segment)", "file", filename)
+	params.XcType = avpipe.XcAudio
+	params.Format = "dash"
+	params.Ecodec2 = "aac"
+	params.AudioSegDurationTs = 96000
+	params.Url = filename
+	params.StartPts = 1441792
+	params.StartSegmentStr = "16"
+	avpipe.InitUrlIOHandler(filename, &fileInputOpener{url: filename}, &fileOutputOpener{dir: audioABRDir2})
 	boilerXc(t, params)
 
 	// Create playable file by muxing audio/video segments
@@ -1606,9 +1637,16 @@ func TestABRMuxing(t *testing.T) {
 	for i := 1; i <= 15; i++ {
 		muxSpec += fmt.Sprintf("%s%s%s%02d%s\n", "audio,1,", audioABRDir, "/achunk-stream0-000", i, ".m4s")
 	}
+	for i := 16; i <= 30; i++ {
+		muxSpec += fmt.Sprintf("%s%s%s%02d%s\n", "audio,1,", audioABRDir2, "/achunk-stream0-000", i, ".m4s")
+	}
+
 	muxSpec += "video,1," + videoABRDir + "/vinit-stream0.m4s\n"
 	for i := 1; i <= 15; i++ {
 		muxSpec += fmt.Sprintf("%s%s%s%02d%s\n", "video,1,", videoABRDir, "/vchunk-stream0-000", i, ".m4s")
+	}
+	for i := 16; i <= 30; i++ {
+		muxSpec += fmt.Sprintf("%s%s%s%02d%s\n", "video,1,", videoABRDir2, "/vchunk-stream0-000", i, ".m4s")
 	}
 	filename = muxOutDir + "/segment-1.mp4"
 	params.MuxingSpec = muxSpec
@@ -1630,6 +1668,17 @@ func TestABRMuxing(t *testing.T) {
 	// Now probe the generated files
 	videoMezProbeInfo := boilerProbe(t, xcTestResult)
 
+	xcTestResult2 := &XcTestResult{
+		mezFile:   []string{fmt.Sprintf("%s/vsegment-2.mp4", videoMezDir)},
+		timeScale: 24000,
+		level:     31,
+		pixelFmt:  "yuv420p",
+	}
+	// Now probe mez video and output file and become sure both have the same duration
+	avpipe.InitIOHandler(&fileInputOpener{url: xcTestResult.mezFile[0]}, &fileOutputOpener{dir: videoMezDir})
+	// Now probe the generated files
+	videoMezProbeInfo2 := boilerProbe(t, xcTestResult2)
+
 	xcTestResult = &XcTestResult{
 		mezFile:   []string{fmt.Sprintf("%s/segment-1.mp4", muxOutDir)},
 		timeScale: 24000,
@@ -1639,7 +1688,7 @@ func TestABRMuxing(t *testing.T) {
 	avpipe.InitIOHandler(&fileInputOpener{url: xcTestResult.mezFile[0]}, &fileOutputOpener{dir: muxOutDir})
 	muxOutProbeInfo := boilerProbe(t, xcTestResult)
 
-	assert.Equal(t, true, int(videoMezProbeInfo[0].ContainerInfo.Duration) == int(muxOutProbeInfo[0].ContainerInfo.Duration))
+	assert.Equal(t, true, int(videoMezProbeInfo[0].ContainerInfo.Duration+videoMezProbeInfo2[0].ContainerInfo.Duration) == int(muxOutProbeInfo[0].ContainerInfo.Duration))
 }
 
 func TestMarshalParams(t *testing.T) {

--- a/elvxc/cmd/probe.go
+++ b/elvxc/cmd/probe.go
@@ -20,6 +20,7 @@ func Probe(cmdRoot *cobra.Command) error {
 	cmdProbe.PersistentFlags().StringP("filename", "f", "", "(mandatory) filename to be probed")
 	cmdProbe.PersistentFlags().BoolP("seekable", "", false, "(optional) seekable stream")
 	cmdProbe.PersistentFlags().BoolP("listen", "", false, "listen mode for RTMP.")
+	cmdProbe.PersistentFlags().Int32("connection-timeout", 0, "connection timeout for RTMP when listening on a port.")
 
 	return nil
 }
@@ -35,7 +36,11 @@ func doProbe(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("Invalid seekable flag")
 	}
-	log.Debug("doProbe", "seekable", seekable, "filename", filename)
+
+	connectionTimeout, err := cmd.Flags().GetInt32("connection-timeout")
+	if err != nil {
+		return fmt.Errorf("Invalid connection-timeout flag")
+	}
 
 	listen, err := cmd.Flags().GetBool("listen")
 	if err != nil {
@@ -43,9 +48,10 @@ func doProbe(cmd *cobra.Command, args []string) error {
 	}
 
 	params := &avpipe.XcParams{
-		Url:      filename,
-		Seekable: seekable,
-		Listen:   listen,
+		Url:               filename,
+		Seekable:          seekable,
+		Listen:            listen,
+		ConnectionTimeout: int(connectionTimeout),
 	}
 
 	avpipe.InitIOHandler(&elvxcInputOpener{url: filename}, &elvxcOutputOpener{dir: ""})

--- a/elvxc/cmd/probe.go
+++ b/elvxc/cmd/probe.go
@@ -20,7 +20,7 @@ func Probe(cmdRoot *cobra.Command) error {
 	cmdProbe.PersistentFlags().StringP("filename", "f", "", "(mandatory) filename to be probed")
 	cmdProbe.PersistentFlags().BoolP("seekable", "", false, "(optional) seekable stream")
 	cmdProbe.PersistentFlags().BoolP("listen", "", false, "listen mode for RTMP.")
-	cmdProbe.PersistentFlags().Int32("connection-timeout", 0, "connection timeout for RTMP when listening on a port.")
+	cmdProbe.PersistentFlags().Int32("connection-timeout", 0, "connection timeout for RTMP when listening on a port or MPEGTS to receive first UDP datagram.")
 
 	return nil
 }

--- a/elvxc/cmd/probe.go
+++ b/elvxc/cmd/probe.go
@@ -19,6 +19,7 @@ func Probe(cmdRoot *cobra.Command) error {
 
 	cmdProbe.PersistentFlags().StringP("filename", "f", "", "(mandatory) filename to be probed")
 	cmdProbe.PersistentFlags().BoolP("seekable", "", false, "(optional) seekable stream")
+	cmdProbe.PersistentFlags().BoolP("listen", "", false, "listen mode for RTMP.")
 
 	return nil
 }
@@ -36,9 +37,20 @@ func doProbe(cmd *cobra.Command, args []string) error {
 	}
 	log.Debug("doProbe", "seekable", seekable, "filename", filename)
 
+	listen, err := cmd.Flags().GetBool("listen")
+	if err != nil {
+		return fmt.Errorf("Invalid listen flag")
+	}
+
+	params := &avpipe.XcParams{
+		Url:      filename,
+		Seekable: seekable,
+		Listen:   listen,
+	}
+
 	avpipe.InitIOHandler(&elvxcInputOpener{url: filename}, &elvxcOutputOpener{dir: ""})
 
-	probe, err := avpipe.Probe(filename, seekable)
+	probe, err := avpipe.Probe(params)
 	if err != nil {
 		return fmt.Errorf("Probing failed. file=%s", filename)
 	}

--- a/elvxc/cmd/transcode.go
+++ b/elvxc/cmd/transcode.go
@@ -263,6 +263,7 @@ func InitTranscode(cmdRoot *cobra.Command) error {
 	cmdTranscode.PersistentFlags().BoolP("debug-frame-level", "", false, "debug frame level.")
 	cmdTranscode.PersistentFlags().BoolP("skip-decoding", "", false, "skip decoding when start-time-ts is set.")
 	cmdTranscode.PersistentFlags().BoolP("listen", "", false, "listen mode for RTMP.")
+	cmdTranscode.PersistentFlags().Int32("connection-timeout", 0, "connection timeout for RTMP when listening on a port.")
 	cmdTranscode.PersistentFlags().Int32P("threads", "t", 1, "transcoding threads.")
 	cmdTranscode.PersistentFlags().StringP("audio-index", "", "", "the indexes of audio stream (comma separated).")
 	cmdTranscode.PersistentFlags().StringP("channel-layout", "", "", "audio channel layout.")
@@ -347,6 +348,11 @@ func doTranscode(cmd *cobra.Command, args []string) error {
 	listen, err := cmd.Flags().GetBool("listen")
 	if err != nil {
 		return fmt.Errorf("Invalid listen flag")
+	}
+
+	connectionTimeout, err := cmd.Flags().GetInt32("connection-timeout")
+	if err != nil {
+		return fmt.Errorf("Invalid connection-timeout flag")
 	}
 
 	forceEqualFrameDuration, err := cmd.Flags().GetBool("equal-fduration")
@@ -662,6 +668,7 @@ func doTranscode(cmd *cobra.Command, args []string) error {
 		SyncAudioToStreamId:    int(syncAudioToStreamId),
 		StreamId:               streamId,
 		Listen:                 listen,
+		ConnectionTimeout:      int(connectionTimeout),
 		FilterDescriptor:       filterDescriptor,
 		SkipDecoding:           skipDecoding,
 		ExtractImageIntervalTs: extractImageIntervalTs,

--- a/elvxc/cmd/transcode.go
+++ b/elvxc/cmd/transcode.go
@@ -263,7 +263,7 @@ func InitTranscode(cmdRoot *cobra.Command) error {
 	cmdTranscode.PersistentFlags().BoolP("debug-frame-level", "", false, "debug frame level.")
 	cmdTranscode.PersistentFlags().BoolP("skip-decoding", "", false, "skip decoding when start-time-ts is set.")
 	cmdTranscode.PersistentFlags().BoolP("listen", "", false, "listen mode for RTMP.")
-	cmdTranscode.PersistentFlags().Int32("connection-timeout", 0, "connection timeout for RTMP when listening on a port.")
+	cmdTranscode.PersistentFlags().Int32("connection-timeout", 0, "connection timeout for RTMP when listening on a port or MPEGTS to receive first UDP datagram.")
 	cmdTranscode.PersistentFlags().Int32P("threads", "t", 1, "transcoding threads.")
 	cmdTranscode.PersistentFlags().StringP("audio-index", "", "", "the indexes of audio stream (comma separated).")
 	cmdTranscode.PersistentFlags().StringP("channel-layout", "", "", "audio channel layout.")

--- a/exc/elv_xc.c
+++ b/exc/elv_xc.c
@@ -1750,6 +1750,5 @@ main(
 
     free(tids);
 
-    elv_log("rc=%d", rc);
     return rc;
 }

--- a/exc/elv_xc.c
+++ b/exc/elv_xc.c
@@ -1109,6 +1109,7 @@ usage(
         "\t-bypass :                (optional) Bypass transcoding. Default is 0, must be 0 or 1\n"
         "\t-channel-layout :        (optional) Channel layout for audio, can be \"mono\", \"stereo\", \"5.0\" or \"5.1\"....\n"
         "\t-command :               (optional) Directing command of exc, can be \"transcode\", \"probe\" or \"mux\" (default is transcode).\n"
+        "\t-connection-timeout:     (optional) Default 10 sec. Connection timeout for rtmp or mpegts protocols.\n"
         "\t-crf :                   (optional) Mutually exclusive with video-bitrate. Default: 23\n"
         "\t-crypt-iv :              (optional) 128-bit AES IV, as hex\n"
         "\t-crypt-key :             (optional) 128-bit AES key, as hex\n"
@@ -1239,6 +1240,7 @@ main(
         .rc_max_rate = 0,
         .sample_rate = -1,                  /* Audio sampling rate 44100 */
         .channel_layout = 0,                /* Preserve input channel layout */
+        .connection_timeout = 10,
         .seekable = 0,
         .video_seg_duration_ts = -1,        /* input argument, same units as input stream PTS */
         .audio_seg_duration_ts = -1,        /* input argument, same units as input stream PTS */
@@ -1324,6 +1326,10 @@ main(
                 }
             } else if (!strcmp(argv[i], "-crf")) {
                 p.crf_str = strdup(argv[i+1]);
+            } else if (!strcmp(argv[i], "-connection-timeout")) {
+                if (sscanf(argv[i+1], "%d", &p.connection_timeout) != 1) {
+                    usage(argv[0], argv[i], EXIT_FAILURE);
+                }
             } else if (!strcmp(argv[i], "-channel-layout")) {
                 p.channel_layout = av_get_channel_layout(argv[i+1]);
                 if (p.channel_layout == 0)

--- a/exc/elv_xc.c
+++ b/exc/elv_xc.c
@@ -1115,7 +1115,7 @@ usage(
         "\t-bypass :                (optional) Bypass transcoding. Default is 0, must be 0 or 1\n"
         "\t-channel-layout :        (optional) Channel layout for audio, can be \"mono\", \"stereo\", \"5.0\" or \"5.1\"....\n"
         "\t-command :               (optional) Directing command of exc, can be \"transcode\", \"probe\" or \"mux\" (default is transcode).\n"
-        "\t-connection-timeout:     (optional) Default 10 sec. Connection timeout for rtmp or mpegts protocols.\n"
+        "\t-connection-timeout:     (optional) Seconds (default 10). Connection timeout for rtmp or mpegts protocols.\n"
         "\t-crf :                   (optional) Mutually exclusive with video-bitrate. Default: 23\n"
         "\t-crypt-iv :              (optional) 128-bit AES IV, as hex\n"
         "\t-crypt-key :             (optional) 128-bit AES key, as hex\n"

--- a/exc/elv_xc.c
+++ b/exc/elv_xc.c
@@ -75,7 +75,6 @@ udp_thread_func(
             elv_err("UDP select error fd=%d, err=%d, url=%s", params->fd, errno, url);
             break;
         } else if (ret == 0) {
-            elv_log("XXX UDP read timeout, connection_timeout=%d", connection_timeout);
             /* If no packet has not received yet, check connection_timeout */
             if (first) {
                 if (connection_timeout > 0) {

--- a/libavpipe/include/avpipe_version.h
+++ b/libavpipe/include/avpipe_version.h
@@ -10,5 +10,5 @@
 
 /* Only increase these versions for release purposes */
 #define AVPIPE_MAJOR_VERSION    1
-#define AVPIPE_MINOR_VERSION    0
+#define AVPIPE_MINOR_VERSION    1
 

--- a/libavpipe/include/avpipe_xc.h
+++ b/libavpipe/include/avpipe_xc.h
@@ -427,6 +427,7 @@ typedef struct xcparams_t {
     int         extract_images_sz;          // Size of the array extract_images_ts
 
     int         debug_frame_level;
+    int         connection_timeout;         // Connection timeout for RTMP or MPEGTS protocols
 } xcparams_t;
 
 #define MAX_CODEC_NAME  256

--- a/libavpipe/include/avpipe_xc.h
+++ b/libavpipe/include/avpipe_xc.h
@@ -579,8 +579,7 @@ avpipe_channel_name(
  * @brief   Probes object stream specified by input handler.
  *
  * @param   in_handlers     A pointer to input handlers that direct the probe
- * @param   seekable        A flag to specify whether input stream is seakable or no
- * @param   params          A pointer to the parameters for transcoding.
+ * @param   params          A pointer to the parameters for transcoding/probing.
  * @param   xcprob          A pointer to the xcprobe_t that could contain probing info.
  * @param   n_streams       Will contail number of streams that are probed if successful.
  * @return  Returns 0 if successful, otherwise corresponding eav error.

--- a/libavpipe/include/avpipe_xc.h
+++ b/libavpipe/include/avpipe_xc.h
@@ -427,7 +427,7 @@ typedef struct xcparams_t {
     int         extract_images_sz;          // Size of the array extract_images_ts
 
     int         debug_frame_level;
-    int         connection_timeout;         // Connection timeout for RTMP or MPEGTS protocols
+    int         connection_timeout;         // Connection timeout in sec for RTMP or MPEGTS protocols
 } xcparams_t;
 
 #define MAX_CODEC_NAME  256

--- a/libavpipe/include/avpipe_xc.h
+++ b/libavpipe/include/avpipe_xc.h
@@ -337,7 +337,8 @@ typedef enum xc_type_t {
     xc_audio_join     = 10,   // 0x08 | xc_audio
     xc_audio_pan      = 18,   // 0x10 | xc_audio
     xc_mux            = 32,
-    xc_extract_images = 65
+    xc_extract_images = 65,
+    xc_probe          = 128
 } xc_type_t;
 
 /* handled image types in get_overlay_filter_string*/
@@ -576,18 +577,17 @@ avpipe_channel_name(
 /**
  * @brief   Probes object stream specified by input handler.
  *
- * @param   url             url/filename of the media content to probe
  * @param   in_handlers     A pointer to input handlers that direct the probe
  * @param   seekable        A flag to specify whether input stream is seakable or no
+ * @param   params          A pointer to the parameters for transcoding.
  * @param   xcprob          A pointer to the xcprobe_t that could contain probing info.
  * @param   n_streams       Will contail number of streams that are probed if successful.
  * @return  Returns 0 if successful, otherwise corresponding eav error.
  */
 int
 avpipe_probe(
-    char *url,
     avpipe_io_handler_t *in_handlers,
-    int seekable,
+    xcparams_t *params,
     xcprobe_t **xcprobe,
     int *n_streams);
 

--- a/libavpipe/src/avpipe_mux.c
+++ b/libavpipe/src/avpipe_mux.c
@@ -383,6 +383,7 @@ get_next_packet(
     pkt->stream_index = index;
     xctx->is_pkt_valid[index] = 0;
 
+    pkt->dts = pkt->pts;
     dump_packet(pkt->stream_index, "MUX IN ", pkt, xctx->debug_frame_level);
 
 read_frame_again:
@@ -392,7 +393,7 @@ read_frame_again:
         if (pkts[index].pts == pkt->pts)
             goto read_frame_again;
         xctx->is_pkt_valid[index] = 1;
-        if (pkt->pts > 0) {
+        if (pkt->pts >= 0) {
             if (index == 0) {
                 if (pkt->pts > in_mux_ctx->last_video_pts)
                     in_mux_ctx->last_video_pts = pkt->pts;
@@ -447,7 +448,7 @@ avpipe_mux(
         if (ret <= 0)
             break;
 
-        dump_packet(pkt.stream_index, "MUX OUT ", &pkt, 1);
+        dump_packet(pkt.stream_index, "MUX OUT ", &pkt, xctx->debug_frame_level);
 
         if (av_interleaved_write_frame(xctx->out_muxer_ctx.format_context, &pkt) < 0) {
             elv_err("Failure in copying mux packet");

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -3844,6 +3844,7 @@ avpipe_probe(
     url = params->url;
     // Disable sync audio to stream id when probing
     params->sync_audio_to_stream_id = -1;
+    params->stream_id = -1;
 
     if (!in_handlers) {
         elv_err("avpipe_probe NULL handlers, url=%s", url);

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -3852,6 +3852,7 @@ avpipe_probe(
         goto avpipe_probe_end;
     }
 
+    inctx.params = params;
     if (in_handlers->avpipe_opener(url, &inctx) < 0) {
         rc = eav_open_input;
         goto avpipe_probe_end;
@@ -4107,7 +4108,7 @@ avpipe_init(
     xcparams_t *p)
 {
     xctx_t *p_xctx = NULL;
-    xcparams_t *params;
+    xcparams_t *params = NULL;
     int rc = 0;
     ioctx_t *inctx = (ioctx_t *)calloc(1, sizeof(ioctx_t));
 
@@ -4118,6 +4119,9 @@ avpipe_init(
         goto avpipe_init_failed;
     }
 
+    params = (xcparams_t *) calloc(1, sizeof(xcparams_t));
+    *params = *p;
+    inctx->params = params;
     if (!p->url || p->url[0] == '\0' ||
         in_handlers->avpipe_opener(p->url, inctx) < 0) {
         elv_err("Failed to open avpipe input \"%s\"", p->url != NULL ? p->url : "");
@@ -4133,14 +4137,11 @@ avpipe_init(
     }
 
     p_xctx = (xctx_t *) calloc(1, sizeof(xctx_t));
-    params = (xcparams_t *) calloc(1, sizeof(xcparams_t));
-    *params = *p;
     p_xctx->params = params;
     p_xctx->inctx = inctx;
     p_xctx->in_handlers = in_handlers;
     p_xctx->out_handlers = out_handlers;
     p_xctx->debug_frame_level = p->debug_frame_level;
-    inctx->params = params;
 
     if (!params->format ||
         (strcmp(params->format, "dash") &&

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -3943,12 +3943,6 @@ avpipe_probe(
 
 avpipe_probe_end:
     if (decoder_ctx.format_context) {
-        /*AVIOContext *avioctx = (AVIOContext *) decoder_ctx.format_context->pb;
-        if (avioctx) {
-            av_freep(&avioctx->buffer);
-            av_freep(&avioctx);
-        }
-*/
         avformat_close_input(&decoder_ctx.format_context);
     }
 

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -389,6 +389,13 @@ prepare_decoder(
     AVDictionary *opts = NULL;
     if (params && params->listen)
         av_dict_set(&opts, "listen", "1" , 0);
+
+    if (decoder_context->is_rtmp && params->connection_timeout > 0) {
+        char timeout[32];
+        sprintf(timeout, "%d", params->connection_timeout);
+        av_dict_set(&opts, "timeout", timeout, 0);
+    }
+
     /* Allocate AVFormatContext in format_context and find input file format */
     rc = avformat_open_input(&decoder_context->format_context, inctx->url, NULL, &opts);
     if (rc != 0) {
@@ -3932,11 +3939,12 @@ avpipe_probe(
 
 avpipe_probe_end:
     if (decoder_ctx.format_context) {
-        AVIOContext *avioctx = (AVIOContext *) decoder_ctx.format_context->pb;
+        /*AVIOContext *avioctx = (AVIOContext *) decoder_ctx.format_context->pb;
         if (avioctx) {
             av_freep(&avioctx->buffer);
             av_freep(&avioctx);
         }
+*/
         avformat_close_input(&decoder_ctx.format_context);
     }
 

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -3842,6 +3842,8 @@ avpipe_probe(
     }
 
     url = params->url;
+    // Disable sync audio to stream id when probing
+    params->sync_audio_to_stream_id = -1;
 
     if (!in_handlers) {
         elv_err("avpipe_probe NULL handlers, url=%s", url);

--- a/live/lhr_tool_test.go
+++ b/live/lhr_tool_test.go
@@ -16,9 +16,9 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/eluv-io/avpipe"
 	"github.com/eluv-io/errors-go"
 	elog "github.com/eluv-io/log-go"
-	"github.com/eluv-io/avpipe"
 )
 
 //
@@ -356,10 +356,15 @@ func _TestAudioVideoHlsLive(t *testing.T) {
 
 func (io *inputOpener) Open(fd int64, url string) (avpipe.InputHandler, error) {
 	tlog.Debug("IN_OPEN", "fd", fd, "url", url)
+
 	io.url = url
 	tc, err := getReqCtxByURL(url)
 	if err != nil {
 		return nil, err
+	}
+
+	if (len(url) >= 4 && url[0:4] == "rtmp") || (len(url) >= 3 && url[0:3] == "udp") {
+		return &inputCtx{tc: tc}, nil
 	}
 
 	tc.fd = fd
@@ -443,7 +448,8 @@ func (i *inputCtx) Close() (err error) {
 }
 
 func (i *inputCtx) Size() int64 {
-	if i.tc.url[0:3] == "udp" {
+	if (len(i.tc.url) > 3 && i.tc.url[0:3] == "udp") ||
+		(len(i.tc.url) > 4 && i.tc.url[0:4] == "rtmp") {
 		if debugFrameLevel {
 			tlog.Debug("IN_SIZE", "url", i.tc.url)
 		}

--- a/live/lhr_tool_test.go
+++ b/live/lhr_tool_test.go
@@ -364,6 +364,8 @@ func (io *inputOpener) Open(fd int64, url string) (avpipe.InputHandler, error) {
 	}
 
 	if (len(url) >= 4 && url[0:4] == "rtmp") || (len(url) >= 3 && url[0:3] == "udp") {
+		tc.fd = fd
+		putReqCtxByFD(fd, tc)
 		return &inputCtx{tc: tc}, nil
 	}
 

--- a/live/live_probe_test.go
+++ b/live/live_probe_test.go
@@ -13,7 +13,7 @@ import (
 // 2) avpipe probe connects to listening ffmpeg and probes the stream
 func TestProbeRTMPConnect(t *testing.T) {
 	setupLogging()
-	outputDir := "TestProbeListenRTMP"
+	outputDir := "TestProbeRTMPConnect"
 
 	// Create output directory if it doesn't exist
 	if _, err := os.Stat(outputDir); os.IsNotExist(err) {
@@ -68,7 +68,7 @@ func TestProbeRTMPConnect(t *testing.T) {
 // 2) Starts ffmpeg to connect to listening avpipe
 func TestProbeRTMPListen(t *testing.T) {
 	setupLogging()
-	outputDir := "TestProbeListenRTMP"
+	outputDir := "TestProbeRTMPListen"
 
 	// Create output directory if it doesn't exist
 	if _, err := os.Stat(outputDir); os.IsNotExist(err) {
@@ -123,5 +123,120 @@ func TestProbeRTMPListen(t *testing.T) {
 	assert.Equal(t, 0, probeInfo.StreamInfo[1].ChannelLayout)
 
 	liveSource.Stop()
+}
 
+// 1) Starts ffmpeg for streaming UDP MPEGTS
+// 2) avpipe probe reads the generated UDP stream and probes the stream
+func TestProbeUDPConnect(t *testing.T) {
+	setupLogging()
+	outputDir := "TestProbeUDPConnect"
+
+	// Create output directory if it doesn't exist
+	if _, err := os.Stat(outputDir); os.IsNotExist(err) {
+		os.Mkdir(outputDir, 0755)
+	}
+
+	liveSource := NewLiveSource()
+	url := fmt.Sprintf("udp://localhost:%d", liveSource.Port)
+
+	// Start ffmpeg UDP MPEGTS
+	err := liveSource.Start("udp")
+	if err != nil {
+		t.Error(err)
+	}
+
+	time.Sleep(2 * time.Second)
+
+	XCParams := &avpipe.XcParams{
+		Seekable:          false,
+		XcType:            avpipe.Xcprobe,
+		StreamId:          -1,
+		Url:               url,
+		DebugFrameLevel:   debugFrameLevel,
+		ConnectionTimeout: 5,
+	}
+
+	// Transcode audio mez files in background
+	reqCtx := &testCtx{url: url}
+	putReqCtxByURL(url, reqCtx)
+
+	avpipe.InitIOHandler(&inputOpener{dir: outputDir}, &outputOpener{dir: outputDir})
+
+	tlog.Info("Probing MPEGTS stream start", "params", fmt.Sprintf("%+v", *XCParams))
+	probeInfo, err := avpipe.Probe(XCParams)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "h264", probeInfo.StreamInfo[0].CodecName)
+	assert.Equal(t, 1280, probeInfo.StreamInfo[0].Width)
+	assert.Equal(t, 720, probeInfo.StreamInfo[0].Height)
+	assert.Equal(t, 100, probeInfo.StreamInfo[0].Profile)
+	assert.Equal(t, 32, probeInfo.StreamInfo[0].Level)
+
+	assert.Equal(t, "ac3", probeInfo.StreamInfo[1].CodecName)
+	assert.Equal(t, int64(384000), probeInfo.StreamInfo[1].BitRate)
+	assert.Equal(t, 6, probeInfo.StreamInfo[1].Channels)
+	assert.Equal(t, 1551, probeInfo.StreamInfo[1].ChannelLayout)
+
+	liveSource.Stop()
+
+}
+
+// 1) Starts avpipe probe to read UDP stream and probes the stream
+// 2) Starts ffmpeg for streaming UDP MPEGTS
+func TestProbeUDPListen(t *testing.T) {
+	setupLogging()
+	outputDir := "TestProbeUDPConnect"
+
+	// Create output directory if it doesn't exist
+	if _, err := os.Stat(outputDir); os.IsNotExist(err) {
+		os.Mkdir(outputDir, 0755)
+	}
+
+	liveSource := NewLiveSource()
+	url := fmt.Sprintf("udp://localhost:%d", liveSource.Port)
+
+	XCParams := &avpipe.XcParams{
+		Seekable:        false,
+		XcType:          avpipe.Xcprobe,
+		StreamId:        -1,
+		Url:             url,
+		DebugFrameLevel: debugFrameLevel,
+	}
+
+	// Transcode audio mez files in background
+	reqCtx := &testCtx{url: url}
+	putReqCtxByURL(url, reqCtx)
+
+	avpipe.InitIOHandler(&inputOpener{dir: outputDir}, &outputOpener{dir: outputDir})
+
+	done := make(chan bool, 1)
+	var probeInfo *avpipe.ProbeInfo
+	var err error
+
+	go func() {
+		tlog.Info("Probing MPEGTS stream start", "params", fmt.Sprintf("%+v", *XCParams))
+		probeInfo, err = avpipe.Probe(XCParams)
+		done <- true
+	}()
+
+	// Start ffmpeg UDP MPEGTS
+	err = liveSource.Start("udp")
+	if err != nil {
+		t.Error(err)
+	}
+
+	<-done
+	assert.NoError(t, err)
+	assert.Equal(t, "h264", probeInfo.StreamInfo[0].CodecName)
+	assert.Equal(t, 1280, probeInfo.StreamInfo[0].Width)
+	assert.Equal(t, 720, probeInfo.StreamInfo[0].Height)
+	assert.Equal(t, 100, probeInfo.StreamInfo[0].Profile)
+	assert.Equal(t, 32, probeInfo.StreamInfo[0].Level)
+
+	assert.Equal(t, "ac3", probeInfo.StreamInfo[1].CodecName)
+	assert.Equal(t, int64(384000), probeInfo.StreamInfo[1].BitRate)
+	assert.Equal(t, 6, probeInfo.StreamInfo[1].Channels)
+	assert.Equal(t, 1551, probeInfo.StreamInfo[1].ChannelLayout)
+
+	liveSource.Stop()
 }

--- a/live/live_probe_test.go
+++ b/live/live_probe_test.go
@@ -32,7 +32,6 @@ func TestProbeRTMPConnect(t *testing.T) {
 		DebugFrameLevel: debugFrameLevel,
 	}
 
-	// Transcode audio mez files in background
 	reqCtx := &testCtx{url: url}
 	putReqCtxByURL(url, reqCtx)
 
@@ -74,7 +73,6 @@ func TestProbeRTMPListen(t *testing.T) {
 		ConnectionTimeout: 5,
 	}
 
-	// Transcode audio mez files in background
 	reqCtx := &testCtx{url: url}
 	putReqCtxByURL(url, reqCtx)
 
@@ -137,7 +135,6 @@ func TestProbeUDPConnect(t *testing.T) {
 		ConnectionTimeout: 5,
 	}
 
-	// Transcode audio mez files in background
 	reqCtx := &testCtx{url: url}
 	putReqCtxByURL(url, reqCtx)
 
@@ -178,7 +175,6 @@ func TestProbeUDPListen(t *testing.T) {
 		DebugFrameLevel: debugFrameLevel,
 	}
 
-	// Transcode audio mez files in background
 	reqCtx := &testCtx{url: url}
 	putReqCtxByURL(url, reqCtx)
 

--- a/live/live_probe_test.go
+++ b/live/live_probe_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/eluv-io/avpipe"
 	"github.com/stretchr/testify/assert"
-	"os"
 	"testing"
 	"time"
 )
@@ -13,12 +12,6 @@ import (
 // 2) avpipe probe connects to listening ffmpeg and probes the stream
 func TestProbeRTMPConnect(t *testing.T) {
 	setupLogging()
-	outputDir := "TestProbeRTMPConnect"
-
-	// Create output directory if it doesn't exist
-	if _, err := os.Stat(outputDir); os.IsNotExist(err) {
-		os.Mkdir(outputDir, 0755)
-	}
 
 	liveSource := NewLiveSource()
 	url := fmt.Sprintf("rtmp://localhost:%d/rtmp/Doj1Nr3S", liveSource.Port)
@@ -43,7 +36,7 @@ func TestProbeRTMPConnect(t *testing.T) {
 	reqCtx := &testCtx{url: url}
 	putReqCtxByURL(url, reqCtx)
 
-	avpipe.InitIOHandler(&inputOpener{dir: outputDir}, &outputOpener{dir: outputDir})
+	avpipe.InitIOHandler(&inputOpener{}, &outputOpener{})
 
 	tlog.Info("Probing RTMP stream start", "params", fmt.Sprintf("%+v", *XCParams))
 	probeInfo, err := avpipe.Probe(XCParams)
@@ -68,12 +61,6 @@ func TestProbeRTMPConnect(t *testing.T) {
 // 2) Starts ffmpeg to connect to listening avpipe
 func TestProbeRTMPListen(t *testing.T) {
 	setupLogging()
-	outputDir := "TestProbeRTMPListen"
-
-	// Create output directory if it doesn't exist
-	if _, err := os.Stat(outputDir); os.IsNotExist(err) {
-		os.Mkdir(outputDir, 0755)
-	}
 
 	liveSource := NewLiveSource()
 	url := fmt.Sprintf("rtmp://localhost:%d/rtmp/Doj1Nr3S", liveSource.Port)
@@ -91,7 +78,7 @@ func TestProbeRTMPListen(t *testing.T) {
 	reqCtx := &testCtx{url: url}
 	putReqCtxByURL(url, reqCtx)
 
-	avpipe.InitIOHandler(&inputOpener{dir: outputDir}, &outputOpener{dir: outputDir})
+	avpipe.InitIOHandler(&inputOpener{}, &outputOpener{})
 
 	done := make(chan bool, 1)
 	var probeInfo *avpipe.ProbeInfo
@@ -129,12 +116,6 @@ func TestProbeRTMPListen(t *testing.T) {
 // 2) avpipe probe reads the generated UDP stream and probes the stream
 func TestProbeUDPConnect(t *testing.T) {
 	setupLogging()
-	outputDir := "TestProbeUDPConnect"
-
-	// Create output directory if it doesn't exist
-	if _, err := os.Stat(outputDir); os.IsNotExist(err) {
-		os.Mkdir(outputDir, 0755)
-	}
 
 	liveSource := NewLiveSource()
 	url := fmt.Sprintf("udp://localhost:%d", liveSource.Port)
@@ -160,7 +141,7 @@ func TestProbeUDPConnect(t *testing.T) {
 	reqCtx := &testCtx{url: url}
 	putReqCtxByURL(url, reqCtx)
 
-	avpipe.InitIOHandler(&inputOpener{dir: outputDir}, &outputOpener{dir: outputDir})
+	avpipe.InitIOHandler(&inputOpener{}, &outputOpener{})
 
 	tlog.Info("Probing MPEGTS stream start", "params", fmt.Sprintf("%+v", *XCParams))
 	probeInfo, err := avpipe.Probe(XCParams)
@@ -185,12 +166,6 @@ func TestProbeUDPConnect(t *testing.T) {
 // 2) Starts ffmpeg for streaming UDP MPEGTS
 func TestProbeUDPListen(t *testing.T) {
 	setupLogging()
-	outputDir := "TestProbeUDPConnect"
-
-	// Create output directory if it doesn't exist
-	if _, err := os.Stat(outputDir); os.IsNotExist(err) {
-		os.Mkdir(outputDir, 0755)
-	}
 
 	liveSource := NewLiveSource()
 	url := fmt.Sprintf("udp://localhost:%d", liveSource.Port)
@@ -207,7 +182,7 @@ func TestProbeUDPListen(t *testing.T) {
 	reqCtx := &testCtx{url: url}
 	putReqCtxByURL(url, reqCtx)
 
-	avpipe.InitIOHandler(&inputOpener{dir: outputDir}, &outputOpener{dir: outputDir})
+	avpipe.InitIOHandler(&inputOpener{}, &outputOpener{})
 
 	done := make(chan bool, 1)
 	var probeInfo *avpipe.ProbeInfo

--- a/live/live_probe_test.go
+++ b/live/live_probe_test.go
@@ -1,0 +1,53 @@
+package live
+
+import (
+	"fmt"
+	"github.com/eluv-io/avpipe"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestProbeListenRTMP(t *testing.T) {
+	setupLogging()
+	outputDir := "TestProbeListenRTMP"
+
+	// Create output directory if it doesn't exist
+	if _, err := os.Stat(outputDir); os.IsNotExist(err) {
+		os.Mkdir(outputDir, 0755)
+	}
+
+	liveSource := NewLiveSource()
+	url := fmt.Sprintf("rtmp://localhost:%d/rtmp/Doj1Nr3S", liveSource.Port)
+
+	err := liveSource.Start("rtmp")
+	if err != nil {
+		t.Error(err)
+	}
+
+	time.Sleep(2 * time.Second)
+
+	XCParams := &avpipe.XcParams{
+		Seekable: false,
+		XcType:   avpipe.Xcprobe,
+		StreamId: -1,
+		Url:      url,
+		//DebugFrameLevel: debugFrameLevel,
+		DebugFrameLevel: true,
+	}
+
+	// Transcode audio mez files in background
+	reqCtx := &testCtx{url: url}
+	putReqCtxByURL(url, reqCtx)
+
+	avpipe.InitIOHandler(&inputOpener{dir: outputDir}, &outputOpener{dir: outputDir})
+
+	tlog.Info("Probing RTMP stream start", "params", fmt.Sprintf("%+v", *XCParams))
+	probeInfo, err := avpipe.Probe(XCParams)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 40, probeInfo.StreamInfo[0].Level)
+	liveSource.Stop()
+
+}

--- a/live/live_probe_test.go
+++ b/live/live_probe_test.go
@@ -9,7 +9,9 @@ import (
 	"time"
 )
 
-func TestProbeListenRTMP(t *testing.T) {
+// 1) Starts ffmpeg for streaming RTMP in listen mode
+// 2) avpipe probe connects to listening ffmpeg and probes the stream
+func TestProbeRTMPConnect(t *testing.T) {
 	setupLogging()
 	outputDir := "TestProbeListenRTMP"
 
@@ -21,7 +23,8 @@ func TestProbeListenRTMP(t *testing.T) {
 	liveSource := NewLiveSource()
 	url := fmt.Sprintf("rtmp://localhost:%d/rtmp/Doj1Nr3S", liveSource.Port)
 
-	err := liveSource.Start("rtmp")
+	// Start ffmpeg RTMP in listen mode
+	err := liveSource.Start("rtmp_listen")
 	if err != nil {
 		t.Error(err)
 	}
@@ -29,12 +32,11 @@ func TestProbeListenRTMP(t *testing.T) {
 	time.Sleep(2 * time.Second)
 
 	XCParams := &avpipe.XcParams{
-		Seekable: false,
-		XcType:   avpipe.Xcprobe,
-		StreamId: -1,
-		Url:      url,
-		//DebugFrameLevel: debugFrameLevel,
-		DebugFrameLevel: true,
+		Seekable:        false,
+		XcType:          avpipe.Xcprobe,
+		StreamId:        -1,
+		Url:             url,
+		DebugFrameLevel: debugFrameLevel,
 	}
 
 	// Transcode audio mez files in background
@@ -47,7 +49,79 @@ func TestProbeListenRTMP(t *testing.T) {
 	probeInfo, err := avpipe.Probe(XCParams)
 
 	assert.NoError(t, err)
+	assert.Equal(t, "h264", probeInfo.StreamInfo[0].CodecName)
+	assert.Equal(t, 1920, probeInfo.StreamInfo[0].Width)
+	assert.Equal(t, 1080, probeInfo.StreamInfo[0].Height)
+	assert.Equal(t, 100, probeInfo.StreamInfo[0].Profile)
 	assert.Equal(t, 40, probeInfo.StreamInfo[0].Level)
+
+	assert.Equal(t, "aac", probeInfo.StreamInfo[1].CodecName)
+	assert.Equal(t, int64(394000), probeInfo.StreamInfo[1].BitRate)
+	assert.Equal(t, 6, probeInfo.StreamInfo[1].Channels)
+	assert.Equal(t, 0, probeInfo.StreamInfo[1].ChannelLayout)
+
+	liveSource.Stop()
+
+}
+
+// 1) Starts avpipe probe to listen for an incoming RTMP stream
+// 2) Starts ffmpeg to connect to listening avpipe
+func TestProbeRTMPListen(t *testing.T) {
+	setupLogging()
+	outputDir := "TestProbeListenRTMP"
+
+	// Create output directory if it doesn't exist
+	if _, err := os.Stat(outputDir); os.IsNotExist(err) {
+		os.Mkdir(outputDir, 0755)
+	}
+
+	liveSource := NewLiveSource()
+	url := fmt.Sprintf("rtmp://localhost:%d/rtmp/Doj1Nr3S", liveSource.Port)
+
+	XCParams := &avpipe.XcParams{
+		Seekable:          false,
+		XcType:            avpipe.Xcprobe,
+		StreamId:          -1,
+		Url:               url,
+		DebugFrameLevel:   debugFrameLevel,
+		ConnectionTimeout: 5,
+	}
+
+	// Transcode audio mez files in background
+	reqCtx := &testCtx{url: url}
+	putReqCtxByURL(url, reqCtx)
+
+	avpipe.InitIOHandler(&inputOpener{dir: outputDir}, &outputOpener{dir: outputDir})
+
+	done := make(chan bool, 1)
+	var probeInfo *avpipe.ProbeInfo
+	var err error
+
+	go func() {
+		tlog.Info("Probing RTMP stream start", "params", fmt.Sprintf("%+v", *XCParams))
+		probeInfo, err = avpipe.Probe(XCParams)
+		done <- true
+	}()
+
+	err = liveSource.Start("rtmp_connect")
+	if err != nil {
+		t.Error(err)
+	}
+
+	<-done
+	assert.NoError(t, err)
+	tlog.Info("Probe done", "probeInfo", fmt.Sprintf("%+v", *probeInfo))
+	assert.Equal(t, "h264", probeInfo.StreamInfo[0].CodecName)
+	assert.Equal(t, 1920, probeInfo.StreamInfo[0].Width)
+	assert.Equal(t, 1080, probeInfo.StreamInfo[0].Height)
+	assert.Equal(t, 100, probeInfo.StreamInfo[0].Profile)
+	assert.Equal(t, 40, probeInfo.StreamInfo[0].Level)
+
+	assert.Equal(t, "aac", probeInfo.StreamInfo[1].CodecName)
+	assert.Equal(t, int64(394000), probeInfo.StreamInfo[1].BitRate)
+	assert.Equal(t, 6, probeInfo.StreamInfo[1].Channels)
+	assert.Equal(t, 0, probeInfo.StreamInfo[1].ChannelLayout)
+
 	liveSource.Stop()
 
 }

--- a/live/live_source.go
+++ b/live/live_source.go
@@ -74,7 +74,7 @@ func (l *LiveSource) startUDP() (err error) {
 
 	log.Info("starting live source", "url", sourceUrl)
 
-	// i.e ffmpeg -re -i media/FS1-19-10-15-70sec.ts -c copy -f mpegts udp://127.0.0.1:21001?pkt_size=1316
+	// i.e ffmpeg -re -i media/BBB4_HD_51_AVC_120s_CCBYblendercloud.ts -c copy -f mpegts udp://127.0.0.1:21001?pkt_size=1316
 	l.cmd = exec.Command(ffmpeg,
 		"-re",
 		"-i",

--- a/live/ts_recorder_test.go
+++ b/live/ts_recorder_test.go
@@ -25,7 +25,7 @@ func TestUdpToMp4(t *testing.T) {
 	done := make(chan bool, 1)
 	testComplet := make(chan bool, 1)
 
-	err := liveSource.Start()
+	err := liveSource.Start("udp")
 	if err != nil {
 		t.Error(err)
 	}
@@ -133,7 +133,7 @@ func TestUdpToMp4WithCancelling1(t *testing.T) {
 	liveSource := NewLiveSource()
 	url := fmt.Sprintf("udp://localhost:%d", liveSource.Port)
 
-	err := liveSource.Start()
+	err := liveSource.Start("udp")
 	if err != nil {
 		t.Error(err)
 	}
@@ -194,7 +194,7 @@ func TestUdpToMp4WithCancelling2(t *testing.T) {
 	url := fmt.Sprintf("udp://localhost:%d", liveSource.Port)
 	done := make(chan bool, 1)
 
-	err := liveSource.Start()
+	err := liveSource.Start("udp")
 	if err != nil {
 		t.Error(err)
 	}
@@ -268,7 +268,7 @@ func TestUdpToMp4WithCancelling3(t *testing.T) {
 	url := fmt.Sprintf("udp://localhost:%d", liveSource.Port)
 	done := make(chan bool, 1)
 
-	err := liveSource.Start()
+	err := liveSource.Start("udp")
 	if err != nil {
 		t.Error(err)
 	}
@@ -342,7 +342,7 @@ func TestUdpToMp4WithCancelling4(t *testing.T) {
 	url := fmt.Sprintf("udp://localhost:%d", liveSource.Port)
 	done := make(chan bool, 1)
 
-	err := liveSource.Start()
+	err := liveSource.Start("udp")
 	if err != nil {
 		t.Error(err)
 	}

--- a/run_live_tests.sh
+++ b/run_live_tests.sh
@@ -1,0 +1,18 @@
+if ! [ -x `command -v gsutil` ]
+then
+    echo "gsutil could not be found, install gsutil"
+    exit 1
+fi
+
+if [ ! -d "./media" ]
+then
+    mkdir ./media
+    gsutil -m cp 'gs://eluvio-test-assets/*' ./media
+fi
+
+echo "Running live UDP tests"
+go test -run TestUdpToMp4 ./live/
+
+echo "Running live probe tests"
+go test -run TestProbe ./live/
+


### PR DESCRIPTION
issue: https://github.com/eluv-io/avpipe/issues/4

- Add connection timeout to avpipe params for RTMP/MPEGTS streams.
- For RTMP listen mode, avpipe will wait for incoming connection up to connection_timeout (if connection_timeout > 0).
- For UDP/MPEGTS, avpipe will wait for incoming UDP datagrams up to connection_timeout (if connection_timeout > 0).
- Modify avpipe_probe to use xcparams.
- Add unit tests for live stream probing (RTMP and MPEGTS)