### PR TITLE
Fix double-free on probe of non-udp stream

### DIFF
--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -298,7 +298,7 @@ prepare_input(
     AVIOContext *avioctx;
     int bufin_sz = AVIO_IN_BUF_SIZE;
 
-    /* For RTMP protocol don't create input callbacks */
+    /* For RTMP or SRT protocol don't create input callbacks */
     decoder_context->is_rtmp = 0;
     decoder_context->is_srt = 0;
     if (inctx->url && !strncmp(inctx->url, "rtmp://", 7)) {
@@ -4238,13 +4238,13 @@ avpipe_probe(
 
 avpipe_probe_end:
     if (decoder_ctx.format_context) {
-        if (decoder_ctx.format_context->pb->buffer){
-            AVIOContext *avioctx = (AVIOContext *) decoder_ctx.format_context->pb;
+        if (decoder_ctx.format_context->flags & AVFMT_FLAG_CUSTOM_IO) {
+            AVIOContext *avioctx = decoder_ctx.format_context->pb;
             if (avioctx) {
                 av_freep(&avioctx->buffer);
                 av_freep(&avioctx);
             }
-	}
+        }
         avformat_close_input(&decoder_ctx.format_context);
     }
 
@@ -4657,8 +4657,8 @@ avpipe_fini(
 
     /* note: the internal buffer could have changed, and be != avio_ctx_buffer */
     if (decoder_context && decoder_context->format_context) {
-        if ((*xctx)->inctx && strncmp((*xctx)->inctx->url, "rtmp://", 7) && strncmp((*xctx)->inctx->url, "srt://", 6)) {
-            AVIOContext *avioctx = (AVIOContext *) decoder_context->format_context->pb;
+        if (decoder_context->format_context->flags & AVFMT_FLAG_CUSTOM_IO) {
+            AVIOContext *avioctx = decoder_context->format_context->pb;
             if (avioctx) {
                 av_freep(&avioctx->buffer);
                 av_freep(&avioctx);


### PR DESCRIPTION
According to ffmpeg documentation, the user should only free this themself if the io context was set by the user manually. Resolves crash caused by #41. 

This caused a crash on probing an SRT or RTMP stream. I also slightly cleaned up the manual checks on protocols to use FFMPEG's own flag for custom IO.

Quote from FFMPEG documentation about `pb`:

```C
    /**
     * I/O context.
     *
     * - demuxing: either set by the user before avformat_open_input() (then
     *             the user must close it manually) or set by avformat_open_input().
     * - muxing: set by the user before avformat_write_header(). The caller must
     *           take care of closing / freeing the IO context.
     *
     * Do NOT set this field if AVFMT_NOFILE flag is set in
     * iformat/oformat.flags. In such a case, the (de)muxer will handle
     * I/O in some other way and this field will be NULL.
     */
    AVIOContext *pb;
```