### PR TITLE
SideData changes to more closely match ffprobe JSON and media_struct.MediaStruct

### DIFF
--- a/avpipe.go
+++ b/avpipe.go
@@ -1466,6 +1466,8 @@ func Probe(params *XcParams) (*ProbeInfo, error) {
 				RotationCw: float64(probeArray[i].side_data.display_matrix.rotation_cw),
 			}
 			probeInfo.StreamInfo[i].SideDataList[0] = displayMatrix
+		} else {
+			probeInfo.StreamInfo[i].SideDataList = make([]interface{}, 0)
 		}
 
 		// Convert AVDictionary data to Tags of type map[string]string using the built in av_dict_get() iterator

--- a/avpipe.go
+++ b/avpipe.go
@@ -334,12 +334,11 @@ const (
 )
 
 type SideDataDisplayMatrix struct {
-	Rotation   float64
-	RotationCw float64
+	Type       string  `json:"side_data_type"`
+	Rotation   float64 `json:"rotation"`
+	RotationCw float64 `json:"rotation_cw"`
 }
-type SideData struct {
-	DisplayMatrix SideDataDisplayMatrix
-}
+
 type StreamInfo struct {
 	StreamIndex        int               `json:"stream_index"`
 	StreamId           int32             `json:"stream_id"`
@@ -366,7 +365,7 @@ type StreamInfo struct {
 	FieldOrder         string            `json:"field_order,omitempty"`
 	Profile            int               `json:"profile,omitempty"`
 	Level              int               `json:"level,omitempty"`
-	SideData           SideData          `json:"side_data,omitempty"`
+	SideDataList       []interface{}     `json:"side_data_list,omitempty"`
 	Tags               map[string]string `json:"tags,omitempty"`
 }
 
@@ -1457,8 +1456,17 @@ func Probe(params *XcParams) (*ProbeInfo, error) {
 		probeInfo.StreamInfo[i].FieldOrder = AVFieldOrderNames[AVFieldOrder(probeArray[i].field_order)]
 		probeInfo.StreamInfo[i].Profile = int(probeArray[i].profile)
 		probeInfo.StreamInfo[i].Level = int(probeArray[i].level)
-		probeInfo.StreamInfo[i].SideData.DisplayMatrix.Rotation = float64(probeArray[i].side_data.display_matrix.rotation)
-		probeInfo.StreamInfo[i].SideData.DisplayMatrix.RotationCw = float64(probeArray[i].side_data.display_matrix.rotation_cw)
+
+		rot := float64(probeArray[i].side_data.display_matrix.rotation)
+		if rot != 0.0 {
+			probeInfo.StreamInfo[i].SideDataList = make([]interface{}, 1)
+			displayMatrix := SideDataDisplayMatrix{
+				Type:       "Display Matrix",
+				Rotation:   rot,
+				RotationCw: float64(probeArray[i].side_data.display_matrix.rotation_cw),
+			}
+			probeInfo.StreamInfo[i].SideDataList[0] = displayMatrix
+		}
 
 		// Convert AVDictionary data to Tags of type map[string]string using the built in av_dict_get() iterator
 		dict := (*C.AVDictionary)(unsafe.Pointer((probeArray[i].tags)))
@@ -1541,7 +1549,7 @@ func StreamInfoAsArray(s []StreamInfo) []StreamInfo {
 		}
 	}
 	a := make([]StreamInfo, maxIdx+1)
-	for i, _ := range a {
+	for i := range a {
 		a[i].StreamIndex = i
 		a[i].CodecType = AVMediaTypeNames[AVMediaType(AVMEDIA_TYPE_UNKNOWN)]
 	}


### PR DESCRIPTION
Change `StreamInfo.SideData` to `StreamInfo.SideDataList`, change type to generic `[]interface{}`

Add `Type` field to `SideDataDisplayMatrix` with JSON fieldname "side_data_type" to match ffprobe output format. (value should always set to string "Display Matrix") Only return a `SideDataDisplayMatrix` element within `StreamInfo.SideDataList` if there is a non-zero rotation found. 

Minor edit to get rid of compiler warning "Redundant '_' expression"