### PR TITLE
Rotate

### DIFF
--- a/avpipe.go
+++ b/avpipe.go
@@ -240,6 +240,7 @@ type XcParams struct {
 	ExtractImagesTs        []int64            `json:"extract_images_ts,omitempty"`
 	VideoTimeBase          int                `json:"video_time_base"`
 	VideoFrameDurationTs   int                `json:"video_frame_duration_ts"`
+	Rotate                 int                `json:"rotate"`
 }
 
 // NewXcParams initializes a XcParams struct with unset/default values
@@ -1245,6 +1246,7 @@ func getCParams(params *XcParams) (*C.xcparams_t, error) {
 		extract_images_sz:         C.int(extractImagesSize),
 		video_time_base:           C.int(params.VideoTimeBase),
 		video_frame_duration_ts:   C.int(params.VideoFrameDurationTs),
+		rotate:                    C.int(params.Rotate),
 
 		// All boolean params are handled below
 	}

--- a/avpipe_test.go
+++ b/avpipe_test.go
@@ -409,6 +409,43 @@ func TestVideoSeg(t *testing.T) {
 
 }
 
+func TestVideoSegWithRotate(t *testing.T) {
+	url := videoBigBuckBunnyPath
+	if fileMissing(url, fn()) {
+		return
+	}
+
+	outputDir := path.Join(baseOutPath, fn())
+	params := &avpipe.XcParams{
+		BypassTranscoding:      false,
+		Format:                 "fmp4-segment",
+		AudioBitrate:           128000,
+		AudioSegDurationTs:     -1,
+		BitDepth:               8,
+		CrfStr:                 "23",
+		DurationTs:             -1,
+		Ecodec:                 "libx264",
+		EncHeight:              -1,
+		EncWidth:               -1,
+		ExtractImageIntervalTs: -1,
+		GPUIndex:               -1,
+		SampleRate:             -1,
+		StartFragmentIndex:     1,
+		StartSegmentStr:        "1",
+		StreamId:               -1,
+		SyncAudioToStreamId:    -1,
+		VideoBitrate:           -1,
+		VideoSegDurationTs:     900000,
+		ForceKeyInt:            60,
+		XcType:                 avpipe.XcVideo,
+		Url:                    url,
+		DebugFrameLevel:        debugFrameLevel,
+		Rotate:                 90,
+	}
+	xcTest(t, outputDir, params, nil, true)
+
+}
+
 func TestVideoSegDoubleTS(t *testing.T) {
 	url := videoBigBuckBunnyPath
 	outputDir := path.Join(baseOutPath, fn())

--- a/elvxc/cmd/transcode.go
+++ b/elvxc/cmd/transcode.go
@@ -325,6 +325,7 @@ func InitTranscode(cmdRoot *cobra.Command) error {
 	cmdTranscode.PersistentFlags().Int64P("extract-image-interval-ts", "", -1, "extract frames at this interval.")
 	cmdTranscode.PersistentFlags().StringP("extract-images-ts", "", "", "the frames to extract (PTS, comma separated).")
 	cmdTranscode.PersistentFlags().BoolP("seekable", "", true, "seekable stream.")
+	cmdTranscode.PersistentFlags().Int32("rotate", 0, "Rotate the output video frame (valid values 0, 90, 180, 270).")
 
 	return nil
 }
@@ -598,6 +599,11 @@ func doTranscode(cmd *cobra.Command, args []string) error {
 	crfStr := strconv.Itoa(int(crf))
 	startSegmentStr := strconv.Itoa(int(startSegment))
 
+	rotate, err := cmd.Flags().GetInt32("rotate")
+	if err != nil {
+		return fmt.Errorf("Invalid rotate value")
+	}
+
 	cryptScheme := avpipe.CryptNone
 	val := cmd.Flag("crypt-scheme").Value.String()
 	if len(val) > 0 {
@@ -693,6 +699,7 @@ func doTranscode(cmd *cobra.Command, args []string) error {
 		VideoTimeBase:          int(videoTimeBase),
 		VideoFrameDurationTs:   int(videoFrameDurationTs),
 		Seekable:               seekable,
+		Rotate:                 int(rotate),
 	}
 
 	err = getAudioIndexes(params, audioIndex)

--- a/exc/elv_xc.c
+++ b/exc/elv_xc.c
@@ -1095,6 +1095,7 @@ usage(
         "\t-r :                     (optional) number of repeats. Default is 1 repeat, must be bigger than 1\n"
         "\t-rc-buffer-size :        (optional) Determines the interval used to limit bit rate\n"
         "\t-rc-max-rate :           (optional) Maximum encoding bit rate, used in conjuction with rc-buffer-size\n"
+        "\t-rotate :                (optional) Rotate the input video. Default is 0 with no rotation, other values 90, 180, 270.\n"
         "\t-sample-rate :           (optional) Default: -1. For aac output sample rate is set to input sample rate and this parameter is ignored.\n"
         "\t-seekable :              (optional) Seekable stream. Default is 0, must be 0 or 1\n"
         "\t-seg-duration :          (mandatory if format is \"segment\") segment duration secs (positive integer). It is used for making mp4 segments.\n"
@@ -1199,6 +1200,7 @@ main(
         .start_time_ts = 0,                 /* same units as input stream PTS */
         .start_fragment_index = 0,          /* Default is zero */
         .sync_audio_to_stream_id = -1,      /* Default -1 (no sync to a video stream) */
+        .rotate = 0,                        /* Default 0 (means no transpose/rotation) */
         .xc_type = xc_none,
         .video_bitrate = -1,                /* not used if using CRF */
         .watermark_text = NULL,
@@ -1438,6 +1440,10 @@ main(
                 if (sscanf(argv[i+1], "%d", &p.rc_max_rate) != 1) {
                     usage(argv[0], argv[i], EXIT_FAILURE);
                 }
+            } else if (!strcmp(argv[i], "-rotate")) {
+                if (sscanf(argv[i+1], "%d", &p.rotate) != 1) {
+                    usage(argv[0], argv[i], EXIT_FAILURE);
+                }
             } else if (strlen(argv[i]) > 2) {
                 usage(argv[0], argv[i], EXIT_FAILURE);
             } else {
@@ -1507,7 +1513,7 @@ main(
                     usage(argv[0], argv[i], EXIT_FAILURE);
                 }
                 if ( n_threads < 1 ) usage(argv[0], argv[i], EXIT_FAILURE);
-            }
+            } 
             break;
         case 'v':
             if (!strcmp(argv[i], "-video-bitrate")) {

--- a/exc/elv_xc.c
+++ b/exc/elv_xc.c
@@ -1515,7 +1515,7 @@ main(
                     usage(argv[0], argv[i], EXIT_FAILURE);
                 }
                 if ( n_threads < 1 ) usage(argv[0], argv[i], EXIT_FAILURE);
-            } 
+            }
             break;
         case 'v':
             if (!strcmp(argv[i], "-video-bitrate")) {

--- a/libavpipe/include/avpipe_xc.h
+++ b/libavpipe/include/avpipe_xc.h
@@ -439,6 +439,7 @@ typedef struct xcparams_t {
 
     int         debug_frame_level;
     int         connection_timeout;         // Connection timeout in sec for RTMP or MPEGTS protocols
+    int         rotate;                     // For video transpose or rotation
 } xcparams_t;
 
 #define MAX_CODEC_NAME  256

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -1142,7 +1142,7 @@ prepare_video_encoder(
     encoder_codec_context->height = params->enc_height != -1 ? params->enc_height : decoder_context->codec_context[index]->height;
     encoder_codec_context->width = params->enc_width != -1 ? params->enc_width : decoder_context->codec_context[index]->width;
 
-    /* If the rotation param is set to 1 (90 decgree) or 3 (270 degree) the change width and hight */
+    /* If the rotation param is set to 90 or 270 degree then change width and hight */
     if (params->rotate == 90 || params->rotate == 270) {
         encoder_codec_context->height = params->enc_width != -1 ? params->enc_width : decoder_context->codec_context[index]->width;
         encoder_codec_context->width = params->enc_height != -1 ? params->enc_height : decoder_context->codec_context[index]->height;


### PR DESCRIPTION
This is a new feature to rotate the video frames.

- Add new parameter rotate to avpipe to rotate the video frames clockwise. Valid values for this param are 0, 90, 180, and 270.