### PR TITLE
Don't shift pts for audio join/merge/pan

### DIFF
--- a/elvxc/cmd/transcode.go
+++ b/elvxc/cmd/transcode.go
@@ -324,6 +324,7 @@ func InitTranscode(cmdRoot *cobra.Command) error {
 	cmdTranscode.PersistentFlags().Int32("bitdepth", 8, "Refers to number of colors each pixel can have, can be 8, 10, 12.")
 	cmdTranscode.PersistentFlags().Int64P("extract-image-interval-ts", "", -1, "extract frames at this interval.")
 	cmdTranscode.PersistentFlags().StringP("extract-images-ts", "", "", "the frames to extract (PTS, comma separated).")
+	cmdTranscode.PersistentFlags().BoolP("seekable", "b", true, "seekable stream.")
 
 	return nil
 }
@@ -338,6 +339,11 @@ func doTranscode(cmd *cobra.Command, args []string) error {
 	bypass, err := cmd.Flags().GetBool("bypass")
 	if err != nil {
 		return fmt.Errorf("Invalid bypass flag")
+	}
+
+	seekable, err := cmd.Flags().GetBool("seekable")
+	if err != nil {
+		return fmt.Errorf("Invalid seekable flag")
 	}
 
 	debugFrameLevel, err := cmd.Flags().GetBool("debug-frame-level")
@@ -686,6 +692,7 @@ func doTranscode(cmd *cobra.Command, args []string) error {
 		DebugFrameLevel:        debugFrameLevel,
 		VideoTimeBase:          int(videoTimeBase),
 		VideoFrameDurationTs:   int(videoFrameDurationTs),
+		Seekable:               seekable,
 	}
 
 	err = getAudioIndexes(params, audioIndex)

--- a/elvxc/cmd/transcode.go
+++ b/elvxc/cmd/transcode.go
@@ -324,7 +324,7 @@ func InitTranscode(cmdRoot *cobra.Command) error {
 	cmdTranscode.PersistentFlags().Int32("bitdepth", 8, "Refers to number of colors each pixel can have, can be 8, 10, 12.")
 	cmdTranscode.PersistentFlags().Int64P("extract-image-interval-ts", "", -1, "extract frames at this interval.")
 	cmdTranscode.PersistentFlags().StringP("extract-images-ts", "", "", "the frames to extract (PTS, comma separated).")
-	cmdTranscode.PersistentFlags().BoolP("seekable", "b", true, "seekable stream.")
+	cmdTranscode.PersistentFlags().BoolP("seekable", "", true, "seekable stream.")
 
 	return nil
 }

--- a/libavpipe/include/avpipe_utils.h
+++ b/libavpipe/include/avpipe_utils.h
@@ -9,6 +9,7 @@
 void
 dump_frame(
     int is_audio,
+    int stream_index,
     char *msg,
     int num,
     AVFrame *frame,

--- a/libavpipe/include/avpipe_version.h
+++ b/libavpipe/include/avpipe_version.h
@@ -10,5 +10,5 @@
 
 /* Only increase these versions for release purposes */
 #define AVPIPE_MAJOR_VERSION    1
-#define AVPIPE_MINOR_VERSION    13
+#define AVPIPE_MINOR_VERSION    14
 

--- a/libavpipe/src/avpipe_utils.c
+++ b/libavpipe/src/avpipe_utils.c
@@ -29,6 +29,7 @@ const char *stream_type_str(
 void
 dump_frame(
     int is_audio,
+    int stream_index,
     char *msg,
     int num,
     AVFrame *frame,
@@ -37,11 +38,11 @@ dump_frame(
     if (!debug_frame_level || !frame)
         return;
 
-    elv_dbg("%s FRAME %s [%d] pts=%"PRId64" pkt_dts=%"PRId64" pkt_duration=%"PRId64" be_time_stamp=%"PRId64" key=%d pict_type=%d "
+    elv_dbg("%s FRAME %s, stream_index=%d, [%d] pts=%"PRId64" pkt_dts=%"PRId64" pkt_duration=%"PRId64" be_time_stamp=%"PRId64" key=%d pict_type=%d "
         "pkt_size=%d nb_samples=%d "
         "width=%d height=%d linesize=%d "
         "format=%d coded_pic_num=%d flags=%x channels=%d"
-        "\n", is_audio ? "AUDIO" : "VIDEO", msg, num,
+        "\n", is_audio ? "AUDIO" : "VIDEO", msg, stream_index, num,
         frame->pts, frame->pkt_dts, frame->pkt_duration, frame->best_effort_timestamp,
         frame->key_frame, frame->pict_type,
         frame->pkt_size, frame->nb_samples,

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -2031,7 +2031,7 @@ encode_frame(
 #ifndef USE_RESAMPLE_AAC
             else if (selected_decoded_audio(decoder_context, stream_index) >= 0) {
                 if (encoder_context->first_encoding_audio_pts[stream_index] == AV_NOPTS_VALUE) {
-                    /* Remember the first video PTS to use as an offset later */
+                    /* Remember the first audio PTS to use as an offset later */
                     encoder_context->first_encoding_audio_pts[stream_index] = frame->pts;
                     elv_log("PTS stream_index=%d first_encoding_audio_pts=%"PRId64" dec=%"PRId64" read=%"PRId64" stream=%d:%s",
                         stream_index,
@@ -3024,8 +3024,12 @@ flush_decoder(
     AVFilterContext *buffersink_ctx = decoder_context->video_buffersink_ctx;
     AVFilterContext *buffersrc_ctx = decoder_context->video_buffersrc_ctx;
     AVCodecContext *codec_context = decoder_context->codec_context[stream_index];
-    int response = avcodec_send_packet(codec_context, NULL);	/* Passing NULL means flush the decoder buffers */
+    int response = 0;
 
+    if (codec_context == NULL)
+        return eav_success;
+
+    response = avcodec_send_packet(codec_context, NULL);    /* Passing NULL means flush the decoder buffers */
     frame = av_frame_alloc();
     filt_frame = av_frame_alloc();
 

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -2905,6 +2905,7 @@ transcode_video_func(
     if (!xctx->err)
         xctx->err = err;
 
+    elv_channel_close(xctx->vc, 0);
     elv_dbg("transcode_video_func err=%d, stop=%d, url=%s", err, xctx->stop, params->url);
 
     return NULL;
@@ -3000,7 +3001,8 @@ transcode_audio_func(
     if (!xctx->err)
         xctx->err = err;
     
-    elv_dbg("transcode_audio_func err=%d, stop=%d", err, xctx->stop);
+    elv_channel_close(xctx->ac, 0);
+    elv_dbg("transcode_audio_func err=%d, xctx->err=%d, stop=%d", err, xctx->err, xctx->stop);
 
     return NULL;
 }

--- a/utils/src/elv_channel.c
+++ b/utils/src/elv_channel.c
@@ -57,8 +57,13 @@ elv_channel_send(
         return -1;
 
     pthread_mutex_lock(&channel->_mutex);
-    while (channel->_count >= channel->_capacity) {
+    while (channel->_count >= channel->_capacity && channel->_closed == 0) {
         pthread_cond_wait(&channel->_cond_recv, &channel->_mutex);
+    }
+
+    if (channel->_closed) {
+        pthread_mutex_unlock(&channel->_mutex);
+        return 0;
     }
 
     channel->_count++;


### PR DESCRIPTION
- Don't shift pts for audio join/merge/pan (regression).
- Add stream index when dumping frame.
- If a channel has closed don't send a message.