### PR TITLE
Frame duration

### DIFF
--- a/avpipe.go
+++ b/avpipe.go
@@ -240,6 +240,7 @@ type XcParams struct {
 	ExtractImageIntervalTs int64              `json:"extract_image_interval_ts,omitempty"`
 	ExtractImagesTs        []int64            `json:"extract_images_ts,omitempty"`
 	VideoTimeBase          int                `json:"video_time_base"`
+	VideoFrameDurationTs   int                `json:"video_frame_duration_ts"`
 }
 
 // NewXcParams initializes a XcParams struct with unset/default values
@@ -1239,6 +1240,7 @@ func getCParams(params *XcParams) (*C.xcparams_t, error) {
 		extract_image_interval_ts: C.int64_t(params.ExtractImageIntervalTs),
 		extract_images_sz:         C.int(extractImagesSize),
 		video_time_base:           C.int(params.VideoTimeBase),
+		video_frame_duration_ts:   C.int(params.VideoFrameDurationTs),
 
 		// All boolean params are handled below
 	}

--- a/elvxc/cmd/transcode.go
+++ b/elvxc/cmd/transcode.go
@@ -298,6 +298,7 @@ func InitTranscode(cmdRoot *cobra.Command) error {
 	cmdTranscode.PersistentFlags().Int32P("enc-height", "", -1, "default -1 means use source height.")
 	cmdTranscode.PersistentFlags().Int32P("enc-width", "", -1, "default -1 means use source width.")
 	cmdTranscode.PersistentFlags().Int32P("video-time-base", "", 0, "Video encoder timebase, must be > 0 (the actual timebase would be 1/video-time-base).")
+	cmdTranscode.PersistentFlags().Int32P("video-frame-duration-ts", "", 0, "Frame duration of the output video in time base.")
 	cmdTranscode.PersistentFlags().Int64P("duration-ts", "", -1, "default -1 means entire stream.")
 	cmdTranscode.PersistentFlags().Int64P("audio-seg-duration-ts", "", 0, "(mandatory if format is not 'segment' and transcoding audio) audio segment duration time base (positive integer).")
 	cmdTranscode.PersistentFlags().Int64P("video-seg-duration-ts", "", 0, "(mandatory if format is not 'segment' and transcoding video) video segment duration time base (positive integer).")
@@ -559,9 +560,14 @@ func doTranscode(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("enc-width is not valid")
 	}
 
-	video_time_base, err := cmd.Flags().GetInt32("video-time-base")
+	videoTimeBase, err := cmd.Flags().GetInt32("video-time-base")
 	if err != nil {
 		return fmt.Errorf("video-time-base is not valid")
+	}
+
+	videoFrameDurationTs, err := cmd.Flags().GetInt32("video-frame-duration-ts")
+	if err != nil {
+		return fmt.Errorf("video-frame-duration-ts is not valid")
 	}
 
 	durationTs, err := cmd.Flags().GetInt64("duration-ts")
@@ -685,7 +691,8 @@ func doTranscode(cmd *cobra.Command, args []string) error {
 		ExtractImageIntervalTs: extractImageIntervalTs,
 		ChannelLayout:          channelLayout,
 		DebugFrameLevel:        debugFrameLevel,
-		VideoTimeBase:          int(video_time_base),
+		VideoTimeBase:          int(videoTimeBase),
+		VideoFrameDurationTs:   int(videoFrameDurationTs),
 	}
 
 	err = getAudioIndexes(params, audioIndex)

--- a/exc/elv_xc.c
+++ b/exc/elv_xc.c
@@ -1105,6 +1105,7 @@ usage(
         "\t-xc-type :               (optional) Transcoding type. Default is \"all\", can be \"video\", \"audio\", \"audio-merge\", \"audio-join\", \"audio-pan\", \"all\", \"extract-images\"\n"
         "\t                                    or \"extract-all-images\". \"all\" means transcoding video and audio together.\n"
         "\t-video-bitrate :         (optional) Mutually exclusive with crf. Default: -1 (unused)\n"
+        "\t-video-frame-duration-ts :  (optional) Frame duration of the output video in time base.\n"
         "\t-video-seg-duration-ts : (mandatory If format is not \"segment\" and transcoding video) video segment duration time base (positive integer).\n"
         "\t-video-time-base :       (optional) Video encoder timebase, must be > 0 (the actual timebase would be 1/video-time-base).\n"
         "\t-wm-text :               (optional) Watermark text that will be presented in every video frame if it exist. It has higher priority than overlay watermark.\n"
@@ -1210,6 +1211,7 @@ main(
         .seg_duration = NULL,
         .debug_frame_level = 0,
         .video_time_base = 0,
+        .video_frame_duration_ts = 0,
     };
 
     i = 1;
@@ -1514,6 +1516,10 @@ main(
         case 'v':
             if (!strcmp(argv[i], "-video-bitrate")) {
                 if (sscanf(argv[i+1], "%d", &p.video_bitrate) != 1) {
+                    usage(argv[0], argv[i], EXIT_FAILURE);
+                }
+            } else if (!strcmp(argv[i], "-video-frame-duration-ts")) {
+                if (sscanf(argv[i+1], "%d", &p.video_frame_duration_ts) != 1) {
                     usage(argv[0], argv[i], EXIT_FAILURE);
                 }
             } else if (!strcmp(argv[i], "-video-seg-duration-ts")) {

--- a/libavpipe/include/avpipe_xc.h
+++ b/libavpipe/include/avpipe_xc.h
@@ -435,6 +435,7 @@ typedef struct xcparams_t {
     int         extract_images_sz;          // Size of the array extract_images_ts
 
     int         video_time_base;            // New video encoder time_base (1/video_time_base)
+    int         video_frame_duration_ts;    // Frame duration of the output video in time base
 
     int         debug_frame_level;
     int         connection_timeout;         // Connection timeout in sec for RTMP or MPEGTS protocols

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -2124,6 +2124,15 @@ encode_frame(
             encoder_context->video_frames_written++;
         }
 
+        /* If params->video_frame_duration_ts > 0, then set
+           output packet duration and pts/dts regardless of previous calculations */
+        if (stream_index == decoder_context->video_stream_index &&
+            params->video_frame_duration_ts > 0) {
+            output_packet->pts = output_packet->dts = params->start_pts + (encoder_context->video_frames_written - 1) * params->video_frame_duration_ts;
+            output_packet->duration = params->video_frame_duration_ts;
+            elv_dbg("XXX output_packet->pts=%"PRId64", frame_number=%d", output_packet->pts, encoder_context->video_frames_written);
+        }
+
         dump_packet(selected_decoded_audio(decoder_context, stream_index) >= 0,
             "OUT ", output_packet, debug_frame_level);
 
@@ -4426,7 +4435,8 @@ avpipe_init(
         "filter_descriptor=\"%s\" "
         "extract_image_interval_ts=%"PRId64" "
         "extract_images_sz=%d "
-        "video_time_base=%d/%d",
+        "video_time_base=%d/%d "
+        "video_frame_duration_ts=%d",
         params->stream_id, p->url,
         avpipe_version(),
         params->bypass_transcoding, params->skip_decoding,
@@ -4449,7 +4459,7 @@ avpipe_init(
         params->master_display ? params->master_display : "",
         params->filter_descriptor,
         params->extract_image_interval_ts, params->extract_images_sz,
-        1, params->video_time_base);
+        1, params->video_time_base, params->video_frame_duration_ts);
     elv_log("AVPIPE XCPARAMS %s", buf);
 
     if ((rc = check_params(params)) != eav_success) {

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -2070,7 +2070,8 @@ encode_frame(
         output_packet->pts += params->start_pts;
         output_packet->dts += params->start_pts;
 
-        if (encoder_context->video_encoder_prev_pts > 0 &&
+        if (decoder_context->is_mpegts &&
+            encoder_context->video_encoder_prev_pts > 0 &&
             stream_index == decoder_context->video_stream_index &&
             encoder_context->calculated_frame_duration > 0 &&
             output_packet->pts != AV_NOPTS_VALUE &&

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -2131,7 +2131,7 @@ encode_frame(
             params->video_frame_duration_ts > 0) {
             output_packet->pts = output_packet->dts = params->start_pts + (encoder_context->video_frames_written - 1) * params->video_frame_duration_ts;
             output_packet->duration = params->video_frame_duration_ts;
-            elv_dbg("XXX output_packet->pts=%"PRId64", frame_number=%d", output_packet->pts, encoder_context->video_frames_written);
+            elv_dbg("output_packet->pts=%"PRId64", frame_number=%d", output_packet->pts, encoder_context->video_frames_written);
         }
 
         dump_packet(selected_decoded_audio(decoder_context, stream_index) >= 0,

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -2131,7 +2131,9 @@ encode_frame(
             params->video_frame_duration_ts > 0) {
             output_packet->pts = output_packet->dts = params->start_pts + (encoder_context->video_frames_written - 1) * params->video_frame_duration_ts;
             output_packet->duration = params->video_frame_duration_ts;
-            elv_dbg("output_packet->pts=%"PRId64", frame_number=%d", output_packet->pts, encoder_context->video_frames_written);
+            if (debug_frame_level)
+                elv_dbg("output_packet->pts=%"PRId64", frame_number=%d",
+                    output_packet->pts, encoder_context->video_frames_written);
         }
 
         dump_packet(selected_decoded_audio(decoder_context, stream_index) >= 0,


### PR DESCRIPTION
issue: https://github.com/eluv-io/avpipe/issues/34

- Add a new parameter `video_frame_duration_ts` to avpipe to set the frame duration of output video stream to a specific number based on ts.
- This feature will help to cut the fmp4 segments properly and exactly at specific timebase. For example, if input stream/video is an RTMP stream with various frame duration, this feature will help to produce proper mezzanines with exactly equal duration.