### PR TITLE
Add filename/url field to probe result

### DIFF
--- a/avpipe.go
+++ b/avpipe.go
@@ -344,6 +344,7 @@ type StreamInfo struct {
 }
 
 type ContainerInfo struct {
+	Filename   string  `json:"filename"`
 	Duration   float64 `json:"duration"`
 	FormatName string  `json:"format_name"`
 }
@@ -1425,6 +1426,7 @@ func Probe(params *XcParams) (*ProbeInfo, error) {
 		probeInfo.StreamInfo[i].Level = int(probeArray[i].level)
 	}
 
+	probeInfo.ContainerInfo.Filename = params.Url
 	probeInfo.ContainerInfo.FormatName = C.GoString((*C.char)(unsafe.Pointer(cprobe.container_info.format_name)))
 	probeInfo.ContainerInfo.Duration = float64(cprobe.container_info.duration)
 

--- a/elvxc/cmd/probe.go
+++ b/elvxc/cmd/probe.go
@@ -101,6 +101,7 @@ func doProbe(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("Container\n")
+	fmt.Printf("\tfilename: %s\n", probe.ContainerInfo.Filename)
 	fmt.Printf("\tformat_name: %s\n", probe.ContainerInfo.FormatName)
 	fmt.Printf("\tduration: %.5f\n", probe.ContainerInfo.Duration)
 


### PR DESCRIPTION
Simple addition to the probe response in Go to help with automation tools and apps (analogous to ffprobe output)

No need to change the C probe and exc.