### PR TITLE
Fix corner cases with start_time_ts, skip_decoding, and bypass

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ typedef struct xcparams_t {
     int     bypass_transcoding;         // if 0 means do transcoding, otherwise bypass transcoding
     char    *format;                    // Output format [Required, Values: dash, hls, mp4, fmp4]
     int64_t start_time_ts;              // Transcode the source starting from this time
-    int64_t skip_over_pts;              // Like start_time_ts but expressed in input pts
     int64_t start_pts;                  // Starting PTS for output
     int64_t duration_ts;                // Transcode time period from start_time_ts (-1 for entire source)
     char    *start_segment_str;         // Specify index of the first segment  TODO: change type to int

--- a/avpipe.c
+++ b/avpipe.c
@@ -1253,7 +1253,7 @@ set_mux_handlers(
 {
     if (p_in_handlers) {
         avpipe_io_handler_t *in_handlers = (avpipe_io_handler_t *)calloc(1, sizeof(avpipe_io_handler_t));
-        in_handlers->avpipe_opener = in_opener;
+        in_handlers->avpipe_opener = in_mux_opener;
         in_handlers->avpipe_closer = in_closer;
         in_handlers->avpipe_reader = in_mux_read_packet;
         in_handlers->avpipe_writer = in_write_packet;

--- a/avpipe.c
+++ b/avpipe.c
@@ -1031,7 +1031,7 @@ in_mux_opener(
 
     if (size > 0)
         inctx->sz = size;
-    elv_dbg("IN MUX OPEN fd=%"PRId64", size=%"PRId64, fd, size);
+    elv_dbg("IN MUX OPEN url=%s, fd=%"PRId64", size=%"PRId64, url, fd, size);
 
     *((int64_t *)(inctx->opaque)) = fd;
     return 0;

--- a/avpipe.go
+++ b/avpipe.go
@@ -166,7 +166,6 @@ type XcParams struct {
 	BypassTranscoding      bool               `json:"bypass,omitempty"`
 	Format                 string             `json:"format,omitempty"`
 	StartTimeTs            int64              `json:"start_time_ts,omitempty"`
-	SkipOverPts            int64              `json:"skip_over_pts,omitempty"`
 	StartPts               int64              `json:"start_pts,omitempty"` // Start PTS for output
 	DurationTs             int64              `json:"duration_ts,omitempty"`
 	StartSegmentStr        string             `json:"start_segment_str,omitempty"`
@@ -1160,7 +1159,6 @@ func getCParams(params *XcParams) (*C.xcparams_t, error) {
 		url:                       C.CString(params.Url),
 		format:                    C.CString(params.Format),
 		start_time_ts:             C.int64_t(params.StartTimeTs),
-		skip_over_pts:             C.int64_t(params.SkipOverPts),
 		start_pts:                 C.int64_t(params.StartPts),
 		duration_ts:               C.int64_t(params.DurationTs),
 		start_segment_str:         C.CString(params.StartSegmentStr),

--- a/avpipe_test.go
+++ b/avpipe_test.go
@@ -765,6 +765,94 @@ func TestConcurrentABRTranscode(t *testing.T) {
 	doTranscode(t, params, nThreads, outputDir, filename)
 }
 
+func TestStartTimeTsWithSkipDecoding(t *testing.T) {
+	filename := "./media/video-960.mp4"
+	outputDir := path.Join(baseOutPath, fn())
+	boilerplate(t, outputDir, "")
+
+	params := &avpipe.XcParams{
+		BypassTranscoding:   false,
+		Format:              "dash",
+		StartTimeTs:         180000,
+		StartPts:            900000,
+		DurationTs:          720000,
+		StartSegmentStr:     "19",
+		VideoSegDurationTs:  60000,
+		SkipDecoding:        true,
+		StartFragmentIndex:  1081,
+		ForceKeyInt:         60,
+		SegDuration:         "30",
+		Ecodec:              h264Codec,
+		EncHeight:           -1,
+		EncWidth:            -1,
+		XcType:              avpipe.XcVideo,
+		StreamId:            -1,
+		SyncAudioToStreamId: -1,
+		Url:                 filename,
+		DebugFrameLevel:     debugFrameLevel,
+	}
+
+	avpipe.InitUrlIOHandler(filename, &fileInputOpener{url: filename}, &fileOutputOpener{dir: outputDir})
+	boilerXc(t, params)
+
+	files, err := ioutil.ReadDir(outputDir)
+	assert.NoError(t, err)
+	assert.Equal(t, 14, len(files))
+
+	// Check the ABR segment is within the expected chunks
+	// Starting chunk is "vchunk-stream0-00019.m4s" and ending chunk is "vchunk-stream0-00030.m4s".
+	for i := 0; i < len(files); i++ {
+		if files[i].Name() == "vchunk-stream0-00031.m4s" ||
+			files[i].Name() == "vchunk-stream0-00018.m4s" {
+			assert.Error(t, fmt.Errorf("failed skip decoding"))
+		}
+	}
+}
+
+func TestStartTimeTsWithoutSkipDecoding(t *testing.T) {
+	filename := "./media/video-960.mp4"
+	outputDir := path.Join(baseOutPath, fn())
+	boilerplate(t, outputDir, "")
+
+	params := &avpipe.XcParams{
+		BypassTranscoding:   false,
+		Format:              "dash",
+		StartTimeTs:         180000,
+		StartPts:            900000,
+		DurationTs:          720000,
+		StartSegmentStr:     "19",
+		VideoSegDurationTs:  60000,
+		SkipDecoding:        false,
+		StartFragmentIndex:  1081,
+		ForceKeyInt:         60,
+		SegDuration:         "30",
+		Ecodec:              h264Codec,
+		EncHeight:           -1,
+		EncWidth:            -1,
+		XcType:              avpipe.XcVideo,
+		StreamId:            -1,
+		SyncAudioToStreamId: -1,
+		Url:                 filename,
+		DebugFrameLevel:     debugFrameLevel,
+	}
+
+	avpipe.InitUrlIOHandler(filename, &fileInputOpener{url: filename}, &fileOutputOpener{dir: outputDir})
+	boilerXc(t, params)
+
+	files, err := ioutil.ReadDir(outputDir)
+	assert.NoError(t, err)
+	assert.Equal(t, 14, len(files))
+
+	// Check the ABR segment is within the expected chunks
+	// Starting chunk is "vchunk-stream0-00019.m4s" and ending chunk is "vchunk-stream0-00030.m4s".
+	for i := 0; i < len(files); i++ {
+		if files[i].Name() == "vchunk-stream0-00031.m4s" ||
+			files[i].Name() == "vchunk-stream0-00018.m4s" {
+			assert.Error(t, fmt.Errorf("failed skip decoding"))
+		}
+	}
+}
+
 func TestAudioAAC2AACMezMaker(t *testing.T) {
 	filename := "./media/bbb-audio-stereo-2min.aac"
 	outputDir := path.Join(baseOutPath, fn())
@@ -2329,6 +2417,7 @@ func xcTest2(t *testing.T, outputDir string, params *avpipe.XcParams, xcTestResu
 // This test uses the following new APIs
 // - to obtain a handle of running session:
 //   - XcInit()
+//
 // - to run the tx session
 //   - XcRun()
 func boilerXc2(t *testing.T, params *avpipe.XcParams) {

--- a/elvxc/cmd/mux.go
+++ b/elvxc/cmd/mux.go
@@ -117,7 +117,7 @@ func (muxInput *elvxcMuxInput) Stat(statType avpipe.AVStatType, statArgs interfa
 	return nil
 }
 
-//Implement AVPipeOutputOpener
+// Implement AVPipeOutputOpener
 type AVCmdMuxOutputOpener struct {
 }
 

--- a/exc/elv_mux.c
+++ b/exc/elv_mux.c
@@ -23,6 +23,7 @@ in_mux_opener(
         return -1;
     }
 
+    elv_dbg("IN MUX OPEN fd=%"PRId64, fd);
     *((int *)(inctx->opaque)) = fd;
     return 0;
 }
@@ -120,6 +121,8 @@ read_next_input:
         c->opaque = (int *) calloc(1, sizeof(int));
         if (in_mux_opener(filepath, c) < 0) {
             elv_err("in_mux_read_packet failed to open file=%s", filepath);
+            free(c->opaque);
+            c->opaque = NULL;
             return -1;
         }
         fd = *((int64_t *)(c->opaque));

--- a/libavpipe/include/avpipe_xc.h
+++ b/libavpipe/include/avpipe_xc.h
@@ -362,7 +362,6 @@ typedef struct xcparams_t {
     int     bypass_transcoding;     // if 0 means do transcoding, otherwise bypass transcoding (only copy)
     char    *format;                // Output format [Required, Values: dash, hls, mp4, fmp4]
     int64_t start_time_ts;          // Transcode the source starting from this time
-    int64_t skip_over_pts;          // Like start_time_ts but expressed in input pts
     int64_t start_pts;              // Starting PTS for output
     int64_t duration_ts;            // Transcode time period [-1 for entire source length from start_time_ts]
     char    *start_segment_str;     // Specify index of the first segment  TODO: change type to int

--- a/libavpipe/src/avpipe_mux.c
+++ b/libavpipe/src/avpipe_mux.c
@@ -343,6 +343,7 @@ avpipe_init_muxer(
     p_xctx->params = params;
     p_xctx->in_handlers = in_handlers;
     p_xctx->out_handlers = out_handlers;
+    p_xctx->debug_frame_level = params->debug_frame_level;
     *xctx = p_xctx;
 
     return eav_success;
@@ -371,8 +372,10 @@ get_next_packet(
             continue;
         AVStream *stream1 = xctx->in_muxer_ctx[i].format_context->streams[0];
         AVStream *stream2 = xctx->in_muxer_ctx[index].format_context->streams[0];
-        if (av_compare_ts(pkts[i].pts, stream1->time_base, pkts[index].pts, stream2->time_base) <= 0)
+        if (av_compare_ts(pkts[i].pts, stream1->time_base, pkts[index].pts, stream2->time_base) <= 0) {
             index = i;
+            break;
+        }
     }
 
     /* If there is no valid packet anymore return */

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -1788,10 +1788,6 @@ should_skip_encoding(
     else
         frame_in_pts_offset = frame->pts - decoder_context->video_input_start_pts;
 
-    /* If there is no video transcoding return 0 */
-    if ((p->xc_type & xc_video) == 0)
-        return 0;
-
     /* Drop frames before the desired 'start_time'
      * If the format is dash or hls, we skip the frames in skip_until_start_time_pts()
      * without decoding the frame.

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -1807,13 +1807,6 @@ should_skip_encoding(
         return 1;
     }
 
-    /* Skip beginning based on input packet pts */
-    if (p->skip_over_pts > 0 && frame->pts <= p->skip_over_pts) {
-        elv_dbg("ENCODE SKIP frame early pts=%" PRId64 ", frame_in_pts_offset=%" PRId64 ", skip_over_pts=%" PRId64,
-            frame->pts, frame_in_pts_offset, p->skip_over_pts);
-        return 1;
-    }
-
     /* To allow for packet reordering frames can come with pts past the desired duration */
     if (p->duration_ts > 0) {
         const int64_t max_valid_ts = p->start_time_ts + p->duration_ts;
@@ -3448,10 +3441,6 @@ avpipe_xc(
 
     xctx->do_instrument = do_instrument;
     xctx->debug_frame_level = debug_frame_level;
-
-    elv_dbg("START TIME %d SKIP_PTS %d, START PTS %d (output), DURATION %d",
-        params->start_time_ts, params->skip_over_pts,
-        params->start_pts, params->duration_ts);
 
 #if INPUT_IS_SEEKABLE
     /* Seek to start position */

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -3029,7 +3029,7 @@ skip_until_start_time_pts(
     AVPacket *input_packet,
     xcparams_t *params)
 {
-    if (params->start_time_ts <= 0 || !params->skip_decoding)
+    if (params->start_time_ts <= 0 || !params->bypass_transcoding)
         return 0;
 
     /* If the format is not dash/hls then return.


### PR DESCRIPTION
- Fix a combination of start_time_ts with skip_decoding and bypass.
- Add unit test for start_time_ts and skip_decoding.
- Fix a small mem leak in exc utility.
- Use in_mux_opener in muxing callback.