### PR TITLE
Fix audio/video sync for muxed output

### DIFF
--- a/avpipe.go
+++ b/avpipe.go
@@ -1490,9 +1490,8 @@ func StreamInfoAsArray(s []StreamInfo) []StreamInfo {
 	return a
 }
 
-func H264GuessLevel(url string, profile int, bitrate int64, framerate, width, height int) int {
+func H264GuessLevel(profile int, bitrate int64, framerate, width, height int) int {
 	level := C.avpipe_h264_guess_level(
-		C.CString(url),
 		C.int(profile),
 		C.int64_t(bitrate),
 		C.int(framerate),

--- a/avpipe.go
+++ b/avpipe.go
@@ -1501,9 +1501,9 @@ func H264GuessLevel(profile int, bitrate int64, framerate, width, height int) in
 	return int(level)
 }
 
-func H264GuessProfile(bandwidth, width, height int) int {
+func H264GuessProfile(bitdepth, width, height int) int {
 	profile := C.avpipe_h264_guess_profile(
-		C.int(bandwidth),
+		C.int(bitdepth),
 		C.int(width),
 		C.int(height))
 

--- a/avpipe_test.go
+++ b/avpipe_test.go
@@ -1931,7 +1931,7 @@ func TestLevel(t *testing.T) {
 	}
 
 	for i := 0; i < len(levelParams); i++ {
-		level := avpipe.H264GuessLevel("", levelParams[i].profile, levelParams[i].bitrate, levelParams[i].framerate, levelParams[i].width, levelParams[i].height)
+		level := avpipe.H264GuessLevel(levelParams[i].profile, levelParams[i].bitrate, levelParams[i].framerate, levelParams[i].width, levelParams[i].height)
 		assert.Equal(t, levelParams[i].expectedLevel, level)
 	}
 }

--- a/libavpipe/include/avpipe_xc.h
+++ b/libavpipe/include/avpipe_xc.h
@@ -676,7 +676,6 @@ set_extract_images(
 /**
  * @brief   Returns the level based on the input values
  *
- * @param   url             Url of the video.
  * @param   profile_idc     Profile of the video.
  * @param   bitrate         Bit rate of the video.
  * @param   framerate       Frame rate of the video.
@@ -687,7 +686,6 @@ set_extract_images(
  */
 int
 avpipe_h264_guess_level(
-    char *url,
     int profile_idc,
     int64_t bitrate,
     int framerate,

--- a/libavpipe/src/avpipe_level.c
+++ b/libavpipe/src/avpipe_level.c
@@ -166,7 +166,6 @@ h264_guess_level(int profile_idc,
 
 int
 avpipe_h264_guess_level(
-    char *url,
     int profile_idc,
     int64_t bitrate,
     int framerate,
@@ -185,7 +184,7 @@ avpipe_h264_guess_level(
     else {
         // Fallback to traditional avpipe find_level() if h264_guess_level() fails to find the level.
         level = find_level(framerate, width, height);
-        elv_warn("CHECK LEVEL url=%s h264_guess_level failed to find level descriptor, fallback to find_level (found level=%d)", url, level);
+        elv_warn("CHECK LEVEL h264_guess_level failed to find level descriptor, fallback to find_level (found level=%d)", level);
     }
 
     return level;

--- a/libavpipe/src/avpipe_mux.c
+++ b/libavpipe/src/avpipe_mux.c
@@ -255,8 +255,10 @@ avpipe_init_muxer(
         return eav_codec_context;
     }
 
-    /* The output format has to be fragmented to avoid doing seeks */
-    //av_opt_set(out_muxer_ctx->format_context->priv_data, "movflags", "frag_every_frame", 0);
+    /* The output format has to be fragmented to avoid doing seeks in the output.
+     * Don't set frag_every_frame in movflags because it causes audio/video to become out of sync
+     * when doing random access on the muxed file.
+     */
     av_opt_set(out_muxer_ctx->format_context->priv_data, "movflags", "frag_keyframe", 0);
 
     out_muxer_ctx->format_context->avpipe_opaque = out_handlers;

--- a/libavpipe/src/avpipe_mux.c
+++ b/libavpipe/src/avpipe_mux.c
@@ -256,8 +256,8 @@ avpipe_init_muxer(
     }
 
     /* The output format has to be fragmented to avoid doing seeks */
-    av_opt_set(out_muxer_ctx->format_context->priv_data, "movflags", "frag_every_frame", 0);
-    //av_opt_set(out_muxer_ctx->format_context->priv_data, "segment_format_options", "movflags=faststart", 0);
+    //av_opt_set(out_muxer_ctx->format_context->priv_data, "movflags", "frag_every_frame", 0);
+    av_opt_set(out_muxer_ctx->format_context->priv_data, "movflags", "frag_keyframe", 0);
 
     out_muxer_ctx->format_context->avpipe_opaque = out_handlers;
 

--- a/libavpipe/src/avpipe_mux.c
+++ b/libavpipe/src/avpipe_mux.c
@@ -260,6 +260,7 @@ avpipe_init_muxer(
      * when doing random access on the muxed file.
      */
     av_opt_set(out_muxer_ctx->format_context->priv_data, "movflags", "frag_keyframe", 0);
+    av_opt_set(out_muxer_ctx->format_context->priv_data, "movflags", "cmaf", 0);
 
     out_muxer_ctx->format_context->avpipe_opaque = out_handlers;
 

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -766,7 +766,7 @@ set_h264_params(
     if (encoder_codec_context->framerate.den != 0)
         framerate = encoder_codec_context->framerate.num/encoder_codec_context->framerate.den;
 
-    encoder_codec_context->level = avpipe_h264_guess_level(params->url,
+    encoder_codec_context->level = avpipe_h264_guess_level(
                                                 encoder_codec_context->profile,
                                                 encoder_codec_context->bit_rate,
                                                 framerate,
@@ -919,7 +919,7 @@ set_nvidia_params(
     if (encoder_codec_context->framerate.den != 0)
         framerate = encoder_codec_context->framerate.num/encoder_codec_context->framerate.den;
 
-    encoder_codec_context->level = avpipe_h264_guess_level(params->url,
+    encoder_codec_context->level = avpipe_h264_guess_level(
                                                 encoder_codec_context->profile,
                                                 encoder_codec_context->bit_rate,
                                                 framerate,


### PR DESCRIPTION
- Fix audio/video synchronization when doing random access on the muxed file. 