### PR TITLE
Special url

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,14 @@ The following repositories can be checked out in any directory, but for better o
     
 ## Build FFmpeg and avpipe
 
-- Build ffmpeg: in FFmpeg directory `<ffmpeg-path>` run
+- Build eluv-io/FFmpeg: in FFmpeg directory `<ffmpeg-path>` run
   - `./build.sh`
 - Set environment variables: in avpipe directory run
   - `source init-env.sh <ffmpeg-path>`
 - Build avpipe: in avpipe directory run
   - `make`
 - This installs the binaries under `<avpipe-path>/bin`
+- Note: avpipe has to be built and linked with eluv-io/FFmpeg to be functional.
 
 ## Test avpipe
 
@@ -126,6 +127,7 @@ typedef struct xcparams_t {
     int         extract_images_sz;          // Size of the array extract_images_ts
 
     int         debug_frame_level;
+    int         connection_timeout;         // Connection timeout in sec for RTMP or MPEGTS protocols
 } xcparams_t;
 
 ```
@@ -154,6 +156,8 @@ typedef struct xcparams_t {
   - setting xc_type = xc_audio_pan would pick different audio channels from input and create a new audio stream (for example picking different channels from a 5.1 channel layout and producing a stereo containing two channels).
   - setting xc_type = xc_audio_merge would merge different input audio streams and produce a new multi-channel output stream (for example, merging different input mono streams and create a new 5.1)
 - **Debugging with frames:** if the parameter debug_frame_level is on then the logs will also include very low level debug messages to trace reading/writing every piece of data.
+- **Connection timeout:** This parameter is useful when recording / transcoding RTMP or MPEGTS streams. If avpipe is listening for an RTMP stream, connection_timeout determines the time in sec to listen for an incoming RTMP stream. If avpipe is listening for incoming UDP MPEGTS packets, connection_timeout determines the time in sec to wait for the first incoming UDP packet (if no packet is received during connection_timeout, then timeout would happen and an error would be generated).
+
 
 ### Counters
 

--- a/avpipe.c
+++ b/avpipe.c
@@ -961,8 +961,8 @@ set_handlers(
 }
 
 /*
- * Returns a handle that refers to an initialized trasncoding session.
- * If initialization is not successfull it return -1.
+ * Obtains a handle that refers to an initialized trasncoding session with specified params.
+ * If initialization is successfull it return eav_success, otherwise it returns corresponding error code.
  */
 int32_t
 xc_init(
@@ -1406,7 +1406,7 @@ probe(
     xcprobe_t **xcprobe,
     int *n_streams)
 {
-    avpipe_io_handler_t *in_handlers;
+    avpipe_io_handler_t *in_handlers = NULL;
     xcprobe_t *probes;
     int rc;
 

--- a/avpipe.go
+++ b/avpipe.go
@@ -1273,12 +1273,12 @@ func getCParams(params *XcParams) (*C.xcparams_t, error) {
 // params: transcoding parameters
 func Xc(params *XcParams) error {
 
-	// Convert XcParams to C.txparams_t
 	if params == nil {
 		log.Error("Failed transcoding, params are not set.")
 		return EAV_PARAM
 	}
 
+	// Convert XcParams to C.txparams_t
 	cparams, err := getCParams(params)
 	if err != nil {
 		log.Error("Transcoding failed", err, "url", params.Url)

--- a/avpipe_test.go
+++ b/avpipe_test.go
@@ -1264,6 +1264,44 @@ func TestAudio2Channel1Stereo(t *testing.T) {
 	xcTest(t, outputDir, params, xcTestResult, true)
 }
 
+// Transcode pcm_s24le 60000 sample rate, into aac 48000 sample rate
+func TestAudio2Channel1Stereo_pcm_60000(t *testing.T) {
+	filename := "./media/Sintel_30s_6ch_pcm_s24le_60000Hz.mov"
+	outputDir := path.Join(baseOutPath, fn())
+
+	params := &avpipe.XcParams{
+		BypassTranscoding:   false,
+		Format:              "fmp4-segment",
+		StartTimeTs:         0,
+		DurationTs:          -1,
+		StartSegmentStr:     "1",
+		SegDuration:         "30",
+		Ecodec2:             "aac",
+		Dcodec2:             "",
+		XcType:              avpipe.XcAudioPan,
+		ChannelLayout:       avpipe.ChannelLayout("stereo"),
+		NumAudio:            1,
+		StreamId:            -1,
+		SyncAudioToStreamId: -1,
+		FilterDescriptor:    "[0:6]pan=stereo|c0=c0|c1=c0[aout]",
+		Url:                 filename,
+		DebugFrameLevel:     debugFrameLevel,
+	}
+	params.AudioIndex[0] = 6
+
+	xcTestResult := &XcTestResult{
+		timeScale:         48000,
+		sampleRate:        48000,
+		channelLayoutName: "stereo",
+	}
+
+	for i := 1; i <= 1; i++ {
+		xcTestResult.mezFile = append(xcTestResult.mezFile, fmt.Sprintf("%s/asegment-%d.mp4", outputDir, i))
+	}
+
+	xcTest(t, outputDir, params, xcTestResult, true)
+}
+
 // Timebase of BBB0_HD_8_XDCAM_120s_CCBYblendercloud.mxf is 1001/60000
 func TestIrregularTsMezMaker_1001_60000(t *testing.T) {
 	filename := "./media/BBB0_HD_8_XDCAM_120s_CCBYblendercloud.mxf"

--- a/libavpipe/include/avpipe_version.h
+++ b/libavpipe/include/avpipe_version.h
@@ -10,5 +10,5 @@
 
 /* Only increase these versions for release purposes */
 #define AVPIPE_MAJOR_VERSION    1
-#define AVPIPE_MINOR_VERSION    1
+#define AVPIPE_MINOR_VERSION    2
 

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -925,6 +925,10 @@ set_nvidia_params(
         encoder_codec_context->profile = FF_PROFILE_H264_HIGH;
     }
 
+/*
+    For nvidia let the encoder to pick the level, in some cases level is different from h264 encoder and
+    avpipe_h264_guess_level() function would not pick the right level for nvidia.
+
     if (encoder_codec_context->framerate.den != 0)
         framerate = encoder_codec_context->framerate.num/encoder_codec_context->framerate.den;
 
@@ -935,6 +939,7 @@ set_nvidia_params(
                                                 encoder_codec_context->width,
                                                 encoder_codec_context->height);
     av_opt_set_int(encoder_codec_context->priv_data, "level", encoder_codec_context->level, 0);
+*/
 
     /*
      * According to https://superuser.com/questions/1296374/best-settings-for-ffmpeg-with-nvenc

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -1304,8 +1304,8 @@ prepare_audio_encoder(
         sample_rate <= 0)
         sample_rate = DEFAULT_ACC_SAMPLE_RATE;
 
-    /* 
-     *  If sample_rate is set and 
+    /*
+     *  If sample_rate is set and
      *      - encoder is not "aac" or
      *      - if encoder is "aac" and encoder sample_rate is not valid and transcoding is pan/merge/join
      *  then

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -1664,8 +1664,8 @@ set_idr_frame_key_flag(
             if (encoder_context->is_mpegts && encoder_context->calculated_frame_duration > 0)
                 missing_frames = diff / encoder_context->calculated_frame_duration;
             if (debug_frame_level) {
-                elv_dbg("FRAME SET KEY flag, seg_duration_ts=%d pts=%"PRId64", missing_frames=%d",
-                    params->video_seg_duration_ts, frame->pts, missing_frames);
+                elv_dbg("FRAME SET KEY flag, seg_duration_ts=%d pts=%"PRId64", missing_frames=%d, last_key_frame_pts=%"PRId64,
+                    params->video_seg_duration_ts, frame->pts, missing_frames, encoder_context->last_key_frame);
             }
             frame->pict_type = AV_PICTURE_TYPE_I;
             encoder_context->last_key_frame = frame->pts - missing_frames * encoder_context->calculated_frame_duration;
@@ -1680,6 +1680,7 @@ set_idr_frame_key_flag(
                     params->force_keyint, frame->pts);
             }
             frame->pict_type = AV_PICTURE_TYPE_I;
+            encoder_context->last_key_frame = frame->pts;
             encoder_context->forced_keyint_countdown = params->force_keyint;
         }
         encoder_context->forced_keyint_countdown --;

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -1307,11 +1307,13 @@ prepare_audio_encoder(
     /* 
      *  If sample_rate is set and 
      *      - encoder is not "aac" or
-     *      - if encoder is "aac" and encoder sample_rate is not valid
+     *      - if encoder is "aac" and encoder sample_rate is not valid and transcoding is pan/merge/join
      *  then
      *      - set encoder sample_rate to the specified sample_rate.
      */
-    if (sample_rate > 0 && (strcmp(ecodec, "aac") || !is_valid_aac_sample_rate(encoder_context->codec_context[index]->sample_rate))) {
+    if (sample_rate > 0 &&
+        (strcmp(ecodec, "aac") || !is_valid_aac_sample_rate(encoder_context->codec_context[index]->sample_rate)) &&
+        (params->xc_type == xc_audio_merge || params->xc_type == xc_audio_pan || params->xc_type == xc_audio_join)) {
         /*
          * Audio resampling, which is active for aac encoder, needs more work to adjust sampling properly
          * when input sample rate is different from output sample rate. (--RM)

--- a/live/lhr.go
+++ b/live/lhr.go
@@ -15,8 +15,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/eluv-io/errors-go"
 	"github.com/eluv-io/avpipe"
+	"github.com/eluv-io/errors-go"
 
 	"github.com/grafov/m3u8"
 

--- a/scripts/cmd_samples.sh
+++ b/scripts/cmd_samples.sh
@@ -1,19 +1,17 @@
 # Text watermarking
-./bin/exc -seg-duration 30 -xc-type video -f media/creed_1_min.mov -wm-text "TEST WATERMARK" -wm-color black -wm-relative-size 0.05 -wm-xloc W/2 -wm-yloc H*0.9 -format fmp4-segment
-./bin/exc -seg-duration 30 -xc-type video -f media/creed_1_min.mov -wm-text "%{pts\\:gmtime\\:1602968400\\:%d-%m-%Y %T}" -wm-color black -wm-relative-size 0.05 -wm-xloc W/2 -wm-yloc H*0.9 -format fmp4-segment
+./bin/exc -seg-duration 30 -xc-type video -f media/TOS8_FHD_51-2_PRHQ_60s_CCBYblendercloud.mov -wm-text "TEST WATERMARK" -wm-color black -wm-relative-size 0.05 -wm-xloc W/2 -wm-yloc H*0.9 -format fmp4-segment
+./bin/exc -seg-duration 30 -xc-type video -f media/TOS8_FHD_51-2_PRHQ_60s_CCBYblendercloud.mov -wm-text "%{pts\\:gmtime\\:1602968400\\:%d-%m-%Y %T}" -wm-color black -wm-relative-size 0.05 -wm-xloc W/2 -wm-yloc H*0.9 -format fmp4-segment
 
 # Timecode watermarking
-./bin/elvxc transcode --seg-duration 30 --xc-type video -f media/creed_1_min.mov --wm-timecode-rate 24 --wm-color black --wm-relative-size 0.05 --wm-xloc W/2 --wm-yloc H*0.9 --format fmp4-segment --wm-timecode "00\:00\:00\:00"
+./bin/elvxc transcode --seg-duration 30 --xc-type video -f media/TOS8_FHD_51-2_PRHQ_60s_CCBYblendercloud.mov --wm-timecode-rate 24 --wm-color black --wm-relative-size 0.05 --wm-xloc W/2 --wm-yloc H*0.9 --format fmp4-segment --wm-timecode "00\:00\:00\:00"
 
 # Image watermarking
-./bin/elvxc transcode --wm-overlay ./fox_watermark.png --wm-overlay-type png --wm-xloc "main_w/2-overlay_w/2" --wm-yloc main_h*0.7 -f O/O1-mez/fsegment0-00001.mp4 --seg-duration-ts 48000 --xc-type video
-
-./bin/exc -wm-overlay ./fox_watermark.png -wm-xloc "main_w/2-overlay_w/2" -wm-yloc main_h*0.7 -f O/O1-mez/fsegment0-00001.mp4 -seg-duration-ts 48000 -xc-type video
+./bin/elvxc transcode --wm-overlay media/avpipe.png --wm-overlay-type png --wm-xloc "main_w/2-overlay_w/2" --wm-yloc main_h*0.7 -f media/TOS8_FHD_51-2_PRHQ_60s_CCBYblendercloud.mov --xc-type video --seg-duration 30 --format fmp4-segment
 
 # Make HDR mezzanines
-./bin/exc -seg-duration 30.03 -f across_the_universe_2160p_h265_veryslow_segmented_60_sec.mp4 -e libx265 -xc-type video -format fmp4-segment -max-cll "1514,172" -master-display "G(13250,34500)B(7500,3000)R(34000,16000)WP(15635,16450)L(40000000,50)"
+./bin/exc -f ./media/SIN5_4K_MOS_J2K_60s_CCBYblendercloud.mxf -format fmp4-segment -seg-duration 30 -d jpeg2000 -e libx265 -force-keyint 48 -xc-type video -max-cll "1514,172" -master-display "G(13250,34500)B(7500,3000)R(34000,16000)WP(15635,16450)L(40000000,50)"
 
-./bin/exc -seg-duration 30.03 -f across_the_universe_2160p_h265_veryslow_segmented_60_sec.mp4 -e libx265 -xc-type video -format fmp4-segment -bitdepth 10
+./bin/exc -f ./media/SIN5_4K_MOS_J2K_60s_CCBYblendercloud.mxf -format fmp4-segment -seg-duration 30 -d jpeg2000 -e libx265 -force-keyint 48 -xc-type video -bitdepth 10
 
 # Muxing audio/video
 ./bin/exc -command mux -mux-spec scripts/sample_mux_spec_abr.txt -f muxed.mp4
@@ -23,26 +21,26 @@
 
 
 # Audio join
-./bin/elvxc transcode -f ./media/AGAIG-clip-2mono.mp4 --xc-type audio-join --audio-index 1,2 --format fmp4-segment --seg-duration 30
+./bin/elvxc transcode -f ./media/gabby_shading_2mono_1080p.mp4 --xc-type audio-join --audio-index 0,1 --format fmp4-segment --seg-duration 30
 
-ffmpeg-4.2.2-amd64-static/ffmpeg -y -i ./media/AGAIG-clip-2mono.mp4 -vn -filter_complex "[0:1][0:2]join=inputs=2:channel_layout=stereo[aout]" -map [aout] -acodec aac -b:a 128k 'out-audio.mp4'
+ffmpeg-4.2.2-amd64-static/ffmpeg -y -i ./media/gabby_shading_2mono_1080p.mp4 -vn -filter_complex "[0:0][0:1]join=inputs=2:channel_layout=stereo[aout]" -map [aout] -acodec aac -b:a 128k 'out-audio.mp4'
 
 
 # Audio pan
-./bin/exc -f ../media/MGM/multichannel_audio_clip.mov -xc-type audio-pan -filter-descriptor "[0:1]pan=stereo|c0<c1+0.707*c2|c1<c2+0.707*c1[aout]" -format fmp4-segment -seg-duration 30
+./bin/exc -f ./media/case_3_video_and_10_channel_audio_10sec.mov -xc-type audio-pan -filter-descriptor "[0:0]pan=5.1|c0=c3|c1=c4|c2=c5|c3=c6|c4=c7|c5=c8[aout]" -format fmp4-segment -seg-duration 30 -channel-layout 5.1
 
-ffmpeg -i ../media/MGM/multichannel_audio_clip.mov -vn  -filter_complex "[0:1]pan=stereo|c0<c1+0.707*c2|c1<c2+0.707*c1[aout]" -map [aout]  -acodec aac -b:a 128k bb.mp4
+ffmpeg -i ./media/case_3_video_and_10_channel_audio_10sec.mov -vn  -filter_complex "[0:0]pan=5.1|c0=c3|c1=c4|c2=c5|c3=c6|c4=c7|c5=c8[aout]" -map [aout]  -acodec aac -b:a 128k bb.mp4
 
 
 # Audio merge (not functional yet)
-./bin/exc -f ../media/BOB923HL_clip_timebase_1001_60000.MXF -xc-type audio-merge -filter-descriptor "[0:1][0:2][0:3][0:5][0:6]amerge=inputs=5,pan=stereo|c0<c0+c3+0.707*c2|c1<c1+c4+0.707*c2[out]" -format fmp4-segment -seg-duration 30 -audio-index 1,2,3,5,6 -channel-layout stereo
+./bin/exc -f ./media/case_2_video_and_8_mono_audio.mp4 -xc-type audio-merge -filter-descriptor "[0:3][0:4][0:5][0:6][0:7][0:8]amerge=inputs=6,pan=5.1|c0=c0|c1=c1|c2=c2| c3=c3|c4=c4|c5=c5[aout]" -format fmp4-segment -seg-duration 30 -audio-index 3,4,5,6,7,8 -channel-layout stereo
 
-ffmpeg-4.2.2-amd64-static/ffmpeg -y -i ../media/MGM/BOB923HL_clip_timebase_1001_60000.MXF -vn -filter_complex "[0:1][0:2][0:3][0:5][0:6]amerge=inputs=5,pan=stereo|c0<c0+c3+0.707*c2|c1<c1+c4+0.707*c2[aout]" -map [aout] -acodec aac -b:a 128k 'BOB1003HL.MXF.audio.mp4'
+ffmpeg -y -i ./media/case_2_video_and_8_mono_audio.mp4 -vn -filter_complex "[0:3][0:4][0:5][0:6][0:7][0:8]amerge=inputs=6,pan=5.1|c0=c0|c1=c1|c2=c2| c3=c3|c4=c4|c5=c5[aout]" -map [aout] -acodec aac -b:a 128k audio-merge.mp4
 
 $FFMPEG_BIN/ffmpeg -listen 1 -i rtmp://192.168.90.202:1935/rtmp/XQjNir3S -c copy -flags +global_header -f segment -segment_time 60 -segment_format_options movflags=+faststart -reset_timestamps 1 test%d.mp4
 
 
 # Extract frames every 2s (default 10s if interval is not set)
-./bin/exc -f ../media/ErsteChristmas.mp4 -format image2 -e mjpeg -xc-type extract-images -extract-image-interval-ts 25600
+./bin/exc -f ./media/TOS8_FHD_51-2_PRHQ_60s_CCBYblendercloud.mov -format image2 -e mjpeg -xc-type extract-images -extract-image-interval-ts 48000
 # Extract specified frames
-./bin/exc -f ../media/ErsteChristmas.mp4 -format image2 -e mjpeg -xc-type extract-images -extract-images-ts "64000,128000,1152000"
+/bin/exc -f ./media/TOS8_FHD_51-2_PRHQ_60s_CCBYblendercloud.mov -format image2 -e mjpeg -xc-type extract-images -extract-images-ts "72000,240000,432000"

--- a/ts/parse_ts/main.go
+++ b/ts/parse_ts/main.go
@@ -10,9 +10,9 @@ import (
 	"os"
 
 	"github.com/Comcast/gots/packet"
-	"github.com/eluv-io/log-go"
 	"github.com/eluv-io/avpipe/live"
 	"github.com/eluv-io/avpipe/ts"
+	"github.com/eluv-io/log-go"
 )
 
 func main() {

--- a/utils/src/url_parser.c
+++ b/utils/src/url_parser.c
@@ -77,9 +77,13 @@ parse_url(
     /* Protocol */
     parsed_url->protocol = local_url;
 
-    /* Invalid URL */
-    if (colon[0] != '/' && colon[1] != '/')
-        return 1;
+    /* URL doesn't have ://, so consider the entire url as a filename */
+    if (colon[0] != '/' && colon[1] != '/') {
+        parsed_url->protocol = strdup("file");
+        free(local_url);
+        parsed_url->path = strdup(url);
+        return 0;
+    }
 
     /* pass "://" */
     colon = &colon[2];


### PR DESCRIPTION
- Fix a crash when input file URLs have special characters like ":".
- Fix a bug in transcoding audio join/merge/pan when input sample rate doesn't match with AAC.
- Add more unit tests for audio.
- Fix a bug in setting last_key_frame_pts when setting IDR key frames.
- Let nvidia encoders to set the level (nvidia encoder level doesn't match with h264 level).
- More design documents and updating README file.