### PR TITLE
leaking pb->buffer

### DIFF
--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -4210,8 +4210,13 @@ avpipe_probe(
 
 avpipe_probe_end:
     if (decoder_ctx.format_context) {
-        if (decoder_ctx.format_context->pb->buffer)
-            av_free(decoder_ctx.format_context->pb->buffer);
+        if (decoder_ctx.format_context->pb->buffer){
+            AVIOContext *avioctx = (AVIOContext *) decoder_ctx.format_context->pb;
+            if (avioctx) {
+                av_freep(&avioctx->buffer);
+                av_freep(&avioctx);
+            }
+	}
         avformat_close_input(&decoder_ctx.format_context);
     }
 

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -4210,6 +4210,8 @@ avpipe_probe(
 
 avpipe_probe_end:
     if (decoder_ctx.format_context) {
+        if (decoder_ctx.format_context->pb->buffer)
+            av_free(decoder_ctx.format_context->pb->buffer);
         avformat_close_input(&decoder_ctx.format_context);
     }
 


### PR DESCRIPTION
After building avpipe and ffmpeg with debug symbols and running under tcMalloc I found the leak to be originating from the format context on probe.  After trying lots of stuff this made the tcMalloc leak go away.  On the order of 2.5MB for BBB in 4K per probe.  Hoping Reza can see if this is dangerous although I stepped through using the debugger too so the code does not blow up on TestMezMaker.  After further consideration we may want to set the buffer to NULL after free?