### PR TITLE
Keyframe stats

### DIFF
--- a/avpipe.c
+++ b/avpipe.c
@@ -282,6 +282,11 @@ in_stat(
     case in_stat_video_frame_read:
         rc = AVPipeStatInput(fd, stat_type, &c->video_frames_read);
         break;
+
+    case in_stat_first_keyframe_pts:
+        rc = AVPipeStatInput(fd, stat_type, &c->first_key_frame_pts);
+        break;
+
     default:
         rc = -1;
     }

--- a/avpipe.c
+++ b/avpipe.c
@@ -548,6 +548,11 @@ udp_in_stat(
         if (debug_frame_level)
             elv_dbg("IN STAT UDP fd=%d, video frame read=%"PRId64", url=%s", fd, c->video_frames_read, c->url);
         break;
+    case in_stat_first_keyframe_pts:
+        if (debug_frame_level)
+            elv_dbg("IN STAT UDP fd=%d, first keyframe PTS=%"PRId64", url=%s", fd, c->first_key_frame_pts, c->url);
+        rc = AVPipeStatInput(fd, stat_type, &c->first_key_frame_pts);
+        break;
     case in_stat_data_scte35:
         if (debug_frame_level)
             elv_dbg("IN STAT UDP SCTE35 fd=%d, stat_type=%d, url=%s", fd, stat_type, c->url);

--- a/avpipe.go
+++ b/avpipe.go
@@ -311,8 +311,9 @@ const (
 	AV_IN_STAT_DECODING_VIDEO_START_PTS = 16
 	AV_OUT_STAT_BYTES_WRITTEN           = 32
 	AV_OUT_STAT_FRAME_WRITTEN           = 64
-	AV_OUT_STAT_ENCODING_END_PTS        = 128
-	AV_IN_STAT_DATA_SCTE35              = 256
+	AV_IN_STAT_FIRST_KEYFRAME_PTS       = 128
+	AV_OUT_STAT_ENCODING_END_PTS        = 256
+	AV_IN_STAT_DATA_SCTE35              = 512
 )
 
 type StreamInfo struct {
@@ -729,6 +730,9 @@ func (h *ioHandler) InStat(avp_stat C.avp_stat_t, stat_args unsafe.Pointer) erro
 	case C.in_stat_video_frame_read:
 		statArgs := *(*uint64)(stat_args)
 		err = h.input.Stat(AV_IN_STAT_VIDEO_FRAME_READ, &statArgs)
+	case C.in_stat_first_keyframe_pts:
+		statArgs := *(*uint64)(stat_args)
+		err = h.input.Stat(AV_IN_STAT_FIRST_KEYFRAME_PTS, &statArgs)
 	case C.in_stat_data_scte35:
 		statArgs := C.GoString((*C.char)(stat_args))
 		err = h.input.Stat(AV_IN_STAT_DATA_SCTE35, statArgs)

--- a/avpipe_test.go
+++ b/avpipe_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 const baseOutPath = "test_out"
-const debugFrameLevel = false
+const debugFrameLevel = true
 const h264Codec = "libx264"
 const videoBigBuckBunnyPath = "media/bbb_1080p_30fps_60sec.mp4"
 const videoRockyPath = "media/rocky.mp4"
@@ -42,6 +42,7 @@ type XcTestResult struct {
 type testStatsInfo struct {
 	audioFramesRead         uint64
 	videoFramesRead         uint64
+	firstKeyFramePTS        uint64
 	encodingAudioFrameStats avpipe.EncodingFrameStats
 	encodingVideoFrameStats avpipe.EncodingFrameStats
 }
@@ -154,6 +155,12 @@ func (i *fileInput) Stat(statType avpipe.AVStatType, statArgs interface{}) error
 		if debugFrameLevel {
 			log.Debug("AVP TEST IN STAT", "video start PTS", *startPTS)
 		}
+	case avpipe.AV_IN_STAT_FIRST_KEYFRAME_PTS:
+		keyFramePTS := statArgs.(*uint64)
+		if debugFrameLevel {
+			log.Debug("AVP TEST IN STAT", "video first keyframe PTS", *keyFramePTS)
+		}
+		statsInfo.firstKeyFramePTS = *keyFramePTS
 	}
 	return nil
 }
@@ -1961,6 +1968,7 @@ func TestAVPipeStats(t *testing.T) {
 
 	assert.Equal(t, int64(2880), statsInfo.encodingVideoFrameStats.TotalFramesWritten)
 	assert.Equal(t, int64(5625), statsInfo.encodingAudioFrameStats.TotalFramesWritten)
+	assert.Equal(t, uint64(0), statsInfo.firstKeyFramePTS)
 	// FIXME
 	//assert.Equal(t, int64(720), statsInfo.encodingVideoFrameStats.FramesWritten)
 	//assert.Equal(t, int64(1406), statsInfo.encodingAudioFrameStats.FramesWritten)

--- a/libavpipe/include/avpipe_xc.h
+++ b/libavpipe/include/avpipe_xc.h
@@ -84,15 +84,16 @@ typedef enum avpipe_buftype_t {
 #define AUDIO_BYTES_WRITE_REPORT        (64*1024)
 
 typedef enum avp_stat_t {
-    in_stat_bytes_read = 1,
-    in_stat_audio_frame_read = 2,
-    in_stat_video_frame_read = 4,
-    in_stat_decoding_audio_start_pts = 8,
-    in_stat_decoding_video_start_pts = 16,
-    out_stat_bytes_written = 32,
-    out_stat_frame_written = 64,
-    out_stat_encoding_end_pts = 128,
-    in_stat_data_scte35 = 256
+    in_stat_bytes_read = 1,                 // # of bytes read from input stream
+    in_stat_audio_frame_read = 2,           // # of audio frames read from the input stream
+    in_stat_video_frame_read = 4,           // # of video frames read from the input stream
+    in_stat_decoding_audio_start_pts = 8,   // PTS of first audio packet went to the decoder
+    in_stat_decoding_video_start_pts = 16,  // PTS of first video packet went to the decoder
+    out_stat_bytes_written = 32,            // # of bytes written to the output stream
+    out_stat_frame_written = 64,            // # of frames written to the output stream
+    in_stat_first_keyframe_pts = 128,       // First keyframe in the input stream
+    out_stat_encoding_end_pts = 256,        // 
+    in_stat_data_scte35 = 512               // SCTE data arrived
 } avp_stat_t;
 
 struct coderctx_t;
@@ -163,6 +164,7 @@ typedef struct ioctx_t {
 
     /* Audio/video decoding start pts for stat reporting */
     int64_t decoding_start_pts;
+    int64_t first_key_frame_pts;
 
     /* Output handlers specific data */
     int64_t pts;                /* frame pts */

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -3121,7 +3121,7 @@ skip_for_sync(
     /* Check if the packet is video and it is a key frame */
     if (input_packet->stream_index == decoder_context->video_stream_index) {
         /* first_key_frame_pts points to first video key frame. */
-        if (decoder_context->first_key_frame_pts < 0 &&
+        if (decoder_context->first_key_frame_pts == AV_NOPTS_VALUE &&
             input_packet->flags == AV_PKT_FLAG_KEY) {
             avpipe_io_handler_t *in_handlers = decoder_context->in_handlers;
             decoder_context->first_key_frame_pts = input_packet->pts;
@@ -3135,7 +3135,7 @@ skip_for_sync(
             dump_packet(0, "SYNC ", input_packet, 1);
             return 0;
         }
-        if (decoder_context->first_key_frame_pts < 0) {
+        if (decoder_context->first_key_frame_pts == AV_NOPTS_VALUE) {
             dump_packet(0, "SYNC SKIP ", input_packet, 1);
             return 1;
         }
@@ -3146,7 +3146,7 @@ skip_for_sync(
      * Skip until the audio PTS has reached the first video key frame PTS
      * PENDING(SSS) - this is incorrect if audio PTS is muxed ahead of video
      */
-    if (decoder_context->first_key_frame_pts < 0 ||
+    if (decoder_context->first_key_frame_pts == AV_NOPTS_VALUE ||
         input_packet->pts < decoder_context->first_key_frame_pts) {
         elv_log("PTS SYNC SKIP audio_pts=%"PRId64" first_key_frame_pts=%"PRId64,
             input_packet->pts, decoder_context->first_key_frame_pts);
@@ -3525,7 +3525,7 @@ avpipe_xc(
 
     for (int j=0; j<MAX_STREAMS; j++)
         encoder_context->first_read_frame_pts[j] = -1;
-    decoder_context->first_key_frame_pts = -1;
+    decoder_context->first_key_frame_pts = AV_NOPTS_VALUE;
     decoder_context->mpegts_synced = 0;
     encoder_context->video_last_pts_sent_encode = -1;
     encoder_context->audio_last_pts_sent_encode = -1;
@@ -3633,7 +3633,7 @@ avpipe_xc(
             if (in_handlers->avpipe_stater)
                 in_handlers->avpipe_stater(inctx, in_stat_video_frame_read);
 
-            if (decoder_context->first_key_frame_pts < 0 &&
+            if (decoder_context->first_key_frame_pts == AV_NOPTS_VALUE &&
                     input_packet->flags == AV_PKT_FLAG_KEY) {
                 decoder_context->first_key_frame_pts = input_packet->pts;
                 decoder_context->inctx->first_key_frame_pts = decoder_context->first_key_frame_pts;


### PR DESCRIPTION
- Add new stat event `in_stat_first_keyframe_pts` to signal application when first keyframe available in the input.
- This is necessary to mark the beginning of the stream properly.
- Also modify generation of `first_decoding_audio_pts` and `first_decoding_video_pts` to reflect the first audio/video packet that goes to the decoder.