### PR TITLE
Change video timebase setting to allow controlling bitrate

### DIFF
--- a/libavpipe/include/avpipe_utils.h
+++ b/libavpipe/include/avpipe_utils.h
@@ -59,11 +59,6 @@ dump_trackers(
     AVFormatContext *decoder_format_context);
 
 void
-dump_rate_info(
-    AVFormatContext *format_context,
-    AVCodecContext *codec_context);
-
-void
 connect_ffmpeg_log();
 
 const char *

--- a/libavpipe/include/avpipe_utils.h
+++ b/libavpipe/include/avpipe_utils.h
@@ -59,6 +59,11 @@ dump_trackers(
     AVFormatContext *decoder_format_context);
 
 void
+dump_rate_info(
+    AVFormatContext *format_context,
+    AVCodecContext *codec_context);
+
+void
 connect_ffmpeg_log();
 
 const char *

--- a/libavpipe/src/avpipe_utils.c
+++ b/libavpipe/src/avpipe_utils.c
@@ -116,7 +116,7 @@ dump_encoder(
         return;
 
     elv_dbg("ENCODER url=%s, xc_type=%d, nb_streams=%d\n",
-        url, params->xc_type,
+        url, params ? params->xc_type : 0,
         format_context->nb_streams);
 
     for (int i = 0; i < format_context->nb_streams; i++) {
@@ -147,12 +147,17 @@ dump_codec_context(
 
     elv_dbg("CODEC CONTEXT codec type=%d id=%d "
         "time_base=%d/%d framerate=%d/%d tpf=%d delay=%d "
+        "bit_rate=%d-%d rc=%d-%d-%d q=%d-%d-%d vbv=%f/%f/%d "
         "width=%d height=%d aspect_ratio=%d/%d coded_width=%d coded_height=%d gop=%d "
         "keyint_min=%d refs=%d "
         "frame_size=%d frame_number=%d"
         "\n",
         cc->codec_type, cc->codec_id,
         cc->time_base.num, cc->time_base.den, cc->framerate.num, cc->framerate.den, cc->ticks_per_frame, cc->delay,
+        (int)cc->bit_rate, cc->bit_rate_tolerance,
+        cc->rc_buffer_size, cc->rc_max_rate, cc->rc_min_rate,
+        cc->qmin, cc->qmax, cc->max_qdiff,
+        cc->rc_max_available_vbv_use, cc->rc_min_vbv_overflow_use, cc->rc_initial_buffer_occupancy,
         cc->width, cc->height, cc->sample_aspect_ratio.num, cc->sample_aspect_ratio.den,
         cc->coded_width, cc->coded_height, cc->gop_size,
         cc->keyint_min, cc->refs,
@@ -253,32 +258,6 @@ dump_trackers(
         (int)(ti - t0) / 1000, (int)(ti - t0) % 1000, inctx->read_pos,
         out_tracker->seg_index, out_tracker->last_outctx ? out_tracker->last_outctx->written_bytes:0);
 }
-
-void
-dump_rate_info(
-    AVFormatContext *format_context,
-    AVCodecContext *codec_context)
-{
-    AVFormatContext *fctx = format_context;
-    int video_stream_index = -1;
-    for (int i = 0; i < fctx->nb_streams; i++) {
-        AVStream *s = fctx->streams[i];
-        if (fctx->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_VIDEO) {
-            video_stream_index = i;
-            elv_log("RATE INFO tb=%d/%d afr=%d/%d rfr=%d/%d cc-tb=%d/%d cc-tpf=%d rate=%d/%d rc b/x/n=%d/%d/%d q=%d/%d/%d/ vbv=%d/%d/%d cc-fr=%d/%d",
-                s->time_base.num, s->time_base.den,
-                s->avg_frame_rate.num, s->avg_frame_rate.den,
-                s->r_frame_rate.num, s->r_frame_rate.den,
-                codec_context->time_base.num, codec_context->time_base.den, codec_context->ticks_per_frame,
-                codec_context->bit_rate, codec_context->bit_rate_tolerance,
-                codec_context->rc_buffer_size, codec_context->rc_max_rate, codec_context->rc_min_rate,
-                codec_context->qmin, codec_context->qmax, codec_context->max_qdiff,
-                codec_context->rc_max_available_vbv_use, codec_context->rc_min_vbv_overflow_use, codec_context->rc_initial_buffer_occupancy,
-                codec_context->framerate.num, codec_context->framerate.den);
-        }
-    }
-}
-
 
 static void
 ffmpeg_log_handler(void* ptr, int level, const char* fmt, va_list vl) {

--- a/libavpipe/src/avpipe_utils.c
+++ b/libavpipe/src/avpipe_utils.c
@@ -254,6 +254,32 @@ dump_trackers(
         out_tracker->seg_index, out_tracker->last_outctx ? out_tracker->last_outctx->written_bytes:0);
 }
 
+void
+dump_rate_info(
+    AVFormatContext *format_context,
+    AVCodecContext *codec_context)
+{
+    AVFormatContext *fctx = format_context;
+    int video_stream_index = -1;
+    for (int i = 0; i < fctx->nb_streams; i++) {
+        AVStream *s = fctx->streams[i];
+        if (fctx->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_VIDEO) {
+            video_stream_index = i;
+            elv_log("RATE INFO tb=%d/%d afr=%d/%d rfr=%d/%d cc-tb=%d/%d cc-tpf=%d rate=%d/%d rc b/x/n=%d/%d/%d q=%d/%d/%d/ vbv=%d/%d/%d cc-fr=%d/%d",
+                s->time_base.num, s->time_base.den,
+                s->avg_frame_rate.num, s->avg_frame_rate.den,
+                s->r_frame_rate.num, s->r_frame_rate.den,
+                codec_context->time_base.num, codec_context->time_base.den, codec_context->ticks_per_frame,
+                codec_context->bit_rate, codec_context->bit_rate_tolerance,
+                codec_context->rc_buffer_size, codec_context->rc_max_rate, codec_context->rc_min_rate,
+                codec_context->qmin, codec_context->qmax, codec_context->max_qdiff,
+                codec_context->rc_max_available_vbv_use, codec_context->rc_min_vbv_overflow_use, codec_context->rc_initial_buffer_occupancy,
+                codec_context->framerate.num, codec_context->framerate.den);
+        }
+    }
+}
+
+
 static void
 ffmpeg_log_handler(void* ptr, int level, const char* fmt, va_list vl) {
     elv_log_level_t elv_level;

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -3467,10 +3467,6 @@ avpipe_xc(
         goto xc_done;
     }
 
-    // Muxer may adjust settings in 'write_header'
-    dump_encoder(encoder_context->format_context->url, encoder_context->format_context, NULL);
-    dump_codec_context(encoder_context->codec_context[encoder_context->video_stream_index]);
-
     int video_stream_index = decoder_context->video_stream_index;
     if (params->xc_type & xc_video) {
         if (encoder_context->format_context->streams[0]->avg_frame_rate.num != 0 &&

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -3468,8 +3468,8 @@ avpipe_xc(
     }
 
     // Muxer may adjust settings in 'write_header'
-    //dump_encoder(encoder_context->format_context->url, encoder_context->format_context, NULL);
-    //dump_codec_context(encoder_context->codec_context[encoder_context->video_stream_index]);
+    dump_encoder(encoder_context->format_context->url, encoder_context->format_context, NULL);
+    dump_codec_context(encoder_context->codec_context[encoder_context->video_stream_index]);
 
     int video_stream_index = decoder_context->video_stream_index;
     if (params->xc_type & xc_video) {

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -1224,8 +1224,8 @@ prepare_video_encoder(
         return eav_codec_param;
     }
 
-    encoder_context->stream[encoder_context->video_stream_index]->time_base = encoder_codec_context->time_base;
-    encoder_context->stream[encoder_context->video_stream_index]->avg_frame_rate = decoder_context->stream[decoder_context->video_stream_index]->avg_frame_rate;
+    encoder_context->stream[index]->time_base = encoder_codec_context->time_base;
+    encoder_context->stream[index]->avg_frame_rate = decoder_context->stream[decoder_context->video_stream_index]->avg_frame_rate;
 
     return 0;
 }


### PR DESCRIPTION
The problem to solve is that when transcoding from RTMP (FLV) to H264, the resulting bitrate varies widely with the timebase setting.  This is a quirk of the transcoder that only manifests for the FLV-MP4/H264 use case.  I reproduced this problem exactly as described with ffmpeg sample `transcoding.c`

For example - RTMP timebase is 1000:
- if we set video timebase to a small number (like 30 or 60) the resulting bitrate is larger than desired - for example 14 Mbps when rate is set to 5Mbps
- if we set video timebase to a large number like 15360 or 16000 the resulting bitrate is 700 Kbps when set to 5 Mbps (and also when set to 10 Mbps)
- if we set video timebase to any number around 1000 (like 960!) the resulting bitrate is correct - 5Mbps when set to 5Mbps

The main functional change is allowing timebase values close to the original RTMP (FLV) timebase.

Important observation:
- the avformat MUXER changes the output timebase so it is greater than 10,000
- if we set the timebase to 960, the encoder uses 960, then the muxer makes it 15360 so the output is 15360

This is reflected in the codec context (which is the encoder settings) and format stream (muxer settings):

```
2024-02-13 19:23:01.661 DBG PI ENCODER[0] stream_index=0 url=fsegment-video-%05d.mp4 profile=100 level=40 id=0 codec_type=0 start_time=0 duration=0 nb_frames=0 time_base=1/15360 codec_time_base=0/1 frame_rate=0/0 avg_frame_rate=30/1
2024-02-13 19:23:01.661 DBG PI CODEC CONTEXT codec type=0 id=27 time_base=1/960 framerate=0/1 tpf=1 delay=0 bit_rate=10000000-4000000 rc=10000000-10000000-0 q=-1--1--1 vbv=0.000000/3.000000/-1 width=1920 height=1080 aspect_ratio=0/1 coded_width=1920 coded_height=1080 gop=60 keyint_min=-1 refs=-1 frame_size=0 frame_number=0
```

A few other code changes:

1.  Make sure to set all codec context fields before `avcodec_open2()`
2. Set stream parameters (muxer parameters) after `avcodec_open2()` 

Bonus fix:

1. `set_encoder_options` uses the timebase denominator to calculate segment durations ts and needs the output timebase.  This doesn't affect the current live streams though because we always set video and audio seg duration ts directly

