### PR TITLE
Split `XcInit` into `Create`, `Init`

### DIFF
--- a/avpipe.c
+++ b/avpipe.c
@@ -788,7 +788,7 @@ xc_table_put(
     }
     pthread_mutex_unlock(&tx_mutex);
 
-    elv_dbg("xc_table_put handle=%d, url=%s", txe->handle, xctx->inctx->url);
+    elv_dbg("xc_table_put handle=%d", txe->handle);
     if (txe != NULL)
         return txe->handle;
     return -1;
@@ -1003,7 +1003,6 @@ xc_create_job(int32_t *handle)
     uint32_t h;
     
 
-    *handle = 1;
     init_tx_module();
     connect_ffmpeg_log();
     if ((xctx = calloc(1, sizeof(xctx_t))) == NULL) {

--- a/avpipe.c
+++ b/avpipe.c
@@ -399,6 +399,7 @@ udp_in_read_packet(
     uint8_t *buf,
     int buf_size)
 {
+    // TODO(Nate): Try to get this in line with the ffmpeg handlers a bit more, see libavformat/url.h line 74
     ioctx_t *c = (ioctx_t *)opaque;
     xcparams_t *xcparams = c->params;
     int debug_frame_level = (xcparams != NULL) ? xcparams->debug_frame_level : 0;
@@ -431,6 +432,7 @@ udp_in_read_packet(
          * In this situation, cancelling a transcoding would become impossible since xc_init() has not completed yet.
          * In order to avoid this situation, there will be a UDP_PIPE_TIMEOUT sec timeout when reading from channel.
          */
+        // TODO(Nate): Consolidate this logic appropriately
 read_channel_again:
         if (c->closed)
             return -1;

--- a/avpipe.go
+++ b/avpipe.go
@@ -1512,7 +1512,7 @@ func XcInit(params *XcParams, handle int32) error {
 	}
 
 	// This is literally just used to trigger C rebuild...
-	log.Info("rebuild version 16")
+	log.Info("rebuild version 23")
 
 	rc := C.xc_init((*C.xcparams_t)(unsafe.Pointer(cparams)), C.int32_t(handle))
 	if rc != C.eav_success {

--- a/avpipe.go
+++ b/avpipe.go
@@ -1512,9 +1512,9 @@ func XcInit(params *XcParams, handle int32) error {
 	}
 
 	// This is literally just used to trigger C rebuild...
-	log.Info("rebuild version 14")
+	log.Info("rebuild version 16")
 
-	rc = C.xc_init((*C.xcparams_t)(unsafe.Pointer(cparams)), C.int32_t(handle))
+	rc := C.xc_init((*C.xcparams_t)(unsafe.Pointer(cparams)), C.int32_t(handle))
 	if rc != C.eav_success {
 		return avpipeError(rc)
 	}

--- a/avpipe.go
+++ b/avpipe.go
@@ -1501,8 +1501,16 @@ func XcInit(params *XcParams) (int32, error) {
 		log.Error("Initializing transcoder failed", err, "url", params.Url)
 	}
 
+	// This is literally just used to trigger C rebuild...
+	log.Info("rebuild version 7")
+
 	var handle C.int32_t
-	rc := C.xc_init((*C.xcparams_t)(unsafe.Pointer(cparams)), (*C.int32_t)(unsafe.Pointer(&handle)))
+	rc := C.xc_create_job((*C.int32_t)(unsafe.Pointer(&handle)))
+	if rc != C.eav_success {
+		return -1, avpipeError(rc)
+	}
+
+	rc = C.xc_init((*C.xcparams_t)(unsafe.Pointer(cparams)), handle)
 	if rc != C.eav_success {
 		return -1, avpipeError(rc)
 	}

--- a/avpipe.h
+++ b/avpipe.h
@@ -4,7 +4,8 @@
  * Defines all the interfaces available to the Go layer.
  * There are two sets of API's available for transcoding/probing in this layer:
  * - APIs with handle: these APIs allow the client application to cancel a transcoding if it is necessary.
- *   - xc_init(): to initialize a transcoding and obtain a handle.
+ *   - xc_create_job(): to obtain a handle.
+ *   - xc_init(): to initialize a transcoding with obtained handle.
  *   - xc_run(): to start a transcoding with obtained handle.
  *   - xc_cancel(): to cancel/stop a transcoding with specified handle.
  * - APIs with no handle: these APIs are very simple to use and just need transcoding/probing params.
@@ -21,8 +22,26 @@
 #include "avpipe_xc.h"
 
 /**
- * @brief   Initializes a transcoding context and returns its handle.
+ * @brief   Creates and partially allocates a transcoding job and returns its handle.
+ *          This handle must be used exactly once in a call to xc_init.
+ *
+ * @param   handle          Pointer to the handle of transcoding context.
+ *
+ * @return  If it is successful it returns eav_success, otherwise corresponding error.
+ */
+int32_t
+xc_create_job(int32_t *handle);
+
+/**
+ * @brief   Initializes a transcoding context based on an existing handle and transcoding parameters.
  *          The transcoding context is internal to the C/Go layer.
+ *          
+ *          Context initialization also includes probing an input stream in some circumstances. If
+ *          there is no input data, this call will stall and require a call to xc_cancel to
+ *          terminate it.
+ *          
+ *          If unsuccessful, this function frees all resources, including those associated with
+ *          handle and the parameters passed in.
  *
  * @param   params          Transcoding parameters.
  * @param   handle          Pointer to the handle of transcoding context.
@@ -32,7 +51,7 @@
 int32_t
 xc_init(
     xcparams_t *params,
-    int32_t *handle);
+    int32_t handle);
 
 /**
  * @brief   Starts the transcoding specified by handle.

--- a/avpipe_test.go
+++ b/avpipe_test.go
@@ -734,8 +734,11 @@ func TestV2SingleABRTranscodeCancelling(t *testing.T) {
 	params.EncHeight = 360 // slow down a bit to allow for the cancel
 	params.EncWidth = 640
 
-	handle, err := avpipe.XcInit(params)
+	handle, err := avpipe.XcCreateJob()
 	failNowOnError(t, err)
+	err = avpipe.XcInit(params, handle)
+	failNowOnError(t, err)
+
 	assert.Greater(t, handle, int32(0))
 	go func(handle int32) {
 		// Wait for 2 sec the transcoding starts, then cancel it.
@@ -750,9 +753,12 @@ func TestV2SingleABRTranscodeCancelling(t *testing.T) {
 	params.Ecodec2 = "aac"
 	params.NumAudio = 1
 	params.AudioIndex[0] = 1
-	handleA, err := avpipe.XcInit(params)
+	handleA, err := avpipe.XcCreateJob()
 	assert.NoError(t, err)
 	assert.Greater(t, handleA, int32(0))
+	err = avpipe.XcInit(params, handle)
+	assert.NoError(t, err)
+
 	err = avpipe.XcCancel(handleA)
 	assert.NoError(t, err)
 	err = avpipe.XcRun(handleA)
@@ -1922,8 +1928,12 @@ func TestMezMakerWithOpenInputError(t *testing.T) {
 	params.EncHeight = 360 // slow down a bit to allow for the cancel
 	params.EncWidth = 640
 
-	handle, err := avpipe.XcInit(params)
-	assert.Less(t, handle, int32(0))
+	handle, err := avpipe.XcCreateJob()
+	assert.NoError(t, err)
+	assert.Greater(t, handle, int32(0))
+	err = avpipe.XcInit(params, handle)
+	assert.Error(t, err)
+
 	err = avpipe.XcRun(handle)
 	assert.Error(t, err)
 
@@ -1966,8 +1976,11 @@ func TestMezMakerWithReadInputError(t *testing.T) {
 	params.EncHeight = 360 // slow down a bit to allow for the cancel
 	params.EncWidth = 640
 
-	handle, err := avpipe.XcInit(params)
-	assert.Less(t, handle, int32(0))
+	handle, err := avpipe.XcCreateJob()
+	assert.NoError(t, err)
+	assert.Greater(t, handle, int32(0))
+	err = avpipe.XcInit(params, handle)
+	assert.Error(t, err)
 	err = avpipe.XcRun(handle)
 	assert.Error(t, err)
 
@@ -2734,9 +2747,11 @@ func xcTest2(t *testing.T, outputDir string, params *avpipe.XcParams, xcTestResu
 // - to run the tx session
 //   - XcRun()
 func boilerXc2(t *testing.T, params *avpipe.XcParams) {
-	handle, err := avpipe.XcInit(params)
+	handle, err := avpipe.XcCreateJob()
 	failNowOnError(t, err)
 	assert.Greater(t, handle, int32(0))
+	err = avpipe.XcInit(params, handle)
+	failNowOnError(t, err)
 	err = avpipe.XcRun(handle)
 	failNowOnError(t, err)
 }

--- a/exc/elv_xc.c
+++ b/exc/elv_xc.c
@@ -740,9 +740,10 @@ tx_thread_func(
         avpipe_io_handler_t *out_handlers = (avpipe_io_handler_t *)calloc(1, sizeof(avpipe_io_handler_t));
         *in_handlers = *params->in_handlers;
         *out_handlers = *params->out_handlers;
-        if ((rc = avpipe_init(&xctx, in_handlers, out_handlers, xcparams)) != eav_success) {
+        xctx = (xctx_t *)calloc(1, sizeof(xctx_t));
+        if ((rc = avpipe_init(xctx, in_handlers, out_handlers, xcparams)) != eav_success) {
             elv_err("THREAD %d, iteration %d, failed to initialize avpipe rc=%d", params->thread_number, i+1, rc);
-            /* avpipe_fini() will release all the resources if the open is successful */
+            avpipe_fini(&xctx);
             if (rc == eav_open_input) {
                 params->err = rc;
                 break;

--- a/libavpipe/include/avpipe_xc.h
+++ b/libavpipe/include/avpipe_xc.h
@@ -520,12 +520,7 @@ typedef struct xctx_t {
     AVPacket            pkt_array[MAX_STREAMS];
     int                 is_pkt_valid[MAX_STREAMS];
 
-    // Mutex used to synchronized access to specifically
-    // - xctx_t.initialized
-    // - xctx_t.decoder_ctx.cancelled
-    // - xctx_t.encoder_ctx.cancelled
-    pthread_mutex_t     cancel_init_mu;
-    int                 initialized;
+    volatile int                 initialized;
 
     elv_channel_t       *vc;        // Video frame channel
     elv_channel_t       *ac;        // Audio frame channel

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -415,7 +415,6 @@ prepare_decoder(
         return eav_mem_alloc;
     }
 
-    decoder_context->audio_duration = 7077;
     const AVIOInterruptCB int_cb = { decode_interrupt_cb, (void*)decoder_context};
     decoder_context->format_context->interrupt_callback = int_cb;
 

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -382,8 +382,8 @@ selected_decoded_audio(
 
 int decode_interrupt_cb(void *ctx) {
     coderctx_t *decoder_ctx = (coderctx_t *)ctx;
-    elv_log("interrupt callback checked. Cancelled is equal to %d", decoder_ctx->audio_duration);
-    return 1;
+    elv_log("interrupt callback checked. Cancelled is equal to %d", decoder_ctx->cancelled);
+    return decoder_ctx->cancelled;
 }
 
 static int
@@ -4645,6 +4645,15 @@ avpipe_fini(
 {
     coderctx_t *decoder_context;
     coderctx_t *encoder_context;
+
+    if (__STDC_VERSION__ >= 201710L)
+        printf("We are using C17!\n");
+    else if (__STDC_VERSION__ >= 201112L)
+        printf("We are using C11!\n");
+    else if (__STDC_VERSION__ >= 199901L)
+        printf("We are using C99!\n");
+    else
+        printf("We are using C89/C90!\n");
 
     if (!xctx || !(*xctx))
         return 0;

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -437,7 +437,9 @@ prepare_decoder(
     /* Allocate AVFormatContext in format_context and find input file format */
     rc = avformat_open_input(&decoder_context->format_context, inctx->url, NULL, &opts);
     if (rc != 0) {
-        elv_err("Could not open input file, err=%d, url=%s", rc, url);
+        elv_err("Could not open input file, err=%d, url=%s, err_str=%s", rc, url, av_err2str(rc));
+        if (rc == AVERROR_EXIT)
+            return eav_cancelled;
         return eav_open_input;
     }
 

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -4251,7 +4251,7 @@ avpipe_probe_end:
     if (decoder_ctx.format_context) {
         if (decoder_ctx.format_context->pb->buffer){
             AVIOContext *avioctx = (AVIOContext *) decoder_ctx.format_context->pb;
-            if (avioctx) {
+            if (avioctx && strncmp(params->url, "rtmp://", 7) && strncmp(params->url, "srt://", 6)) {
                 av_freep(&avioctx->buffer);
                 av_freep(&avioctx);
             }

--- a/live/rtmp_recorder_test.go
+++ b/live/rtmp_recorder_test.go
@@ -2,10 +2,11 @@ package live
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"path"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/eluv-io/avpipe"
 )
@@ -175,7 +176,12 @@ func TestRtmpToMp4WithCancelling1(t *testing.T) {
 	var err error
 	go func() {
 		tlog.Info("Transcoding RTMP stream start", "params", fmt.Sprintf("%+v", *xcParams))
-		handle, err = avpipe.XcInit(xcParams)
+		handle, err = avpipe.XcCreateJob()
+		if err != nil {
+			t.Error("XcCreateJob failed", "err", err)
+		}
+
+		err = avpipe.XcInit(xcParams, handle)
 		if err != nil {
 			t.Error("XcInit initializing RTMP stream failed", "err", err)
 		}
@@ -246,7 +252,12 @@ func TestRtmpToMp4WithCancelling2(t *testing.T) {
 	var err error
 	go func() {
 		tlog.Info("Transcoding RTMP stream start", "params", fmt.Sprintf("%+v", *xcParams))
-		handle, err = avpipe.XcInit(xcParams)
+		handle, err = avpipe.XcCreateJob()
+		if err != nil {
+			t.Error("XcCreateJob failed", "err", err)
+		}
+
+		err = avpipe.XcInit(xcParams, handle)
 		if err != nil {
 			t.Error("XcInit initializing RTMP stream failed", "err", err)
 		}
@@ -326,7 +337,12 @@ func TestRtmpToMp4WithCancelling3(t *testing.T) {
 	go func() {
 
 		tlog.Info("Transcoding RTMP stream start", "params", fmt.Sprintf("%+v", *xcParams))
-		handle, err = avpipe.XcInit(xcParams)
+		handle, err = avpipe.XcCreateJob()
+		if err != nil {
+			t.Error("XcCreateJob failed", "err", err)
+		}
+
+		err = avpipe.XcInit(xcParams, handle)
 		if err != nil {
 			t.Error("XcInit initializing RTMP stream failed", "err", err)
 		}
@@ -407,10 +423,14 @@ func TestRtmpToMp4WithCancelling4(t *testing.T) {
 	var err error
 	go func() {
 		tlog.Info("Transcoding RTMP stream start", "params", fmt.Sprintf("%+v", *xcParams))
-
-		handle, err = avpipe.XcInit(xcParams)
+		handle, err = avpipe.XcCreateJob()
 		if err != nil {
-			t.Error("XcInitializing RTMP stream failed", "err", err)
+			t.Error("XcCreateJob failed", "err", err)
+		}
+
+		err = avpipe.XcInit(xcParams, handle)
+		if err != nil {
+			t.Error("XcInit initializing RTMP stream failed", "err", err)
 		}
 
 		done <- true

--- a/live/srt_recorder_test.go
+++ b/live/srt_recorder_test.go
@@ -2,10 +2,11 @@ package live
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"path"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/eluv-io/avpipe"
 )
@@ -165,7 +166,12 @@ func TestSrtToMp4WithCancelling1(t *testing.T) {
 	var err error
 	go func() {
 		tlog.Info("Transcoding SRT stream start", "params", fmt.Sprintf("%+v", *xcParams))
-		handle, err = avpipe.XcInit(xcParams)
+		handle, err = avpipe.XcCreateJob()
+		if err != nil {
+			t.Error("XcCreateJob failed", "err", err)
+		}
+
+		err = avpipe.XcInit(xcParams, handle)
 		if err != nil {
 			t.Error("XcInit initializing SRT stream failed", "err", err)
 		}
@@ -233,10 +239,16 @@ func TestSrtToMp4WithCancelling2(t *testing.T) {
 	var err error
 	go func() {
 		tlog.Info("Transcoding SRT stream start", "params", fmt.Sprintf("%+v", *xcParams))
-		handle, err = avpipe.XcInit(xcParams)
+		handle, err = avpipe.XcCreateJob()
+		if err != nil {
+			t.Error("XcCreateJob failed", "err", err)
+		}
+
+		err = avpipe.XcInit(xcParams, handle)
 		if err != nil {
 			t.Error("XcInit initializing SRT stream failed", "err", err)
 		}
+
 		err = avpipe.XcRun(handle)
 		if err != nil && err != avpipe.EAV_CANCELLED {
 			t.Error("Transcoding SRT stream failed", "err", err)
@@ -308,7 +320,12 @@ func TestSrtToMp4WithCancelling3(t *testing.T) {
 	go func() {
 
 		tlog.Info("Transcoding SRT stream start", "params", fmt.Sprintf("%+v", *xcParams))
-		handle, err = avpipe.XcInit(xcParams)
+		handle, err = avpipe.XcCreateJob()
+		if err != nil {
+			t.Error("XcCreateJob failed", "err", err)
+		}
+
+		err = avpipe.XcInit(xcParams, handle)
 		if err != nil {
 			t.Error("XcInit initializing SRT stream failed", "err", err)
 		}
@@ -389,9 +406,14 @@ func TestSrtToMp4WithCancelling4(t *testing.T) {
 	go func() {
 		tlog.Info("Transcoding SRT stream start", "params", fmt.Sprintf("%+v", *xcParams))
 
-		handle, err = avpipe.XcInit(xcParams)
+		handle, err = avpipe.XcCreateJob()
 		if err != nil {
-			t.Error("XcInitializing SRT stream failed", "err", err)
+			t.Error("XcCreateJob failed", "err", err)
+		}
+
+		err = avpipe.XcInit(xcParams, handle)
+		if err != nil {
+			t.Error("XcInit initializing SRT stream failed", "err", err)
 		}
 
 		done <- true

--- a/live/ts_recorder_test.go
+++ b/live/ts_recorder_test.go
@@ -2,10 +2,11 @@ package live
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"path"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/eluv-io/avpipe"
 )
@@ -244,9 +245,14 @@ func TestUdpToMp4WithCancelling1(t *testing.T) {
 	avpipe.InitIOHandler(&inputOpener{dir: outputDir}, &outputOpener{dir: outputDir})
 
 	tlog.Info("Transcoding UDP stream start", "params", fmt.Sprintf("%+v", *xcParams))
-	handle, err := avpipe.XcInit(xcParams)
+	handle, err := avpipe.XcCreateJob()
 	if err != nil {
-		t.Error("XcInitializing UDP stream failed", "err", err)
+		t.Error("XcCreateJob failed", "err", err)
+	}
+
+	err = avpipe.XcInit(xcParams, handle)
+	if err != nil {
+		t.Error("XcInit initializing UDP stream failed", "err", err)
 	}
 	err = avpipe.XcCancel(handle)
 	assert.NoError(t, err)
@@ -303,9 +309,14 @@ func TestUdpToMp4WithCancelling2(t *testing.T) {
 	avpipe.InitIOHandler(&inputOpener{dir: outputDir}, &outputOpener{dir: outputDir})
 
 	tlog.Info("Transcoding UDP stream start", "params", fmt.Sprintf("%+v", *xcParams))
-	handle, err := avpipe.XcInit(xcParams)
+	handle, err := avpipe.XcCreateJob()
 	if err != nil {
-		t.Error("XcInitializing UDP stream failed", "err", err)
+		t.Error("XcCreateJob failed", "err", err)
+	}
+
+	err = avpipe.XcInit(xcParams, handle)
+	if err != nil {
+		t.Error("XcInit initializing UDP stream failed", "err", err)
 	}
 	go func() {
 		err := avpipe.XcRun(handle)
@@ -375,9 +386,14 @@ func TestUdpToMp4WithCancelling3(t *testing.T) {
 	avpipe.InitIOHandler(&inputOpener{dir: outputDir}, &outputOpener{dir: outputDir})
 
 	tlog.Info("Transcoding UDP stream start", "params", fmt.Sprintf("%+v", *xcParams))
-	handle, err := avpipe.XcInit(xcParams)
+	handle, err := avpipe.XcCreateJob()
 	if err != nil {
-		t.Error("XcInitializing UDP stream failed", "err", err)
+		t.Error("XcCreateJob failed", "err", err)
+	}
+
+	err = avpipe.XcInit(xcParams, handle)
+	if err != nil {
+		t.Error("XcInit initializing UDP stream failed", "err", err)
 	}
 	go func() {
 		err := avpipe.XcRun(handle)
@@ -446,9 +462,14 @@ func TestUdpToMp4WithCancelling4(t *testing.T) {
 	avpipe.InitIOHandler(&inputOpener{dir: outputDir}, &outputOpener{dir: outputDir})
 	tlog.Info("Transcoding UDP stream start", "params", fmt.Sprintf("%+v", *xcParams))
 
-	handle, err := avpipe.XcInit(xcParams)
+	handle, err := avpipe.XcCreateJob()
 	if err != nil {
-		t.Error("XcInitializing UDP stream failed", "err", err)
+		t.Error("XcCreateJob failed", "err", err)
+	}
+
+	err = avpipe.XcInit(xcParams, handle)
+	if err != nil {
+		t.Error("XcInit initializing UDP stream failed", "err", err)
 	}
 
 	go func() {

--- a/rules.make
+++ b/rules.make
@@ -11,8 +11,8 @@ OSNAME := $(shell uname -s)
 LDFLAGS := \
 		-lavpipe \
 		-lutils \
-		$(shell pkg-config --libs libavfilter libavcodec libavformat libavdevice libswresample libavresample libswscale libavutil libpostproc xcoder srt)
-CFLAGS := $(shell pkg-config --cflags libavfilter libavcodec libavformat libavdevice libswresample libavresample libswscale libavutil libpostproc xcoder srt)
+		$(shell pkg-config --libs libavfilter libavcodec libavformat libavdevice libswresample libavresample libswscale libavutil libpostproc srt)
+CFLAGS := $(shell pkg-config --cflags libavfilter libavcodec libavformat libavdevice libswresample libavresample libswscale libavutil libpostproc srt)
 
 ifeq ($(OSNAME), Darwin)
 	LDFLAGS := ${LDFLAGS} \


### PR DESCRIPTION
This generally replaces the existing avpipe flow of `XcInit` doing both initializing a job and probing the input stream.

This results in the job being cancellable even when doing the initial probe, which is important if a livestream is set up and cancelled before any input data comes in. This goes along with a `content-fabric` PR.

Work that is possibly going to part of this PR is:
- unifying our transcode cancellation procedures to flow through ffmpeg's `interrupt_callback`.