### PR TITLE
Fix bad io crash

### DIFF
--- a/avpipe.c
+++ b/avpipe.c
@@ -975,6 +975,7 @@ xc_init(
     avpipe_io_handler_t *in_handlers = NULL;
     avpipe_io_handler_t *out_handlers = NULL;
 
+    *handle = -1;
     if (!params || !params->url || params->url[0] == '\0' )
         return eav_param;
 
@@ -1002,10 +1003,7 @@ xc_init(
     return eav_success;
 
 end_tx_init:
-
     avpipe_fini(&xctx);
-    free(in_handlers);
-    free(out_handlers);
 
     return rc;
 }

--- a/avpipe.go
+++ b/avpipe.go
@@ -1459,6 +1459,9 @@ func XcInit(params *XcParams) (int32, error) {
 }
 
 func XcRun(handle int32) error {
+	if handle < 0 {
+		return EAV_BAD_HANDLE
+	}
 	rc := C.xc_run(C.int32_t(handle))
 	if rc == 0 {
 		return nil

--- a/avpipe_errors.go
+++ b/avpipe_errors.go
@@ -106,6 +106,9 @@ var EAV_PTS_WRAPPED = errors.New("EAV_PTS_WRAPPED")
 // EAV_IO_TIMEOUT is the error returned when there is a timeout in network/disk io
 var EAV_IO_TIMEOUT = errors.New("EAV_IO_TIMEOUT")
 
+// EAV_BAD_HANDLE is the error returned when the transcoding session handle is not valid
+var EAV_BAD_HANDLE = errors.New("EAV_BAD_HANDLE")
+
 // EAV_UNKNOWN is the error returned when error code doesn't exist in avpipeErrors table (below).
 var EAV_UNKNOWN = errors.New("EAV_UNKNOWN")
 
@@ -135,6 +138,7 @@ var avpipeErrors = map[int]error{
 	int(C.eav_xc_table):             EAV_XC_TABLE,
 	int(C.eav_pts_wrapped):          EAV_PTS_WRAPPED,
 	int(C.eav_io_timeout):           EAV_IO_TIMEOUT,
+	int(C.eav_bad_handle):           EAV_BAD_HANDLE,
 }
 
 func avpipeError(code C.int) error {

--- a/avpipe_test.go
+++ b/avpipe_test.go
@@ -1488,12 +1488,6 @@ func TestMezMakerWithInputOpenError(t *testing.T) {
 
 	handle, err := avpipe.XcInit(params)
 	assert.Less(t, handle, int32(0))
-	go func(handle int32) {
-		// Wait for 2 sec the transcoding starts, then cancel it.
-		time.Sleep(2 * time.Second)
-		err := avpipe.XcCancel(handle)
-		assert.NoError(t, err)
-	}(handle)
 	err = avpipe.XcRun(handle)
 	assert.Error(t, err)
 
@@ -1534,12 +1528,6 @@ func TestMezMakerWithReadError(t *testing.T) {
 
 	handle, err := avpipe.XcInit(params)
 	assert.Less(t, handle, int32(0))
-	go func(handle int32) {
-		// Wait for 2 sec the transcoding starts, then cancel it.
-		time.Sleep(2 * time.Second)
-		err := avpipe.XcCancel(handle)
-		assert.NoError(t, err)
-	}(handle)
 	err = avpipe.XcRun(handle)
 	assert.Error(t, err)
 

--- a/avpipe_test.go
+++ b/avpipe_test.go
@@ -52,7 +52,7 @@ type fileInputOpener struct {
 	t                *testing.T
 	url              string
 	errorOnOpenInput bool // Generate error in opening input
-	errorOnRead      bool // Generate error in reading input
+	errorOnReadInput bool // Generate error in reading input
 }
 
 func (fio *fileInputOpener) Open(_ int64, url string) (
@@ -71,17 +71,17 @@ func (fio *fileInputOpener) Open(_ int64, url string) (
 
 	fio.url = url
 	handler = &fileInput{t: fio.t,
-		file:        f,
-		errorOnRead: fio.errorOnRead,
+		file:             f,
+		errorOnReadInput: fio.errorOnReadInput,
 	}
 	return
 }
 
 // Implements avpipe.InputHandler
 type fileInput struct {
-	t           *testing.T
-	file        *os.File // Input file
-	errorOnRead bool     // Generate error in reading input
+	t                *testing.T
+	file             *os.File // Input file
+	errorOnReadInput bool     // Generate error in reading input
 }
 
 func (i *fileInput) Read(buf []byte) (int, error) {
@@ -89,7 +89,7 @@ func (i *fileInput) Read(buf []byte) (int, error) {
 	if err == io.EOF {
 		return 0, nil
 	}
-	if i.errorOnRead {
+	if i.errorOnReadInput {
 		err = io.ErrNoProgress
 		n = -1
 	}
@@ -1455,7 +1455,7 @@ func TestHEVC_H264MezMaker(t *testing.T) {
 
 // Run a mez making session and fail on opening the input.
 // This simulates the cases when opening the input fails time to time (for example, opening the cloud object).
-func TestMezMakerWithInputOpenError(t *testing.T) {
+func TestMezMakerWithOpenInputError(t *testing.T) {
 	filename := "./media/SIN6_4K_MOS_HEVC_60s.mp4"
 	outputDir := path.Join(baseOutPath, fn())
 
@@ -1495,7 +1495,7 @@ func TestMezMakerWithInputOpenError(t *testing.T) {
 
 // Run a mez making session and fail on reading from input.
 // This simulates the cases when reading the input fails time to time (for example, reading from cloud).
-func TestMezMakerWithReadError(t *testing.T) {
+func TestMezMakerWithReadInputError(t *testing.T) {
 	filename := "./media/SIN6_4K_MOS_HEVC_60s.mp4"
 	outputDir := path.Join(baseOutPath, fn())
 
@@ -1518,7 +1518,7 @@ func TestMezMakerWithReadError(t *testing.T) {
 
 	boilerplate(t, outputDir, filename)
 
-	fio := &fileInputOpener{t: t, url: filename, errorOnRead: true}
+	fio := &fileInputOpener{t: t, url: filename, errorOnReadInput: true}
 	foo := &fileOutputOpener{t: t, dir: outputDir}
 	avpipe.InitIOHandler(fio, foo)
 

--- a/avpipe_test.go
+++ b/avpipe_test.go
@@ -1533,6 +1533,28 @@ func TestMezMakerWithReadInputError(t *testing.T) {
 
 }
 
+// Run a probe and fail on reading from input.
+// This simulates the cases when reading the input fails time to time (for example, reading from cloud).
+func TestProbeWithReadInputError(t *testing.T) {
+	filename := "./media/SIN6_4K_MOS_HEVC_60s.mp4"
+	outputDir := path.Join(baseOutPath, fn())
+
+	boilerplate(t, outputDir, filename)
+
+	fio := &fileInputOpener{t: t, url: filename, errorOnReadInput: true}
+	foo := &fileOutputOpener{t: t, dir: outputDir}
+	avpipe.InitIOHandler(fio, foo)
+
+	params := &avpipe.XcParams{
+		Url:      filename,
+		Seekable: true,
+	}
+	probe, err := avpipe.Probe(params)
+	assert.Error(t, err)
+	assert.Equal(t, (*avpipe.ProbeInfo)(nil), probe)
+
+}
+
 func TestHEVC_H265ABRTranscode(t *testing.T) {
 	f := fn()
 	if testing.Short() {

--- a/libavpipe/include/avpipe_xc.h
+++ b/libavpipe/include/avpipe_xc.h
@@ -55,7 +55,8 @@ typedef enum avpipe_error_t {
     eav_audio_sample            = 22,   // Error in converting audio samples
     eav_xc_table                = 23,   // Error in trancoding table
     eav_pts_wrapped             = 24,   // PTS wrapped error
-    eav_io_timeout              = 25	// IO timeout
+    eav_io_timeout              = 25,   // IO timeout
+    eav_bad_handle              = 26    // Bad handle
 } avpipe_error_t;
 
 typedef enum avpipe_buftype_t {

--- a/live/live_probe_test.go
+++ b/live/live_probe_test.go
@@ -110,6 +110,33 @@ func TestProbeRTMPListen(t *testing.T) {
 	liveSource.Stop()
 }
 
+func TestProbeRTMPNoStream(t *testing.T) {
+	setupLogging()
+
+	liveSource := NewLiveSource()
+	url := fmt.Sprintf("rtmp://localhost:%d/rtmp/Doj1Nr3S", liveSource.Port)
+
+	XCParams := &avpipe.XcParams{
+		Seekable:          false,
+		XcType:            avpipe.Xcprobe,
+		StreamId:          -1,
+		Url:               url,
+		DebugFrameLevel:   debugFrameLevel,
+		ConnectionTimeout: 2,
+	}
+
+	reqCtx := &testCtx{url: url}
+	putReqCtxByURL(url, reqCtx)
+
+	avpipe.InitIOHandler(&inputOpener{}, &outputOpener{})
+
+	tlog.Info("Probing RTMP stream start", "params", fmt.Sprintf("%+v", *XCParams))
+	probeInfo, err := avpipe.Probe(XCParams)
+
+	assert.Error(t, err)
+	assert.Equal(t, (*avpipe.ProbeInfo)(nil), probeInfo)
+}
+
 // 1) Starts ffmpeg for streaming UDP MPEGTS
 // 2) avpipe probe reads the generated UDP stream and probes the stream
 func TestProbeUDPConnect(t *testing.T) {
@@ -162,6 +189,7 @@ func TestProbeUDPConnect(t *testing.T) {
 // 1) Starts avpipe probe to read UDP stream and probes the stream
 // 2) Starts ffmpeg for streaming UDP MPEGTS
 func TestProbeUDPListen(t *testing.T) {
+
 	setupLogging()
 
 	liveSource := NewLiveSource()
@@ -210,4 +238,32 @@ func TestProbeUDPListen(t *testing.T) {
 	assert.Equal(t, 1551, probeInfo.StreamInfo[1].ChannelLayout)
 
 	liveSource.Stop()
+}
+
+func TestProbeUDPNoStream(t *testing.T) {
+
+	setupLogging()
+
+	liveSource := NewLiveSource()
+	url := fmt.Sprintf("udp://localhost:%d", liveSource.Port)
+
+	XCParams := &avpipe.XcParams{
+		Seekable:          false,
+		XcType:            avpipe.Xcprobe,
+		StreamId:          -1,
+		Url:               url,
+		DebugFrameLevel:   debugFrameLevel,
+		ConnectionTimeout: 2,
+	}
+
+	reqCtx := &testCtx{url: url}
+	putReqCtxByURL(url, reqCtx)
+
+	avpipe.InitIOHandler(&inputOpener{}, &outputOpener{})
+
+	tlog.Info("Probing MPEGTS stream start", "params", fmt.Sprintf("%+v", *XCParams))
+	probeInfo, err := avpipe.Probe(XCParams)
+
+	assert.Error(t, err)
+	assert.Equal(t, (*avpipe.ProbeInfo)(nil), probeInfo)
 }


### PR DESCRIPTION
- This issue is detected in fabric when reading media files from cloud fail (https://github.com/qluvio/content-fabric/issues/2260).

- Fix a double free of memory when reading input files fail.
- Add some unit tests to simulate failing situations in input IO.
