### PR TITLE
SCTE parser for MPEG-TS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,14 @@ SUBDIRS=utils libavpipe exc elvxc
 SRCS=avpipe_handler.c
 OBJS=$(SRCS:%.c=$(BINDIR)/%.o)
 
-.PHONY: all test clean
+.PHONY: all test clean help
 
 .DEFAULT_GOAL := dynamic
 
-all install: copy_libs check-env
+help: ## Show help
+	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+all install: copy_libs check-env ## Build C and Go artifacts
 	@for dir in $(SUBDIRS); do \
 	echo "Making $@ in $$dir..."; \
 	(cd $$dir; make $@) || exit 1; \
@@ -18,11 +21,13 @@ all install: copy_libs check-env
 
 dynamic: copy_libs_all all
 
-clean: lclean
+clean: lclean ## Clean C and Go build artifacts
 	@for dir in $(SUBDIRS); do \
 	echo "Making $@ in $$dir..."; \
 	(cd $$dir; make $@) || exit 1; \
 	done
+	@echo "Go clean"
+	@go clean -modcache -testcache -cache -i -r
 
 copy_libs:
 	@(if [ ! -d $(LIBDIR) ]; then mkdir $(LIBDIR); fi)
@@ -67,5 +72,5 @@ ifndef FFMPEG_DIST
   $(error FFMPEG_DIST is undefined)
 endif
 
-test:
+test: ## Run basic tests
 	@./run_tests.sh

--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,11 @@ SUBDIRS=utils libavpipe exc elvxc
 SRCS=avpipe_handler.c
 OBJS=$(SRCS:%.c=$(BINDIR)/%.o)
 
-.PHONY: all test clean help
+.PHONY: all test clean
 
 .DEFAULT_GOAL := dynamic
 
-help: ## Show help
-	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
-
-all install: copy_libs check-env ## Build C and Go artifacts
+all install: copy_libs check-env
 	@for dir in $(SUBDIRS); do \
 	echo "Making $@ in $$dir..."; \
 	(cd $$dir; make $@) || exit 1; \
@@ -21,13 +18,11 @@ all install: copy_libs check-env ## Build C and Go artifacts
 
 dynamic: copy_libs_all all
 
-clean: lclean ## Clean C and Go build artifacts
+clean: lclean
 	@for dir in $(SUBDIRS); do \
 	echo "Making $@ in $$dir..."; \
 	(cd $$dir; make $@) || exit 1; \
 	done
-	@echo "Go clean"
-	@go clean -modcache -testcache -cache -i -r
 
 copy_libs:
 	@(if [ ! -d $(LIBDIR) ]; then mkdir $(LIBDIR); fi)
@@ -72,5 +67,5 @@ ifndef FFMPEG_DIST
   $(error FFMPEG_DIST is undefined)
 endif
 
-test: ## Run basic tests
+test:
 	@./run_tests.sh

--- a/avpipe.c
+++ b/avpipe.c
@@ -540,8 +540,12 @@ udp_in_stat(
         if (debug_frame_level)
             elv_dbg("IN STAT UDP fd=%d, video frame read=%"PRId64", url=%s", fd, c->video_frames_read, c->url);
         break;
+    case in_stat_data_scte35:
+        elv_log("IN STAT UDP SCTE35 fd=%d stat_type=%d", fd, stat_type);
+        (void)AVPipeStatInput(fd, stat_type, c->data);
+        break;
     default:
-        elv_err("IN STATS UDP fd=%d, invalid input stat=%d, url=%s", stat_type, c->url);
+        elv_err("IN STAT UDP fd=%d, invalid input stat=%d, url=%s", stat_type, c->url);
         return 1;
     }
 

--- a/avpipe.c
+++ b/avpipe.c
@@ -544,7 +544,8 @@ udp_in_stat(
             elv_dbg("IN STAT UDP fd=%d, video frame read=%"PRId64", url=%s", fd, c->video_frames_read, c->url);
         break;
     case in_stat_data_scte35:
-        elv_log("IN STAT UDP SCTE35 fd=%d stat_type=%d", fd, stat_type);
+        if (debug_frame_level)
+            elv_dbg("IN STAT UDP SCTE35 fd=%d, stat_type=%d, url=%s", fd, stat_type, c->url);
         rc = AVPipeStatInput(fd, stat_type, c->data);
         break;
     default:

--- a/avpipe.c
+++ b/avpipe.c
@@ -350,7 +350,7 @@ udp_in_opener(
     if (fd <= 0 )
         return -1;
 
-    if (size > 0) 
+    if (size > 0)
         inctx->sz = size;
 
     *((int64_t *)(inctx->opaque)) = fd;
@@ -413,7 +413,7 @@ udp_in_read_packet(
             c->read_bytes += r;
             c->read_pos += r;
             //elv_dbg("IN READ UDP partial read=%d pos=%"PRId64" total=%"PRId64, r, c->read_pos, c->read_bytes);
-            return r;        
+            return r;
         }
 
         /*
@@ -512,6 +512,7 @@ udp_in_stat(
 {
     int64_t fd;
     ioctx_t *c = (ioctx_t *)opaque;
+    int64_t rc;
 
     if (!c || !c->opaque)
         return 0;
@@ -527,10 +528,12 @@ udp_in_stat(
     case in_stat_decoding_audio_start_pts:
         if (debug_frame_level)
             elv_dbg("IN STAT UDP fd=%d, audio start PTS=%"PRId64", url=%s", fd, c->decoding_start_pts, c->url);
+        rc = AVPipeStatInput(fd, stat_type, &c->decoding_start_pts);
         break;
     case in_stat_decoding_video_start_pts:
         if (debug_frame_level)
             elv_dbg("IN STAT UDP fd=%d, video start PTS=%"PRId64", url=%s", fd, c->decoding_start_pts, c->url);
+        rc = AVPipeStatInput(fd, stat_type, &c->decoding_start_pts);
         break;
     case in_stat_audio_frame_read:
         if (debug_frame_level)
@@ -542,14 +545,14 @@ udp_in_stat(
         break;
     case in_stat_data_scte35:
         elv_log("IN STAT UDP SCTE35 fd=%d stat_type=%d", fd, stat_type);
-        (void)AVPipeStatInput(fd, stat_type, c->data);
+        rc = AVPipeStatInput(fd, stat_type, c->data);
         break;
     default:
         elv_err("IN STAT UDP fd=%d, invalid input stat=%d, url=%s", stat_type, c->url);
         return 1;
     }
 
-    return 0;
+    return rc;
 }
 
 

--- a/avpipe.go
+++ b/avpipe.go
@@ -730,8 +730,8 @@ func (h *ioHandler) InStat(avp_stat C.avp_stat_t, stat_args unsafe.Pointer) erro
 		statArgs := *(*uint64)(stat_args)
 		err = h.input.Stat(AV_IN_STAT_VIDEO_FRAME_READ, &statArgs)
 	case C.in_stat_data_scte35:
-		statArgs := *(*uint64)(stat_args)
-		err = h.input.Stat(AV_IN_STAT_DATA_SCTE35, &statArgs)
+		statArgs := C.GoString((*C.char)(stat_args))
+		err = h.input.Stat(AV_IN_STAT_DATA_SCTE35, statArgs)
 	}
 
 	return err

--- a/avpipe.go
+++ b/avpipe.go
@@ -1,16 +1,15 @@
 /*
 Package avpipe has four main interfaces that has to be implemented by the client code:
 
-  1) InputOpener: is the input factory interface that needs an implementation to generate an InputHandler.
+ 1. InputOpener: is the input factory interface that needs an implementation to generate an InputHandler.
 
-  2) InputHandler: is the input handler with Read/Seek/Size/Close methods. An implementation of this
-     interface is needed by ffmpeg to process input streams properly.
+ 2. InputHandler: is the input handler with Read/Seek/Size/Close methods. An implementation of this
+    interface is needed by ffmpeg to process input streams properly.
 
-  3) OutputOpener: is the output factory interface that needs an implementation to generate an OutputHandler.
+ 3. OutputOpener: is the output factory interface that needs an implementation to generate an OutputHandler.
 
-  4) OutputHandler: is the output handler with Write/Seek/Close methods. An implementation of this
-     interface is needed by ffmpeg to write encoded streams properly.
-
+ 4. OutputHandler: is the output handler with Write/Seek/Close methods. An implementation of this
+    interface is needed by ffmpeg to write encoded streams properly.
 */
 package avpipe
 
@@ -313,6 +312,7 @@ const (
 	AV_OUT_STAT_BYTES_WRITTEN           = 32
 	AV_OUT_STAT_FRAME_WRITTEN           = 64
 	AV_OUT_STAT_ENCODING_END_PTS        = 128
+	AV_IN_STAT_DATA_SCTE35              = 256
 )
 
 type StreamInfo struct {
@@ -729,6 +729,9 @@ func (h *ioHandler) InStat(avp_stat C.avp_stat_t, stat_args unsafe.Pointer) erro
 	case C.in_stat_video_frame_read:
 		statArgs := *(*uint64)(stat_args)
 		err = h.input.Stat(AV_IN_STAT_VIDEO_FRAME_READ, &statArgs)
+	case C.in_stat_data_scte35:
+		statArgs := *(*uint64)(stat_args)
+		err = h.input.Stat(AV_IN_STAT_DATA_SCTE35, &statArgs)
 	}
 
 	return err

--- a/elvxc/cmd/transcode.go
+++ b/elvxc/cmd/transcode.go
@@ -98,6 +98,8 @@ func (i *elvxcInput) Stat(statType avpipe.AVStatType, statArgs interface{}) erro
 	case avpipe.AV_IN_STAT_DECODING_VIDEO_START_PTS:
 		startPTS := statArgs.(*uint64)
 		log.Info("AVCMD InputHandler.Stat", "video start PTS", *startPTS)
+	case avpipe.AV_IN_STAT_DATA_SCTE35:
+		log.Info("AVCMD InputHandler.Stat", "hex", statArgs)
 	}
 
 	return nil

--- a/elvxc/cmd/transcode.go
+++ b/elvxc/cmd/transcode.go
@@ -99,7 +99,7 @@ func (i *elvxcInput) Stat(statType avpipe.AVStatType, statArgs interface{}) erro
 		startPTS := statArgs.(*uint64)
 		log.Info("AVCMD InputHandler.Stat", "video start PTS", *startPTS)
 	case avpipe.AV_IN_STAT_DATA_SCTE35:
-		log.Info("AVCMD InputHandler.Stat", "hex", statArgs)
+		log.Info("AVCMD InputHandler.Stat", "scte35", statArgs)
 	}
 
 	return nil

--- a/exc/elv_xc.c
+++ b/exc/elv_xc.c
@@ -356,11 +356,11 @@ in_stat(
             elv_dbg("IN STAT fd=%d, video frame read=%"PRId64, fd, c->video_frames_read);
         break;
     case in_stat_data_scte35:
-        if (debug_frame_level || 1)
+        if (debug_frame_level)
             elv_dbg("IN STAT fd=%d, data=%s", fd, c->data);
         break;
     default:
-        elv_err("IN STATS fd=%d, invalid input stat=%d", fd, stat_type);
+        elv_err("IN STAT fd=%d, invalid input stat=%d", fd, stat_type);
         return 1;
     }
 

--- a/exc/elv_xc.c
+++ b/exc/elv_xc.c
@@ -355,8 +355,12 @@ in_stat(
         if (debug_frame_level)
             elv_dbg("IN STAT fd=%d, video frame read=%"PRId64, fd, c->video_frames_read);
         break;
+    case in_stat_data_scte35:
+        if (debug_frame_level || 1)
+            elv_dbg("IN STAT fd=%d, data=%s", fd, c->data);
+        break;
     default:
-        elv_err("IN STATS fd=%d, invalid input stat=%d", stat_type);
+        elv_err("IN STATS fd=%d, invalid input stat=%d", fd, stat_type);
         return 1;
     }
 

--- a/libavpipe/Makefile
+++ b/libavpipe/Makefile
@@ -5,7 +5,8 @@ SRCS=avpipe_xc.c \
     avpipe_io.c \
     avpipe_mux.c \
     avpipe_level.c \
-    avpipe_udp_thread.c
+    avpipe_udp_thread.c \
+    scte35.c
 
 BINDIR=bin
 LIBDIR=lib

--- a/libavpipe/include/avpipe_utils.h
+++ b/libavpipe/include/avpipe_utils.h
@@ -74,3 +74,8 @@ checksum(
     byte *addr,
     unsigned int count);
 
+void
+hex_encode(
+    byte *buf,
+    int sz,
+    char *str);

--- a/libavpipe/include/avpipe_xc.h
+++ b/libavpipe/include/avpipe_xc.h
@@ -88,10 +88,11 @@ typedef enum avp_stat_t {
     in_stat_audio_frame_read = 2,
     in_stat_video_frame_read = 4,
     in_stat_decoding_audio_start_pts = 8,
-    in_stat_decoding_video_start_pts = 16,
-    out_stat_bytes_written = 32,
-    out_stat_frame_written = 64,
-    out_stat_encoding_end_pts = 128
+    in_stat_decoding_video_start_pts = 16, // 0x0010
+    out_stat_bytes_written = 32,           // 0x0020
+    out_stat_frame_written = 64,           // 0x0040
+    out_stat_encoding_end_pts = 128,       // 0x0080
+    in_stat_data_scte35 = 256              // 0x0100
 } avp_stat_t;
 
 struct coderctx_t;
@@ -167,6 +168,8 @@ typedef struct ioctx_t {
     int64_t pts;                /* frame pts */
     int     stream_index;       /* usually (but not always) video=0 and audio=1 */
     int     seg_index;          /* segment index if this ioctx is a segment */
+
+    uint8_t *data;  /* Data stream buffer (e.g. SCTE-35) */
 
     io_mux_ctx_t    *in_mux_ctx;   /* Input muxer context */
     int             in_mux_index;

--- a/libavpipe/include/avpipe_xc.h
+++ b/libavpipe/include/avpipe_xc.h
@@ -88,11 +88,11 @@ typedef enum avp_stat_t {
     in_stat_audio_frame_read = 2,
     in_stat_video_frame_read = 4,
     in_stat_decoding_audio_start_pts = 8,
-    in_stat_decoding_video_start_pts = 16, // 0x0010
-    out_stat_bytes_written = 32,           // 0x0020
-    out_stat_frame_written = 64,           // 0x0040
-    out_stat_encoding_end_pts = 128,       // 0x0080
-    in_stat_data_scte35 = 256              // 0x0100
+    in_stat_decoding_video_start_pts = 16,
+    out_stat_bytes_written = 32,
+    out_stat_frame_written = 64,
+    out_stat_encoding_end_pts = 128,
+    in_stat_data_scte35 = 256
 } avp_stat_t;
 
 struct coderctx_t;

--- a/libavpipe/include/avpipe_xc.h
+++ b/libavpipe/include/avpipe_xc.h
@@ -259,7 +259,8 @@ typedef struct coderctx_t {
     int audio_stream_index[MAX_AUDIO_MUX];              /* Audio input stream indexes */
     int n_audio;                                        /* Number of audio streams that will be decoded */
 
-    int data_stream_index;
+    int data_scte35_stream_index;                       /* Index of SCTE-35 data stream */
+    int data_stream_index;                              /* Index of an unrecognized data stream */
     int audio_enc_stream_index;                         /* Audio output stream index */
 
     int64_t video_last_wrapped_pts;                     /* Video last wrapped pts */

--- a/libavpipe/src/avpipe_utils.c
+++ b/libavpipe/src/avpipe_utils.c
@@ -309,3 +309,12 @@ checksum(byte *addr, unsigned int count)
     return sum;
 }
 
+// Encode a buffer into a hex string
+// 'str' argument must be allocated (2 * sz)
+void
+hex_encode(byte *buf, int sz, char *str)
+{
+    for (int i = 0; i < sz; i ++) {
+        sprintf(str + 2 * i, "%02x", buf[i]);
+    }
+}

--- a/libavpipe/src/avpipe_utils.c
+++ b/libavpipe/src/avpipe_utils.c
@@ -314,6 +314,9 @@ checksum(byte *addr, unsigned int count)
 void
 hex_encode(byte *buf, int sz, char *str)
 {
+    if (str == NULL) {
+        return;
+    }
     for (int i = 0; i < sz; i ++) {
         sprintf(str + 2 * i, "%02x", buf[i]);
     }

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -3652,12 +3652,11 @@ avpipe_xc(
                 } else {
                     char hex_str[2 * input_packet->size + 1];
                     switch (scte35_command_type) {
-                    case 3:
                     case 4:
                     case 5:
                     case 6:
                         hex_encode(input_packet->data, input_packet->size, hex_str);
-                        elv_log("SCTE [%d] pts=%"PRId64" duration=%"PRId64" flag=%d size=%d "
+                        elv_dbg("SCTE [%d] pts=%"PRId64" duration=%"PRId64" flag=%d size=%d "
                             "data=%s command=%d",
                             input_packet->stream_index, input_packet->pts, input_packet->duration,
                             input_packet->flags, input_packet->size,
@@ -3666,8 +3665,6 @@ avpipe_xc(
                         if (in_handlers->avpipe_stater) {
                             inctx->data = (uint8_t *)hex_str;
                             in_handlers->avpipe_stater(inctx, in_stat_data_scte35);
-                        } else {
-                            elv_log("SCTE FAIL - no avpipe_stater");
                         }
                         break;
                     }

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -373,6 +373,7 @@ prepare_decoder(
     decoder_context->in_handlers = in_handlers;
     decoder_context->inctx = inctx;
     decoder_context->video_stream_index = -1;
+    decoder_context->data_scte35_stream_index = -1;
     for (int j=0; j<MAX_AUDIO_MUX; j++)
         decoder_context->audio_stream_index[j] = -1;
 

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -3656,15 +3656,16 @@ avpipe_xc(
                 case 6: // We may not need '6'
                     hex_encode(input_packet->data, input_packet->size, hex_str);
                     elv_log("SCTE [%d] pts=%"PRId64" duration=%"PRId64" flag=%d size=%d "
-                        "data=%s sidelems=%d",
+                        "data=%s command=%d",
                         input_packet->stream_index, input_packet->pts, input_packet->duration,
                         input_packet->flags, input_packet->size,
-                        hex_str,
-                        input_packet->side_data_elems);
+                        hex_str, scte35_command_type);
 
                     if (in_handlers->avpipe_stater) {
                         inctx->data = (uint8_t *)hex_str;
                         in_handlers->avpipe_stater(inctx, in_stat_data_scte35);
+                    } else {
+                        elv_log("SCTE FAIL - no avpipe_stater");
                     }
                     break;
                 }
@@ -4559,7 +4560,7 @@ init_extract_images(
     params->extract_images_sz = size;
 }
 
-void 
+void
 set_extract_images(
     xcparams_t *params,
     int index,

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -3648,8 +3648,12 @@ avpipe_xc(
                     elv_warn("SCTE [%d] fail to parse pts=%"PRId64" size=%d",
                         input_packet->stream_index, input_packet->pts, input_packet->size);
                 }
-                if (scte35_command_type != 0 /* Skip SCTE-35 command 'NULL' */) {
-                    char hex_str[2048];
+                char hex_str[2048];
+                switch (scte35_command_type) {
+                case 3:
+                case 4:
+                case 5:
+                case 6: // We may not need '6'
                     hex_encode(input_packet->data, input_packet->size, hex_str);
                     elv_log("SCTE [%d] pts=%"PRId64" duration=%"PRId64" flag=%d size=%d "
                         "data=%s sidelems=%d",
@@ -3657,6 +3661,12 @@ avpipe_xc(
                         input_packet->flags, input_packet->size,
                         hex_str,
                         input_packet->side_data_elems);
+
+                    if (in_handlers->avpipe_stater) {
+                        inctx->data = (uint8_t *)hex_str;
+                        in_handlers->avpipe_stater(inctx, in_stat_data_scte35);
+                    }
+                    break;
                 }
             } else {
                 if (debug_frame_level)

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -2988,6 +2988,7 @@ should_stop_decoding(
         if (decoder_context->video_input_start_pts == -1) {
             avpipe_io_handler_t *in_handlers = decoder_context->in_handlers;
             decoder_context->video_input_start_pts = input_packet->pts;
+            decoder_context->inctx->decoding_start_pts = input_packet->pts;
             elv_log("video_input_start_pts=%"PRId64,
                 decoder_context->video_input_start_pts);
             if (in_handlers->avpipe_stater)

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -3000,6 +3000,7 @@ should_stop_decoding(
         if (decoder_context->audio_input_start_pts == -1) {
             avpipe_io_handler_t *in_handlers = decoder_context->in_handlers;
             decoder_context->audio_input_start_pts = input_packet->pts;
+            decoder_context->inctx->decoding_start_pts = input_packet->pts;
             elv_log("audio_input_start_pts=%"PRId64,
                 decoder_context->audio_input_start_pts);
             if (in_handlers->avpipe_stater)

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -3647,27 +3647,28 @@ avpipe_xc(
                 if (res < 0) {
                     elv_warn("SCTE [%d] fail to parse pts=%"PRId64" size=%d",
                         input_packet->stream_index, input_packet->pts, input_packet->size);
-                }
-                char hex_str[2048];
-                switch (scte35_command_type) {
-                case 3:
-                case 4:
-                case 5:
-                case 6: // We may not need '6'
-                    hex_encode(input_packet->data, input_packet->size, hex_str);
-                    elv_log("SCTE [%d] pts=%"PRId64" duration=%"PRId64" flag=%d size=%d "
-                        "data=%s command=%d",
-                        input_packet->stream_index, input_packet->pts, input_packet->duration,
-                        input_packet->flags, input_packet->size,
-                        hex_str, scte35_command_type);
+                } else {
+                    char hex_str[2 * input_packet->size + 1];
+                    switch (scte35_command_type) {
+                    case 3:
+                    case 4:
+                    case 5:
+                    case 6:
+                        hex_encode(input_packet->data, input_packet->size, hex_str);
+                        elv_log("SCTE [%d] pts=%"PRId64" duration=%"PRId64" flag=%d size=%d "
+                            "data=%s command=%d",
+                            input_packet->stream_index, input_packet->pts, input_packet->duration,
+                            input_packet->flags, input_packet->size,
+                            hex_str, scte35_command_type);
 
-                    if (in_handlers->avpipe_stater) {
-                        inctx->data = (uint8_t *)hex_str;
-                        in_handlers->avpipe_stater(inctx, in_stat_data_scte35);
-                    } else {
-                        elv_log("SCTE FAIL - no avpipe_stater");
+                        if (in_handlers->avpipe_stater) {
+                            inctx->data = (uint8_t *)hex_str;
+                            in_handlers->avpipe_stater(inctx, in_stat_data_scte35);
+                        } else {
+                            elv_log("SCTE FAIL - no avpipe_stater");
+                        }
+                        break;
                     }
-                    break;
                 }
             } else {
                 if (debug_frame_level)

--- a/libavpipe/src/scte35.c
+++ b/libavpipe/src/scte35.c
@@ -1,0 +1,56 @@
+/*
+ * scte35.c
+ */
+
+#include "scte35.h"
+
+/*
+ * Parse SCTE-35 command type. Used to dispatch the SCTE-35 signal to a downstream processor.
+ * Could be extended to parse more SCTE-35 information if necessary.
+ *
+ * References:
+ *
+ * - Carlos Fernandez Sanz PR "SCTE-35 support in hlsenc" (not accepted in ffmpeg)
+ *   https://patchwork.ffmpeg.org/project/ffmpeg/patch/1476837390-20225-4-git-send-email-carlos@ccextractor.org/
+ * - Github
+ *   https://github.com/nixiz/scte35-parser
+ *
+ * Simplified byte format (up to the command type)
+ *
+ *   -  8 bits  - table identifier (must be 0xfc)
+ *   -  1 bit   - section syntax indicator
+ *   -  1 bit   - private indicator
+ *   -  2 bits  - reserved
+ *   - 12 bits  - section length
+ *   -  8 bits  - protocol version
+ *   -  1 bit   - encrypted packet
+ *   -  6 bits  - encryption algorithm
+ *   - 33 bits  - pts adjustment
+ *   -  8 bits  - cw index
+ *   - 12 bits  - tier
+ *   - 12 bits  - splice command length
+ *   -  8 bits  - command type
+ *   (splice info follows)
+ */
+int parse_scte35_pkt(uint8_t *scte35_cmd_type, const AVPacket *avpkt)
+{
+    const uint8_t *buf = avpkt->data;
+
+    if (scte35_cmd_type == NULL) {
+        return -1;
+    }
+
+    *scte35_cmd_type = 0;
+
+    if (avpkt->size < 20) {
+        return -1; // Buffer too short
+    }
+
+    uint8_t table_identifier = buf[0];
+    if (table_identifier != 0xfc) {
+        return -1; // Unrecognized table identifier
+    }
+
+    *scte35_cmd_type = buf[13];
+    return 0;
+}

--- a/libavpipe/src/scte35.h
+++ b/libavpipe/src/scte35.h
@@ -1,0 +1,14 @@
+/*
+ * scte35.h
+ */
+
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+
+#include <stdio.h>
+#include <sys/types.h>
+
+int
+parse_scte35_pkt(
+    uint8_t *scte35_cmd_type,
+    const AVPacket *avpkt);

--- a/ts/scte35_test.go
+++ b/ts/scte35_test.go
@@ -1,11 +1,13 @@
 package ts
 
 import (
+	"encoding/hex"
 	"encoding/json"
-	"github.com/Comcast/gots/scte35"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"testing"
+
+	"github.com/Comcast/gots/scte35"
+	"github.com/stretchr/testify/assert"
 )
 
 // print byte array for use in declaring variables, e.g. var testVss = []byte{0x00, 0xfc, 0x30}
@@ -16,7 +18,44 @@ import (
 // time_signal with 3 segmentation_descriptors
 var scteMsg = []byte{0x00, 0xfc, 0x30, 0x57, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xf0, 0x05, 0x06, 0xff, 0xff, 0x90, 0x5c, 0x30, 0x00, 0x41, 0x02, 0x0f, 0x43, 0x55, 0x45, 0x49, 0x09, 0x7b, 0x74, 0xaf, 0x7f, 0x9f, 0x03, 0x00, 0x31, 0x01, 0x01, 0x02, 0x0f, 0x43, 0x55, 0x45, 0x49, 0x09, 0x79, 0xfc, 0x8b, 0x7f, 0x9f, 0x00, 0x00, 0x35, 0x00, 0x01, 0x02, 0x1d, 0x43, 0x55, 0x45, 0x49, 0x09, 0x7b, 0xe8, 0x83, 0x7f, 0x9f, 0x01, 0x0e, 0x45, 0x50, 0x30, 0x33, 0x34, 0x31, 0x31, 0x35, 0x30, 0x36, 0x30, 0x30, 0x39, 0x39, 0x20, 0x06, 0x01, 0x28, 0x20, 0xce, 0x5c}
 
+var scteMsgsHex = []string{
+	"00fc30a00000000182f100fff00506ff9e52e89a008a021d43554549073d06b67fbf010e5348303430363333393330303030210101021b435545490713d3a97f830a0c147714edc71d0000000000000100000214435545490748ed757fff0000a4cb8001002200010216435545490748ed757fff0000a4cb80010034000100000214435545490748ed757fff0000a4cb800100300001000843554549000000009d86c037",
+	"00fc305f0000000182f100fff00506ff9e3d94120049021b4355454907485a237fbf030c5a4d45523030303130303248310101022043554549074894bc7fff0000149970030c4e444545303133373030304830010100084355454900000000daf3a711",
+	"00fc30250000000182f100fff0140564de518f7fefff9ea54ed1fe005265c00000000000008ac36b04",
+}
+
+func TestScteHex(t *testing.T) {
+
+	for _, bufHex := range scteMsgsHex {
+		buf, err := hex.DecodeString(bufHex)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		gsi, err := scte35.NewSCTE35(buf)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		assert.True(t, gsi.CommandInfo().CommandType() == 5 || gsi.CommandInfo().CommandType() == 6)
+
+		if gsi.CommandInfo().CommandType() == 6 {
+			si, err := ConvertGots(0, gsi)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			assert.EqualValues(t, si.SpliceCommandType, 6)
+		}
+
+		if gsi.CommandInfo().CommandType() == 5 {
+			assert.True(t, gsi.PTS().GreaterOrEqual(1))
+		}
+	}
+}
+
 func TestConvert(t *testing.T) {
+
 	gsi, err := scte35.NewSCTE35(scteMsg)
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
Add support for parsing a SCTE-35 data stream in MPEG-TS, if present.
SCTE-35 signals are aligned with the video stream.

Bonus:
- connect input stats for video and audio first decoded frame / PTS
