### PR TITLE
Use Go build tags to select `xcoder` as dependency

### DIFF
--- a/avpipe.go
+++ b/avpipe.go
@@ -29,8 +29,7 @@ package avpipe
 // #cgo CFLAGS: -I${SRCDIR}/libavpipe/include
 // #cgo CFLAGS: -I${SRCDIR}/utils/include
 // #cgo LDFLAGS: -L${SRCDIR}
-// #cgo darwin LDFLAGS: -Wl,-rpath,\@loader_path/../lib
-// #cgo linux LDFLAGS: -Wl,-rpath,\$ORIGIN/../lib
+// #cgo LDFLAGS: -Wl,-rpath,$ORIGIN/../lib
 
 // #include <string.h>
 // #include <stdlib.h>

--- a/avpipe.go
+++ b/avpipe.go
@@ -29,7 +29,6 @@ package avpipe
 // #cgo CFLAGS: -I${SRCDIR}/libavpipe/include
 // #cgo CFLAGS: -I${SRCDIR}/utils/include
 // #cgo LDFLAGS: -L${SRCDIR}
-// #cgo darwin LDFLAGS: -Wl,-rpath,@loader_path/../lib
 // #cgo linux LDFLAGS: -Wl,-rpath,$ORIGIN/../lib
 
 // #include <string.h>

--- a/avpipe.go
+++ b/avpipe.go
@@ -29,7 +29,8 @@ package avpipe
 // #cgo CFLAGS: -I${SRCDIR}/libavpipe/include
 // #cgo CFLAGS: -I${SRCDIR}/utils/include
 // #cgo LDFLAGS: -L${SRCDIR}
-// #cgo LDFLAGS: -Wl,-rpath,$ORIGIN/../lib
+// #cgo darwin LDFLAGS: -Wl,-rpath,@loader_path/../lib
+// #cgo linux LDFLAGS: -Wl,-rpath,$ORIGIN/../lib
 
 // #include <string.h>
 // #include <stdlib.h>

--- a/avpipe.go
+++ b/avpipe.go
@@ -29,8 +29,8 @@ package avpipe
 // #cgo CFLAGS: -I${SRCDIR}/libavpipe/include
 // #cgo CFLAGS: -I${SRCDIR}/utils/include
 // #cgo LDFLAGS: -L${SRCDIR}
-// #cgo darwin LDFLAGS: -Wl,-rpath,@loader_path/../lib
-// #cgo linux LDFLAGS: -Wl,-rpath,$ORIGIN/../lib
+// #cgo darwin LDFLAGS: -Wl,-rpath=\@loader_path/../lib
+// #cgo linux LDFLAGS: -Wl,-rpath=\$ORIGIN/../lib
 
 // #include <string.h>
 // #include <stdlib.h>

--- a/avpipe.go
+++ b/avpipe.go
@@ -29,8 +29,8 @@ package avpipe
 // #cgo CFLAGS: -I${SRCDIR}/libavpipe/include
 // #cgo CFLAGS: -I${SRCDIR}/utils/include
 // #cgo LDFLAGS: -L${SRCDIR}
-// #cgo darwin LDFLAGS: -Wl,-rpath=\@loader_path/../lib
-// #cgo linux LDFLAGS: -Wl,-rpath=\$ORIGIN/../lib
+// #cgo darwin LDFLAGS: -Wl,-rpath,\@loader_path/../lib
+// #cgo linux LDFLAGS: -Wl,-rpath,\$ORIGIN/../lib
 
 // #include <string.h>
 // #include <stdlib.h>

--- a/avpipe.go
+++ b/avpipe.go
@@ -29,6 +29,8 @@ package avpipe
 // #cgo CFLAGS: -I${SRCDIR}/libavpipe/include
 // #cgo CFLAGS: -I${SRCDIR}/utils/include
 // #cgo LDFLAGS: -L${SRCDIR}
+// #cgo darwin LDFLAGS: -Wl,-rpath,@loader_path/../lib
+// #cgo linux LDFLAGS: -Wl,-rpath,$ORIGIN/../lib
 
 // #include <string.h>
 // #include <stdlib.h>

--- a/avpipe.go
+++ b/avpipe.go
@@ -23,7 +23,8 @@ package avpipe
 // #cgo pkg-config: libswscale
 // #cgo pkg-config: libavutil
 // #cgo pkg-config: libpostproc
-// #cgo pkg-config: xcoder
+// #cgo netint pkg-config: xcoder
+// #cgo netint CFLAGS: -DXCODER_ENABLED=1
 // #cgo pkg-config: srt
 // #cgo CFLAGS: -I${SRCDIR}/libavpipe/include
 // #cgo CFLAGS: -I${SRCDIR}/utils/include

--- a/avpipe.go
+++ b/avpipe.go
@@ -24,7 +24,6 @@ package avpipe
 // #cgo pkg-config: libavutil
 // #cgo pkg-config: libpostproc
 // #cgo netint pkg-config: xcoder
-// #cgo netint CFLAGS: -DXCODER_ENABLED=1
 // #cgo pkg-config: srt
 // #cgo CFLAGS: -I${SRCDIR}/libavpipe/include
 // #cgo CFLAGS: -I${SRCDIR}/utils/include

--- a/avpipe_errors.go
+++ b/avpipe_errors.go
@@ -19,8 +19,8 @@ package avpipe
 // #cgo CFLAGS: -I${SRCDIR}/libavpipe/include
 // #cgo CFLAGS: -I${SRCDIR}/utils/include
 // #cgo LDFLAGS: -L${SRCDIR}
-// #cgo darwin LDFLAGS: -Wl,-rpath=\@loader_path/../lib
-// #cgo linux LDFLAGS: -Wl,-rpathr=\$ORIGIN/../lib
+// #cgo darwin LDFLAGS: -Wl,-rpath,\@loader_path/../lib
+// #cgo linux LDFLAGS: -Wl,-rpathr,\$ORIGIN/../lib
 // #include "avpipe.h"
 import "C"
 

--- a/avpipe_errors.go
+++ b/avpipe_errors.go
@@ -19,7 +19,6 @@ package avpipe
 // #cgo CFLAGS: -I${SRCDIR}/libavpipe/include
 // #cgo CFLAGS: -I${SRCDIR}/utils/include
 // #cgo LDFLAGS: -L${SRCDIR}
-// #cgo darwin LDFLAGS: -Wl,-rpath,@loader_path/../lib
 // #cgo linux LDFLAGS: -Wl,-rpath,$ORIGIN/../lib
 // #include "avpipe.h"
 import "C"

--- a/avpipe_errors.go
+++ b/avpipe_errors.go
@@ -19,8 +19,7 @@ package avpipe
 // #cgo CFLAGS: -I${SRCDIR}/libavpipe/include
 // #cgo CFLAGS: -I${SRCDIR}/utils/include
 // #cgo LDFLAGS: -L${SRCDIR}
-// #cgo darwin LDFLAGS: -Wl,-rpath,\@loader_path/../lib
-// #cgo linux LDFLAGS: -Wl,-rpathr,\$ORIGIN/../lib
+// #cgo LDFLAGS: -Wl,-rpath,$ORIGIN/../lib
 // #include "avpipe.h"
 import "C"
 

--- a/avpipe_errors.go
+++ b/avpipe_errors.go
@@ -19,7 +19,8 @@ package avpipe
 // #cgo CFLAGS: -I${SRCDIR}/libavpipe/include
 // #cgo CFLAGS: -I${SRCDIR}/utils/include
 // #cgo LDFLAGS: -L${SRCDIR}
-// #cgo LDFLAGS: -Wl,-rpath,$ORIGIN/../lib
+// #cgo darwin LDFLAGS: -Wl,-rpath,@loader_path/../lib
+// #cgo linux LDFLAGS: -Wl,-rpath,$ORIGIN/../lib
 // #include "avpipe.h"
 import "C"
 

--- a/avpipe_errors.go
+++ b/avpipe_errors.go
@@ -19,8 +19,8 @@ package avpipe
 // #cgo CFLAGS: -I${SRCDIR}/libavpipe/include
 // #cgo CFLAGS: -I${SRCDIR}/utils/include
 // #cgo LDFLAGS: -L${SRCDIR}
-// #cgo darwin LDFLAGS: -Wl,-rpath,@loader_path/../lib
-// #cgo linux LDFLAGS: -Wl,-rpath,$ORIGIN/../lib
+// #cgo darwin LDFLAGS: -Wl,-rpath=\@loader_path/../lib
+// #cgo linux LDFLAGS: -Wl,-rpathr=\$ORIGIN/../lib
 // #include "avpipe.h"
 import "C"
 

--- a/avpipe_errors.go
+++ b/avpipe_errors.go
@@ -19,6 +19,8 @@ package avpipe
 // #cgo CFLAGS: -I${SRCDIR}/libavpipe/include
 // #cgo CFLAGS: -I${SRCDIR}/utils/include
 // #cgo LDFLAGS: -L${SRCDIR}
+// #cgo darwin LDFLAGS: -Wl,-rpath,@loader_path/../lib
+// #cgo linux LDFLAGS: -Wl,-rpath,$ORIGIN/../lib
 // #include "avpipe.h"
 import "C"
 

--- a/avpipe_errors.go
+++ b/avpipe_errors.go
@@ -13,7 +13,7 @@ package avpipe
 // #cgo pkg-config: libswscale
 // #cgo pkg-config: libavutil
 // #cgo pkg-config: libpostproc
-// #cgo pkg-config: xcoder
+// #cgo netint pkg-config: xcoder
 // #cgo pkg-config: srt
 // #cgo CFLAGS: -I${SRCDIR}/include
 // #cgo CFLAGS: -I${SRCDIR}/libavpipe/include


### PR DESCRIPTION
## Description

This simple change will instruct CGO to not look for `libxcoder` unless a build tag of `netting` is used.  Build tags in `content-fabric` builds will propagate, so the following will work on a `content-fabric` build:

```shell
go install -tags WAPC,avpipe,netint ./...
```

On platforms like the Mac/darwin, where `libxcoder` is not available, a user only needs to build `content-fabric` this way, omitting the tag:

```shell
go install -tags WAPC,avpipe ./...
```

Also, while adding build tags to `avpipe`, I also enabled `RPATH` setting on Linux.  The method for Mac/darwin is a bit more involved and may be moot with an FFmpeg change, but this is known to work on Linux as is.  This will prevent a user from not being able to use `qfab` with `avpipe` without moving libraries a lot.  The `RPATH` chosen is `$ORIGIN/../lib` which appears to be a sane default.

## Unknowns

`libavpipe/src/avpipe_xc.c` has several instances of `xcoder` and `netint`.  I am not sure if these will get called, and if so, then a problem could arise.  Earlier versions of my tests had the following in the `.go` files:

```go
#cgo netint CFLAGS: -DXCODER_ENABLED=1
```

I put this in place if it was necessary to use `ifndef` or some other C mechanism to not build this code, but I did not want to touch the `.c` files in this round.

### Evidence:

```shell
$ grep -r netint *
avpipe.go:// #cgo netint pkg-config: xcoder
avpipe_errors.go:// #cgo netint pkg-config: xcoder
libavpipe/src/avpipe_xc.c:set_netint_h264_params(
libavpipe/src/avpipe_xc.c:    elv_dbg("set_netint_h264_params encoding params=%s, url=%s", enc_params, params->url);
libavpipe/src/avpipe_xc.c:set_netint_h265_params(
libavpipe/src/avpipe_xc.c:     * netint only supports bitdepth of 8 and 10 for h265.
libavpipe/src/avpipe_xc.c:    elv_dbg("set_netint_h265_params encoding params=%s, url=%s", enc_params, params->url);
libavpipe/src/avpipe_xc.c:        /* Set netint H264 codensity params */
libavpipe/src/avpipe_xc.c:        set_netint_h264_params(encoder_context, decoder_context, params);
libavpipe/src/avpipe_xc.c:        /* Set netint H265 codensity params */
libavpipe/src/avpipe_xc.c:        set_netint_h265_params(encoder_context, decoder_context, params);
```