### PR TITLE
Use audio filter

### DIFF
--- a/avpipe.c
+++ b/avpipe.c
@@ -336,6 +336,12 @@ udp_in_opener(
         elv_warn("Failed to set UDP socket buf size to=%"PRId64", url=%s, errno=%d", bufsz, url, errno);
     }
 
+    if (set_sock_nonblocking(sockfd) < 0) {
+        elv_err("Failed to make UDP socket nonblocking, errno=%d", errno);
+        return -1;
+    }
+
+
     elv_channel_init(&inctx->udp_channel, MAX_UDP_CHANNEL, NULL);
     inctx->opaque = (int *) calloc(1, sizeof(int)+sizeof(int64_t));
     *((int *)((int64_t *)inctx->opaque+1)) = sockfd;

--- a/avpipe_test.go
+++ b/avpipe_test.go
@@ -1673,7 +1673,7 @@ func TestAVPipeStats(t *testing.T) {
 	xcTest(t, outputDir, params, xcTestResult, true)
 
 	assert.Equal(t, int64(2880), statsInfo.encodingVideoFrameStats.TotalFramesWritten)
-	assert.Equal(t, int64(5625), statsInfo.encodingAudioFrameStats.TotalFramesWritten)
+	assert.Equal(t, int64(5626), statsInfo.encodingAudioFrameStats.TotalFramesWritten)
 	// FIXME
 	//assert.Equal(t, int64(720), statsInfo.encodingVideoFrameStats.FramesWritten)
 	//assert.Equal(t, int64(1406), statsInfo.encodingAudioFrameStats.FramesWritten)

--- a/avpipe_test.go
+++ b/avpipe_test.go
@@ -1264,8 +1264,9 @@ func TestAudio2Channel1Stereo(t *testing.T) {
 	xcTest(t, outputDir, params, xcTestResult, true)
 }
 
-// Transcode pcm_s24le 60000 sample rate, into aac 48000 sample rate
-func TestAudio2Channel1Stereo_pcm_60000(t *testing.T) {
+// Transcode audio pan pcm_s24le with 60000 sample rate, into aac 48000 sample rate.
+// This is case 1 with audio input sample rate incompatible with AAC
+func TestAudioPan2Channel1Stereo_pcm_60000(t *testing.T) {
 	filename := "./media/Sintel_30s_6ch_pcm_s24le_60000Hz.mov"
 	outputDir := path.Join(baseOutPath, fn())
 
@@ -1288,6 +1289,44 @@ func TestAudio2Channel1Stereo_pcm_60000(t *testing.T) {
 		DebugFrameLevel:     debugFrameLevel,
 	}
 	params.AudioIndex[0] = 6
+
+	xcTestResult := &XcTestResult{
+		timeScale:         48000,
+		sampleRate:        48000,
+		channelLayoutName: "stereo",
+	}
+
+	for i := 1; i <= 1; i++ {
+		xcTestResult.mezFile = append(xcTestResult.mezFile, fmt.Sprintf("%s/asegment-%d.mp4", outputDir, i))
+	}
+
+	xcTest(t, outputDir, params, xcTestResult, true)
+}
+
+// Transcode mono pcm_s24le with 60000 sample rate, into aac stereo 48000 sample rate.
+// This is case 2 with audio input sample rate incompatible with AAC
+func TestAudioMonoToStereo_pcm_60000(t *testing.T) {
+	filename := "./media/Sintel_30s_6ch_pcm_s24le_60000Hz.mov"
+	outputDir := path.Join(baseOutPath, fn())
+
+	params := &avpipe.XcParams{
+		BypassTranscoding:   false,
+		Format:              "fmp4-segment",
+		StartTimeTs:         0,
+		DurationTs:          -1,
+		StartSegmentStr:     "1",
+		SegDuration:         "30",
+		Ecodec2:             "aac",
+		Dcodec2:             "",
+		XcType:              avpipe.XcAudio,
+		ChannelLayout:       avpipe.ChannelLayout("stereo"),
+		NumAudio:            1,
+		StreamId:            -1,
+		SyncAudioToStreamId: -1,
+		Url:                 filename,
+		DebugFrameLevel:     debugFrameLevel,
+	}
+	params.AudioIndex[0] = 3
 
 	xcTestResult := &XcTestResult{
 		timeScale:         48000,
@@ -1444,7 +1483,7 @@ func TestMXF_H265MezMaker(t *testing.T) {
 		StreamId:          -1,
 		Url:               filename,
 		DebugFrameLevel:   debugFrameLevel,
-		ForceKeyInt:         48,
+		ForceKeyInt:       48,
 	}
 
 	xcTestResult := &XcTestResult{

--- a/avpipe_test.go
+++ b/avpipe_test.go
@@ -1444,6 +1444,7 @@ func TestMXF_H265MezMaker(t *testing.T) {
 		StreamId:          -1,
 		Url:               filename,
 		DebugFrameLevel:   debugFrameLevel,
+		ForceKeyInt:         48,
 	}
 
 	xcTestResult := &XcTestResult{
@@ -1673,7 +1674,7 @@ func TestAVPipeStats(t *testing.T) {
 	xcTest(t, outputDir, params, xcTestResult, true)
 
 	assert.Equal(t, int64(2880), statsInfo.encodingVideoFrameStats.TotalFramesWritten)
-	assert.Equal(t, int64(5626), statsInfo.encodingAudioFrameStats.TotalFramesWritten)
+	assert.Equal(t, int64(5625), statsInfo.encodingAudioFrameStats.TotalFramesWritten)
 	// FIXME
 	//assert.Equal(t, int64(720), statsInfo.encodingVideoFrameStats.FramesWritten)
 	//assert.Equal(t, int64(1406), statsInfo.encodingAudioFrameStats.FramesWritten)

--- a/libavpipe/Makefile
+++ b/libavpipe/Makefile
@@ -4,7 +4,8 @@ SRCS=avpipe_xc.c \
     avpipe_filters.c \
     avpipe_io.c \
     avpipe_mux.c \
-    avpipe_level.c
+    avpipe_level.c \
+    avpipe_udp_thread.c
 
 BINDIR=bin
 LIBDIR=lib

--- a/libavpipe/include/avpipe_version.h
+++ b/libavpipe/include/avpipe_version.h
@@ -10,5 +10,5 @@
 
 /* Only increase these versions for release purposes */
 #define AVPIPE_MAJOR_VERSION    1
-#define AVPIPE_MINOR_VERSION    3
+#define AVPIPE_MINOR_VERSION    4
 

--- a/libavpipe/src/avpipe_udp_thread.c
+++ b/libavpipe/src/avpipe_udp_thread.c
@@ -1,0 +1,131 @@
+/*
+ * avpipe_udp_thread.c
+ *
+ * Thread function to read UDP/MPEGTS datagrams and push them into udp channel.
+ *
+ */
+#include <sys/types.h>
+#include <sys/socket.h>
+
+#include "avpipe_xc.h"
+#include "elv_channel.h"
+#include "elv_sock.h"
+#include "elv_log.h"
+
+typedef struct udp_thread_params_t {
+    int             fd;             /* Socket fd to read UDP datagrams */
+    elv_channel_t   *udp_channel;   /* udp channel to keep incomming UDP packets */
+    socklen_t       salen;
+    ioctx_t         *inctx;
+} udp_thread_params_t;
+
+int
+read_one_udp_datagram(
+    int sock,
+    udp_packet_t *udp_packet,
+    struct sockaddr *ca,
+    socklen_t *len)
+{
+try_again:
+    udp_packet->len = recvfrom(sock, udp_packet->buf, MAX_UDP_PKT_LEN, 0, ca, len);
+    if (udp_packet->len < 0) {
+        if (errno == EINTR) {
+            elv_log("XXX Got EINTR recvfrom");
+            goto try_again;
+        }
+        return errno;
+    }
+
+    /** Successful read */
+    return 0;
+}
+
+void *
+udp_thread_func(
+    void *thread_params)
+{
+    udp_thread_params_t *params = (udp_thread_params_t *) thread_params;
+    xcparams_t *xcparams = params->inctx->params;
+    int debug_frame_level = (xcparams != NULL) ? xcparams->debug_frame_level : 0;
+    char *url = (xcparams != NULL) ? xcparams->url : "";
+    struct sockaddr     ca;
+    socklen_t len;
+    udp_packet_t *udp_packet;
+    int ret;
+    int first = 1;
+    int pkt_num = 0;
+    int timedout = 0;
+    int connection_timeout = xcparams->connection_timeout;
+
+    for ( ; ; ) {
+        if (params->inctx->closed)
+            break;
+
+        ret = readable_timeout(params->fd, 1);
+        if (ret == -1) {
+            if (errno == EINTR) {
+                elv_log("XXX Got EINTR select");
+                continue;
+            }
+            elv_err("UDP select error fd=%d, err=%d, url=%s", params->fd, errno, url);
+            break;
+        } else if (ret == 0) {
+            /* If no packet has not received yet, check connection_timeout */
+            if (first) {
+                if (connection_timeout > 0) {
+                    connection_timeout--;
+                    if (connection_timeout == 0) {
+                        elv_channel_close(params->udp_channel, 1);
+                        break;
+                    }
+                }
+                continue;
+            }
+
+            elv_err("XXX UDP recv fd=%d, url=%s, errno=%d, timeout=%dsec", params->fd, url, errno, timedout+1);
+            if (timedout++ == UDP_PIPE_TIMEOUT) {
+                elv_err("UDP recv timeout fd=%d, url=%s, errno=%d", params->fd, url, errno);
+                break;
+            }
+            continue;
+        }
+
+recv_again:
+        len = params->salen;
+        udp_packet = (udp_packet_t *) calloc(1, sizeof(udp_packet_t));
+
+        if (params->inctx->closed)
+            break;
+        ret = read_one_udp_datagram(params->fd, udp_packet, &ca, &len);
+        if (ret == EAGAIN || ret == EWOULDBLOCK || udp_packet->len == 0) {
+            free(udp_packet);
+            timedout = 0;
+            continue;
+        }
+        if (ret != 0) {
+            elv_err("UDP recvfrom fd=%d, errno=%d, url=%s", params->fd, errno, url);
+            break;
+        }
+
+        if (first) {
+            first = 0;
+            elv_log("UDP FIRST url=%s", url);
+        }
+
+        pkt_num++;
+        udp_packet->pkt_num = pkt_num;
+        /* If the channel is closed, exit the thread */
+        if (elv_channel_send(params->udp_channel, udp_packet) < 0) {
+            break;
+        }
+        elv_dbg("Rcv UDP packet=%d, len=%d", pkt_num, udp_packet->len);
+        if (debug_frame_level)
+            elv_dbg("Received UDP packet=%d, len=%d, url=%s", pkt_num, udp_packet->len, url);
+        timedout = 0;
+        goto recv_again;
+    }
+
+    elv_log("UDP thread terminated, url=%s", url);
+    return NULL;
+}
+

--- a/libavpipe/src/avpipe_udp_thread.c
+++ b/libavpipe/src/avpipe_udp_thread.c
@@ -30,7 +30,7 @@ try_again:
     udp_packet->len = recvfrom(sock, udp_packet->buf, MAX_UDP_PKT_LEN, 0, ca, len);
     if (udp_packet->len < 0) {
         if (errno == EINTR) {
-            elv_log("XXX Got EINTR recvfrom");
+            elv_dbg("Got EINTR recvfrom");
             goto try_again;
         }
         return errno;
@@ -64,7 +64,7 @@ udp_thread_func(
         ret = readable_timeout(params->fd, 1);
         if (ret == -1) {
             if (errno == EINTR) {
-                elv_log("XXX Got EINTR select");
+                elv_dbg("Got EINTR select");
                 continue;
             }
             elv_err("UDP select error fd=%d, err=%d, url=%s", params->fd, errno, url);
@@ -82,7 +82,7 @@ udp_thread_func(
                 continue;
             }
 
-            elv_err("XXX UDP recv fd=%d, url=%s, errno=%d, timeout=%dsec", params->fd, url, errno, timedout+1);
+            elv_log("UDP recv fd=%d, url=%s, errno=%d, timeout=%dsec", params->fd, url, errno, timedout+1);
             if (timedout++ == UDP_PIPE_TIMEOUT) {
                 elv_err("UDP recv timeout fd=%d, url=%s, errno=%d", params->fd, url, errno);
                 break;
@@ -118,7 +118,7 @@ recv_again:
         if (elv_channel_send(params->udp_channel, udp_packet) < 0) {
             break;
         }
-        elv_dbg("Rcv UDP packet=%d, len=%d", pkt_num, udp_packet->len);
+        //elv_dbg("Rcv UDP packet=%d, len=%d", pkt_num, udp_packet->len);
         if (debug_frame_level)
             elv_dbg("Received UDP packet=%d, len=%d, url=%s", pkt_num, udp_packet->len, url);
         timedout = 0;

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -1309,8 +1309,7 @@ prepare_audio_encoder(
      *      - set encoder sample_rate to the specified sample_rate.
      */
     if (sample_rate > 0 &&
-        (strcmp(ecodec, "aac") || !is_valid_aac_sample_rate(encoder_context->codec_context[index]->sample_rate)) &&
-        (params->xc_type == xc_audio_merge || params->xc_type == xc_audio_pan || params->xc_type == xc_audio_join)) {
+        (strcmp(ecodec, "aac") || !is_valid_aac_sample_rate(encoder_context->codec_context[index]->sample_rate))) {
         /*
          * Audio resampling, which is active for aac encoder, needs more work to adjust sampling properly
          * when input sample rate is different from output sample rate. (--RM)

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -2032,9 +2032,15 @@ encode_frame(
             output_packet->pts != AV_NOPTS_VALUE)
             encoder_context->video_encoder_prev_pts = output_packet->pts;
 
-        /* Rescale using the stream time_base (not the codec context). */
+        /*
+         * Rescale using the stream time_base (not the codec context):
+         *   - if the stream is a video or
+         *   - if it is audio then the decoding stream and encoding stream has the same codec id.
+         */
         if ((stream_index == decoder_context->video_stream_index ||
-            !decoder_context->is_mpegts) &&
+            (selected_decoded_audio(decoder_context, stream_index) >= 0 &&
+             params->ecodec2 != NULL &&
+             !strcmp(avcodec_get_name(decoder_context->codec_parameters[stream_index]->codec_id), params->ecodec2))) &&
             (decoder_context->stream[stream_index]->time_base.den !=
             encoder_context->stream[stream_index]->time_base.den ||
             decoder_context->stream[stream_index]->time_base.num !=

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -102,7 +102,7 @@ const char*
 avpipe_channel_layout_name(
     int channel_layout);
 
-#define USE_RESAMPLE_AAC
+//#define USE_RESAMPLE_AAC
 /* This will be removed after more testing with new audio transcoding using filters */
 #ifdef USE_RESAMPLE_AAC
 

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -2054,7 +2054,10 @@ encode_frame(
             encoder_context->audio_pts = output_packet->pts;
             encoder_context->audio_frames_written++;
         } else {
-            output_packet->duration = output_packet->pts - encoder_context->video_pts;
+            if (encoder_context->video_pts != AV_NOPTS_VALUE)
+                output_packet->duration = output_packet->pts - encoder_context->video_pts;
+            else
+                output_packet->duration = 0;
             encoder_context->video_pts = output_packet->pts;
             encoder_context->video_frames_written++;
         }
@@ -3467,6 +3470,7 @@ avpipe_xc(
     encoder_context->first_encoding_video_pts = -1;
     encoder_context->first_encoding_audio_pts = -1;
     encoder_context->audio_pts = AV_NOPTS_VALUE;
+    encoder_context->video_pts = AV_NOPTS_VALUE;
 
     for (int j=0; j<MAX_STREAMS; j++)
         encoder_context->first_read_frame_pts[j] = -1;

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -1295,13 +1295,6 @@ prepare_audio_encoder(
         encoder_context->codec_context[index]->channel_layout = AV_CH_LAYOUT_STEREO;    // AV_CH_LAYOUT_STEREO is av_get_default_channel_layout(encoder_context->codec_context[index]->channels)
     }
 
-    elv_dbg("ENCODER channels=%d, channel_layout=%d (%s), sample_fmt=%s, sample_rate=%d",
-        encoder_context->codec_context[index]->channels,
-        encoder_context->codec_context[index]->channel_layout,
-        avpipe_channel_layout_name(encoder_context->codec_context[index]->channel_layout),
-        av_get_sample_fmt_name(encoder_context->codec_context[index]->sample_fmt),
-        encoder_context->codec_context[index]->sample_rate);
-
     int sample_rate = params->sample_rate;
     if (!strcmp(ecodec, "aac") &&
         !is_valid_aac_sample_rate(encoder_context->codec_context[index]->sample_rate) &&
@@ -1328,6 +1321,13 @@ prepare_audio_encoder(
         encoder_context->codec_context[index]->time_base = (AVRational){1, sample_rate};
         encoder_context->stream[index]->time_base = (AVRational){1, sample_rate};
     }
+
+    elv_dbg("ENCODER channels=%d, channel_layout=%d (%s), sample_fmt=%s, sample_rate=%d",
+        encoder_context->codec_context[index]->channels,
+        encoder_context->codec_context[index]->channel_layout,
+        avpipe_channel_layout_name(encoder_context->codec_context[index]->channel_layout),
+        av_get_sample_fmt_name(encoder_context->codec_context[index]->sample_fmt),
+        encoder_context->codec_context[index]->sample_rate);
 
     encoder_context->codec_context[index]->bit_rate = params->audio_bitrate;
 

--- a/live/ts_recorder_test.go
+++ b/live/ts_recorder_test.go
@@ -35,8 +35,8 @@ func TestUdpToMp4(t *testing.T) {
 		Seekable:        false,
 		DurationTs:      -1,
 		StartSegmentStr: "1",
-		AudioBitrate:    384000,   // FS1-19-10-14.ts audio bitrate
-		VideoBitrate:    20000000, // fox stream bitrate
+		AudioBitrate:    384000,
+		VideoBitrate:    20000000,
 		ForceKeyInt:     120,
 		SegDuration:     "30.03", // seconds
 		Dcodec2:         "ac3",
@@ -143,8 +143,8 @@ func TestUdpToMp4WithCancelling1(t *testing.T) {
 		Seekable:        false,
 		DurationTs:      -1,
 		StartSegmentStr: "1",
-		AudioBitrate:    384000,   // FS1-19-10-14.ts audio bitrate
-		VideoBitrate:    20000000, // fox stream bitrate
+		AudioBitrate:    384000,
+		VideoBitrate:    20000000,
 		ForceKeyInt:     120,
 		SegDuration:     "30.03", // seconds
 		Dcodec2:         "ac3",
@@ -278,8 +278,8 @@ func TestUdpToMp4WithCancelling3(t *testing.T) {
 		Seekable:        false,
 		DurationTs:      -1,
 		StartSegmentStr: "1",
-		AudioBitrate:    384000,   // FS1-19-10-14.ts audio bitrate
-		VideoBitrate:    20000000, // fox stream bitrate
+		AudioBitrate:    384000,
+		VideoBitrate:    20000000,
 		ForceKeyInt:     120,
 		SegDuration:     "30.03", // seconds
 		Dcodec2:         "ac3",
@@ -352,8 +352,8 @@ func TestUdpToMp4WithCancelling4(t *testing.T) {
 		Seekable:        false,
 		DurationTs:      -1,
 		StartSegmentStr: "1",
-		AudioBitrate:    384000,   // FS1-19-10-14.ts audio bitrate
-		VideoBitrate:    20000000, // fox stream bitrate
+		AudioBitrate:    384000,
+		VideoBitrate:    20000000,
 		ForceKeyInt:     120,
 		SegDuration:     "30.03", // seconds
 		Dcodec2:         "ac3",

--- a/utils/include/elv_sock.h
+++ b/utils/include/elv_sock.h
@@ -21,3 +21,7 @@ tcp_connect(
     const char *host,
     const char *port);
 
+int
+set_sock_nonblocking(
+    int sock);
+

--- a/utils/src/elv_channel.c
+++ b/utils/src/elv_channel.c
@@ -129,7 +129,6 @@ elv_channel_timed_receive(
         rc = pthread_cond_timedwait(&channel->_cond_send, &channel->_mutex, &ts);
         /* ETIMEDOUT is not a real error */
         if (rc != 0) {
-            elv_log("XXX pthread_cond_timedwait rc=%d, count=%d, front=%d, rear=%d", rc, channel->_count, channel->_front, channel->_rear);
             pthread_mutex_unlock(&channel->_mutex);
             return rc;
         }
@@ -177,7 +176,7 @@ elv_channel_close(
     pthread_cond_signal(&channel->_cond_recv);
     pthread_cond_signal(&channel->_cond_send);
 
-    elv_log("XXX elv_channel_close count=%d, front=%d, rear=%d", channel->_count, channel->_front, channel->_rear);
+    elv_dbg("elv_channel_close count=%d, front=%d, rear=%d", channel->_count, channel->_front, channel->_rear);
     /* Purge the channel if the flag is set */
     while (purge_channel && channel->_count > 0) {
         channel->_count--;

--- a/utils/src/elv_channel.c
+++ b/utils/src/elv_channel.c
@@ -133,8 +133,10 @@ elv_channel_timed_receive(
         }
     }
 
-    if (channel->_closed)
+    if (channel->_closed) {
+        pthread_mutex_unlock(&channel->_mutex);
         return EPIPE;
+    }
 
     channel->_count--;
     msg = channel->_items[channel->_front];

--- a/utils/src/elv_sock.c
+++ b/utils/src/elv_sock.c
@@ -7,6 +7,9 @@
 #include <netdb.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+
 
 #include "elv_sock.h"
 #include "elv_log.h"
@@ -88,6 +91,17 @@ tcp_connect(
         return -1;
 
     return sockfd;
+}
+
+int
+set_sock_nonblocking(
+    int sock)
+{
+    int flags = fcntl(sock, F_GETFL);
+    if (flags == -1)
+        return -1;
+
+    return fcntl(sock, F_SETFL, flags | O_NONBLOCK);
 }
 
 #if 0

--- a/utils/test/Makefile
+++ b/utils/test/Makefile
@@ -1,0 +1,45 @@
+include ../../rules.make
+TOP_DIR ?= $(shell pwd)
+SRCS=elv_channel_test.c
+
+BINDIR=.
+OSNAME := $(shell uname -s)
+INCDIRS=-I${FFMPEG_DIST}/include -I../include
+
+OBJS=$(SRCS:%.c=$(BINDIR)/%.o)
+
+.PHONY: all
+
+LIBDIRS=-L${FFMPEG_DIST}/lib -L../lib -L../../lib
+FLAGS=-O0 -ggdb -Wall -fPIC
+
+ifeq ($(OSNAME), Darwin)
+	SHARED_FLAGS=-dynamiclib
+	SHARED_LIB=libutils.dylib
+endif
+ifeq ($(OSNAME), Linux)
+	SHARED_FLAGS=-shared
+	SHARED_LIB=libutils.so
+endif
+
+all: elv_channel_test
+
+elv_channel_test: elv_channel_test.o
+	@echo "Making " $@
+	gcc $? ${LIBDIRS} ${LIBS} -o $(BINDIR)/elv_channel_test
+
+$(BINDIR)/%.o: ./%.c
+	@echo "Compiling ..." $<
+	gcc ${FLAGS} ${INCDIRS} -c $< -o $@
+
+clean:
+	@rm -rf *.o elv_channel_test
+
+tags:
+	ctags -R .
+
+#check-env:
+#ifndef FFMPEG_DIST
+#  $(error FFMPEG_DIST is undefined)
+#endif
+

--- a/utils/test/elv_channel_test.c
+++ b/utils/test/elv_channel_test.c
@@ -1,0 +1,94 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <inttypes.h>
+#include <string.h>
+#include "elv_channel.h"
+
+#define CHANNEL_SIZE1       1
+#define CHANNEL_SIZE5       5
+#define CHANNEL_SIZE100     100
+#define CHANNEL_SIZE100000  100000
+#define TIMEOUT_SEC         5
+#define MSG_COUNT           100000
+
+typedef struct test_thread_params_t {
+    elv_channel_t   *channel;
+    int             with_sleep;
+    int             with_trace;
+} test_thread_params_t;
+
+static void *
+send_thread_func(
+    void *thread_params)
+{
+    test_thread_params_t *params = (test_thread_params_t *) thread_params;
+
+    for (int i=0; i<MSG_COUNT; i++) {
+        int *msg = (int*) malloc(sizeof(int));
+        *msg = i;
+        if (i%100 == 0 && params->with_sleep)
+            usleep(10000);
+        elv_channel_send(params->channel, msg);
+        if (params->with_trace)
+            printf("Sent %d, size=%"PRId64"\n", *msg, elv_channel_size(params->channel));
+    }
+
+    return NULL;
+}
+
+
+static void *
+recv_thread_func(
+    void *thread_params)
+{
+    test_thread_params_t *params = (test_thread_params_t *) thread_params;
+    int *msg;
+
+    for (int i=0; i<MSG_COUNT; i++) {
+        elv_channel_timed_receive(params->channel, TIMEOUT_SEC*1000000, (void **)&msg);
+        if (params->with_trace)
+            printf("Received %d, size=%"PRId64"\n", *msg, elv_channel_size(params->channel));
+        free(msg);
+    }
+
+    return NULL;
+}
+
+static void
+test_send_recv(
+    int channel_size,
+    int do_sleep,
+    int do_trace)
+{
+    pthread_t               recv_tid;
+    pthread_t               send_tid;
+    test_thread_params_t    params;
+
+    memset(&params, 0, sizeof(test_thread_params_t));
+    params.with_sleep = do_sleep;
+    params.with_trace = do_trace;
+    elv_channel_init(&params.channel, channel_size, NULL);
+    pthread_create(&recv_tid, NULL, recv_thread_func, &params);
+    pthread_create(&send_tid, NULL, send_thread_func, &params);
+    pthread_join(send_tid, NULL);
+    pthread_join(recv_tid, NULL);
+    if (elv_channel_size(params.channel) != 0)
+        printf("Test CHANNEL_SIZE%d failed line %d\n", channel_size, __LINE__);
+    elv_channel_fini(&params.channel);
+}
+
+int
+main() {
+    int do_trace = 0;
+
+    test_send_recv(CHANNEL_SIZE1, 0, do_trace);
+    test_send_recv(CHANNEL_SIZE5, 0, do_trace);
+    test_send_recv(CHANNEL_SIZE100, 0, do_trace);
+    test_send_recv(CHANNEL_SIZE100000, 0, do_trace);
+
+    test_send_recv(CHANNEL_SIZE1, 1, do_trace);
+    return 0;
+}


### PR DESCRIPTION
issue: https://github.com/eluv-io/avpipe/issues/10

- Fix pts/dts issue when transcoding mpegts using avpipe audio filters.
- Use audio filters in general instead of using resampling library.
- Refactor UDP thread in case of mpegts transcoding.
- Fix a small issue in elv_channel and add unit test for it
- Support incompatible sample rate with AAC in general case and add unit test for it