### PR TITLE
Make avpipe_init() nonblocking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ O/
 temp/
 test_out/
 
+media/
 media/AGAIG-clip-2mono.mp4
 media/ActOfLove-30sec.mov
 media/BOB923HL_clip_timebase_1001_60000.MXF

--- a/avpipe.c
+++ b/avpipe.c
@@ -148,6 +148,9 @@ in_closer(
     close(fd);
 #endif
 
+    if (!inctx || !inctx->opaque)
+        return 0;
+
     int64_t h = *((int64_t *)(inctx->opaque));
     xcparams_t *xcparams = (inctx != NULL) ? inctx->params : NULL;
     if (xcparams && xcparams->debug_frame_level)

--- a/avpipe.c
+++ b/avpipe.c
@@ -918,6 +918,8 @@ set_handlers(
         *p_out_handlers = out_handlers;
     }
 
+    free_parsed_url(&url_parser);
+
     return eav_success;
 }
 

--- a/avpipe.c
+++ b/avpipe.c
@@ -390,7 +390,7 @@ udp_in_closer(
 
     int fd = *((int64_t *)inctx->opaque);
     int sockfd = *((int *)((int64_t *)inctx->opaque+1));
-    elv_dbg("IN CLOSE UDP fd=%d, sockfd=%d, url=%s\n", fd, sockfd, inctx->url);
+    elv_dbg("IN CLOSE UDP fd=%d, sockfd=%d, url=%s\n", fd, sockfd, inctx->url ? inctx->url : "bogus.mp4");
     free(inctx->opaque);
     close(sockfd);
     return 0;

--- a/avpipe_test.go
+++ b/avpipe_test.go
@@ -1923,7 +1923,8 @@ func TestMezMakerWithOpenInputError(t *testing.T) {
 	params.EncWidth = 640
 
 	handle, err := avpipe.XcInit(params)
-	assert.Equal(t, handle, int32(-1))
+	assert.Greater(t, handle, int32(0))
+	failNowOnError(t, err)
 	err = avpipe.XcRun(handle)
 	assert.Error(t, err)
 

--- a/avpipe_test.go
+++ b/avpipe_test.go
@@ -1923,7 +1923,7 @@ func TestMezMakerWithOpenInputError(t *testing.T) {
 	params.EncWidth = 640
 
 	handle, err := avpipe.XcInit(params)
-	assert.Less(t, handle, int32(0))
+	assert.Equal(t, handle, int32(-1))
 	err = avpipe.XcRun(handle)
 	assert.Error(t, err)
 

--- a/avpipe_test.go
+++ b/avpipe_test.go
@@ -1968,7 +1968,8 @@ func TestMezMakerWithReadInputError(t *testing.T) {
 	params.EncWidth = 640
 
 	handle, err := avpipe.XcInit(params)
-	assert.Less(t, handle, int32(0))
+	assert.Greater(t, handle, int32(0))
+	failNowOnError(t, err)
 	err = avpipe.XcRun(handle)
 	assert.Error(t, err)
 

--- a/exc/elv_xc.c
+++ b/exc/elv_xc.c
@@ -187,7 +187,7 @@ int
 in_closer(
     ioctx_t *inctx)
 {
-    if (!inctx->opaque)
+    if (!inctx || !inctx->opaque)
         return 0;
 
     int fd = *((int *)(inctx->opaque));

--- a/exc/elv_xc.c
+++ b/exc/elv_xc.c
@@ -665,59 +665,6 @@ typedef struct tx_thread_params_t {
     int                 err;
 } tx_thread_params_t;
 
-static char *
-safe_strdup(
-    char *s)
-{
-    if (s)
-        return strdup(s);
-
-    return NULL;
-}
-
-static xcparams_t *
-txparam_copy(
-    xcparams_t *p)
-{
-    xcparams_t *p2 = (xcparams_t *) calloc(1, sizeof(xcparams_t));
-
-    *p2 = *p;
-    p2->url = strdup(p->url);
-    p2->crf_str = safe_strdup(p->crf_str);
-    p2->crypt_iv = safe_strdup(p->crypt_iv);
-    p2->crypt_key = safe_strdup(p->crypt_key);
-    p2->crypt_key_url = safe_strdup(p->crypt_key_url);
-    p2->crypt_kid = safe_strdup(p->crypt_kid);
-    p2->dcodec = safe_strdup(p->dcodec);
-    p2->dcodec2 = safe_strdup(p->dcodec2);
-    p2->ecodec = safe_strdup(p->ecodec);
-    p2->ecodec2 = safe_strdup(p->ecodec2);
-    p2->filter_descriptor = safe_strdup(p->filter_descriptor);
-    p2->format = safe_strdup(p->format);
-    p2->max_cll = safe_strdup(p->max_cll);
-    p2->master_display = safe_strdup(p->master_display);
-    p2->preset = safe_strdup(p->preset);
-    p2->start_segment_str = safe_strdup(p->start_segment_str);
-    p2->watermark_text = safe_strdup(p->watermark_text);
-    p2->watermark_timecode = safe_strdup(p->watermark_timecode);
-    p2->overlay_filename = safe_strdup(p->overlay_filename);
-    if (p->watermark_overlay_len > 0) {
-        p2->watermark_overlay = (char *) calloc(1, p->watermark_overlay_len);
-        memcpy(p2->watermark_overlay, p->watermark_overlay, p->watermark_overlay_len);
-    }
-    p2->watermark_shadow_color = safe_strdup(p->watermark_shadow_color);
-    if (p2->extract_images_sz != 0) {
-        p2->extract_images_ts = calloc(p2->extract_images_sz, sizeof(int64_t));
-        int size = p2->extract_images_sz * sizeof(int64_t);
-        memcpy(p2->extract_images_ts, p->extract_images_ts, size);
-    }
-
-    if (p->seg_duration)
-        p2->seg_duration = strdup(p->seg_duration);
-
-    return p2;
-}
-
 void *
 tx_thread_func(
     void *thread_params)
@@ -735,7 +682,7 @@ tx_thread_func(
          * Pass a copy of params since avpipe_fini() releases all the params memory.
          * (This is needed when repeating the same command with exc.)
          */
-        xcparams_t *xcparams = txparam_copy(params->xcparams);
+        xcparams_t *xcparams = avpipe_copy_xcparams(params->xcparams);
         avpipe_io_handler_t *in_handlers = (avpipe_io_handler_t *)calloc(1, sizeof(avpipe_io_handler_t));
         avpipe_io_handler_t *out_handlers = (avpipe_io_handler_t *)calloc(1, sizeof(avpipe_io_handler_t));
         *in_handlers = *params->in_handlers;

--- a/libavpipe/include/avpipe_version.h
+++ b/libavpipe/include/avpipe_version.h
@@ -10,5 +10,5 @@
 
 /* Only increase these versions for release purposes */
 #define AVPIPE_MAJOR_VERSION    1
-#define AVPIPE_MINOR_VERSION    14
+#define AVPIPE_MINOR_VERSION    15
 

--- a/libavpipe/include/avpipe_xc.h
+++ b/libavpipe/include/avpipe_xc.h
@@ -626,7 +626,7 @@ avpipe_probe_free(
     int n_streams);
 
 /**
- * @brief   Starts transcoding.
+ * @brief   Starts transcoding. Multiple transcoding operations on the same transcoding context is UB.
  *          In case of failure avpipe_fini() should be called to avoid resource leak.
  *
  * @param   xctx                A pointer to transcoding context.

--- a/libavpipe/include/avpipe_xc.h
+++ b/libavpipe/include/avpipe_xc.h
@@ -555,13 +555,12 @@ typedef struct encoding_frame_stats_t {
 } encoding_frame_stats_t;
 
 /**
- * @brief   Allocates and initializes a xctx_t (transcoder context) for piplining the input stream.
- *          In case of failure avpipe_fini() should be called to avoid resource leak.
+ * @brief   Allocates and initializes a xctx_t (transcoder context) for pipelining the input stream.
+ *          in_handlers, out_handlers, and params ownership is always on the caller, and will never
+ *          be freed or modified by this function. In case of failure xctx is NULL.
  *
- * @param   xctx            Points to allocated and initialized memory (different fields are initialized by ffmpeg).
+ * @param   xctx            Pointer that will be filled with a partially initialized transcoding context.
  * @param   in_handlers     A pointer to input handlers. Must be properly set up by the application.
- * @param   inctx           A pointer to ioctx_t for input stream. This has to be allocated and initialized
- *                          by the application before calling this function.
  * @param   out_handlers    A pointer to output handlers. Must be properly set up by the application.
  * @param   params          A pointer to the parameters for transcoding.
  *
@@ -742,5 +741,14 @@ avpipe_h264_guess_profile(
     int width,
     int height);
 
+/**
+ * @brief   Helper function to deep copy an xc_params. In the case of OOM, may fail to initialize
+ *          all fields.
+ * 
+ * @param   p  A pointer to the transcoding parameters to copy.
+ */
+xcparams_t *
+avpipe_copy_xcparams(
+    xcparams_t *p);
 
 #endif

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -3502,8 +3502,6 @@ avpipe_xc(
     if (!params->url || params->url[0] == '\0' ||
         in_handlers->avpipe_opener(params->url, inctx) < 0) {
         elv_err("Failed to open avpipe input \"%s\"", params->url != NULL ? params->url : "");
-        free(inctx);
-        xctx->inctx = NULL;
         rc = eav_open_input;
         return rc;
     }

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -4451,22 +4451,15 @@ avpipe_init(
         goto avpipe_init_failed;
     }
 
-    params = (xcparams_t *) calloc(1, sizeof(xcparams_t));
-    *params = *p;
-    inctx->params = params;
-    if (!p->url || p->url[0] == '\0' ||
-        in_handlers->avpipe_opener(p->url, inctx) < 0) {
-        elv_err("Failed to open avpipe input \"%s\"", p->url != NULL ? p->url : "");
-        free(inctx);
-        rc = eav_open_input;
-        goto avpipe_init_failed;
-    }
-
     if (!xctx) {
         elv_err("Trancoding context is NULL, url=%s", p->url);
         rc = eav_param;
         goto avpipe_init_failed;
     }
+
+    params = (xcparams_t *) calloc(1, sizeof(xcparams_t));
+    *params = *p;
+    inctx->params = params;
 
     p_xctx = (xctx_t *) calloc(1, sizeof(xctx_t));
     p_xctx->params = params;

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -3491,6 +3491,7 @@ avpipe_xc(
         in_handlers->avpipe_opener(params->url, inctx) < 0) {
         elv_err("Failed to open avpipe input \"%s\"", params->url != NULL ? params->url : "");
         free(inctx);
+        xctx->inctx = NULL;
         rc = eav_open_input;
         return rc;
     }

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -385,7 +385,8 @@ decode_interrupt_cb(
     void *ctx) 
 {
     coderctx_t *decoder_ctx = (coderctx_t *)ctx;
-    elv_log("interrupt callback checked. Cancelled is equal to %d", decoder_ctx->cancelled);
+    if (decoder_ctx->cancelled)
+        elv_dbg("interrupt callback checked and stream decoding cancelled");
     return decoder_ctx->cancelled;
 }
 

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -381,6 +381,15 @@ selected_decoded_audio(
 }
 
 static int
+decode_interrupt_cb(
+    void *ctx) 
+{
+    coderctx_t *decoder_ctx = (coderctx_t *)ctx;
+    elv_log("interrupt callback checked. Cancelled is equal to %d", decoder_ctx->cancelled);
+    return decoder_ctx->cancelled;
+}
+
+static int
 prepare_decoder(
     coderctx_t *decoder_context,
     avpipe_io_handler_t *in_handlers,
@@ -408,6 +417,9 @@ prepare_decoder(
         elv_err("Could not allocate memory for Format Context, url=%s", url);
         return eav_mem_alloc;
     }
+
+    const AVIOInterruptCB int_cb = { decode_interrupt_cb, (void*)decoder_context};
+    decoder_context->format_context->interrupt_callback = int_cb;
 
     /* Set our custom reader */
     prepare_input(in_handlers, inctx, decoder_context, seekable);

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -4561,6 +4561,15 @@ log_params(
     elv_log("AVPIPE XCPARAMS %s", buf);
 }
 
+static char *
+safe_strdup(
+    char *s)
+{
+    if (s)
+        return strdup(s);
+
+    return NULL;
+}
 
 xcparams_t *
 avpipe_copy_xcparams(
@@ -4825,14 +4834,4 @@ set_extract_images(
         return;
     }
     params->extract_images_ts[index] = value;
-}
-
-static char *
-safe_strdup(
-    char *s)
-{
-    if (s)
-        return strdup(s);
-
-    return NULL;
 }

--- a/live/rtmp_recorder_test.go
+++ b/live/rtmp_recorder_test.go
@@ -181,8 +181,13 @@ func TestRtmpToMp4WithCancelling0(t *testing.T) {
 			t.Error("XcInit initializing RTMP stream failed", "err", err)
 		}
 
+		err = avpipe.XcRun(handle)
+		assert.Equal(t, err, avpipe.EAV_OPEN_INPUT)
+
 		done <- true
 	}()
+
+	time.Sleep(1 * time.Second)
 
 	err = avpipe.XcCancel(handle)
 	assert.NoError(t, err)

--- a/live/rtmp_recorder_test.go
+++ b/live/rtmp_recorder_test.go
@@ -129,6 +129,73 @@ func TestRtmpToMp4_1(t *testing.T) {
 	testComplete <- true
 }
 
+// Cancels the RTMP live stream transcoding, with no source, immediately after initializing the transcoding (after XcInit).
+// This test was hanging with avpipe release-1.15 and before (this is fixed in release-1.16).
+func TestRtmpToMp4WithCancelling0(t *testing.T) {
+	setupLogging()
+	outputDir := path.Join(baseOutPath, fn())
+	setupOutDir(t, outputDir)
+
+	log.Info("STARTING " + outputDir)
+
+	done := make(chan bool, 1)
+	liveSource := NewLiveSource()
+	url := fmt.Sprintf(RTMP_SOURCE, liveSource.Port)
+
+	xcParams := &avpipe.XcParams{
+		Format:              "fmp4-segment",
+		Seekable:            false,
+		DurationTs:          -1,
+		StartSegmentStr:     "1",
+		AudioBitrate:        256000,
+		VideoBitrate:        20000000,
+		ForceKeyInt:         60,
+		VideoSegDurationTs:  480000,
+		AudioSegDurationTs:  1428480,   // 1428480=29.76s
+		Ecodec2:             "aac",     // "aac"
+		Ecodec:              "libx264", // libx264 software / h264_videotoolbox mac hardware
+		EncHeight:           720,       // 1080
+		EncWidth:            1280,      // 1920
+		XcType:              avpipe.XcAll,
+		StreamId:            -1,
+		Url:                 url,
+		SyncAudioToStreamId: -1,
+		DebugFrameLevel:     debugFrameLevel,
+		Listen:              true,
+	}
+
+	xcParams.NumAudio = 1
+	xcParams.AudioIndex[0] = 1
+	// Transcode audio/video mez files in background
+	reqCtx := &testCtx{url: url}
+	putReqCtxByURL(url, reqCtx)
+
+	avpipe.InitIOHandler(&inputOpener{dir: outputDir}, &outputOpener{dir: outputDir})
+
+	var handle int32
+	var err error
+	go func() {
+		tlog.Info("Transcoding RTMP stream start", "params", fmt.Sprintf("%+v", *xcParams))
+		handle, err = avpipe.XcInit(xcParams)
+		if err != nil {
+			t.Error("XcInit initializing RTMP stream failed", "err", err)
+		}
+
+		done <- true
+	}()
+
+	err = avpipe.XcCancel(handle)
+	assert.NoError(t, err)
+	if err != nil {
+		t.Error("Cancelling RTMP stream failed", "err", err, "url", url)
+		t.FailNow()
+	} else {
+		tlog.Info("Cancelling RTMP stream completed", "err", err, "url", url)
+	}
+
+	<-done
+}
+
 // Cancels the RTMP live stream transcoding immediately after initializing the transcoding (after XcInit).
 func TestRtmpToMp4WithCancelling1(t *testing.T) {
 	setupLogging()

--- a/live/srt_recorder_test.go
+++ b/live/srt_recorder_test.go
@@ -123,6 +123,70 @@ func TestSrtToMp4(t *testing.T) {
 }
 
 // Cancels the SRT live stream transcoding immediately after initializing the transcoding (after XcInit).
+// This test was hanging with avpipe release-1.15 and before (this is fixed in release-1.16).
+func TestSrtToMp4WithCancelling0(t *testing.T) {
+	setupLogging()
+	outputDir := path.Join(baseOutPath, fn())
+	setupOutDir(t, outputDir)
+
+	log.Info("STARTING " + outputDir)
+
+	done := make(chan bool, 1)
+	liveSource := NewLiveSource()
+	url := fmt.Sprintf("srt://localhost:%d?mode=listener&recv_buffer_size=256000&ffs=256000", liveSource.Port)
+
+	xcParams := &avpipe.XcParams{
+		Format:              "fmp4-segment",
+		Seekable:            false,
+		DurationTs:          -1,
+		StartSegmentStr:     "1",
+		AudioBitrate:        256000,
+		VideoBitrate:        20000000,
+		ForceKeyInt:         60,
+		SegDuration:         "30", // seconds
+		Dcodec2:             "ac3",
+		Ecodec2:             "aac",     // "aac"
+		Ecodec:              "libx264", // libx264 software / h264_videotoolbox mac hardware
+		EncHeight:           720,       // 1080
+		EncWidth:            1280,      // 1920
+		XcType:              avpipe.XcAll,
+		StreamId:            -1,
+		Url:                 url,
+		SyncAudioToStreamId: -1,
+		DebugFrameLevel:     debugFrameLevel,
+	}
+
+	// Transcode audio/video mez files in background
+	reqCtx := &testCtx{url: url}
+	putReqCtxByURL(url, reqCtx)
+
+	avpipe.InitIOHandler(&inputOpener{dir: outputDir}, &outputOpener{dir: outputDir})
+
+	var handle int32
+	var err error
+	go func() {
+		tlog.Info("Transcoding SRT stream start", "params", fmt.Sprintf("%+v", *xcParams))
+		handle, err = avpipe.XcInit(xcParams)
+		if err != nil {
+			t.Error("XcInit initializing SRT stream failed", "err", err)
+		}
+
+		done <- true
+	}()
+
+	err = avpipe.XcCancel(handle)
+	assert.NoError(t, err)
+	if err != nil {
+		t.Error("Cancelling SRT stream failed", "err", err, "url", url)
+		t.FailNow()
+	} else {
+		tlog.Info("Cancelling SRT stream completed", "err", err, "url", url)
+	}
+
+	<-done
+}
+
+// Cancels the SRT live stream transcoding immediately after initializing the transcoding (after XcInit).
 func TestSrtToMp4WithCancelling1(t *testing.T) {
 	setupLogging()
 	outputDir := path.Join(baseOutPath, fn())

--- a/live/srt_recorder_test.go
+++ b/live/srt_recorder_test.go
@@ -122,7 +122,7 @@ func TestSrtToMp4(t *testing.T) {
 	testComplete <- true
 }
 
-// Cancels the SRT live stream transcoding immediately after initializing the transcoding (after XcInit).
+// Cancels the SRT live stream transcoding, with no source, immediately after initializing the transcoding (after XcInit).
 // This test was hanging with avpipe release-1.15 and before (this is fixed in release-1.16).
 func TestSrtToMp4WithCancelling0(t *testing.T) {
 	setupLogging()

--- a/utils/src/elv_sock.c
+++ b/utils/src/elv_sock.c
@@ -74,20 +74,29 @@ udp_socket(
 
 int
 tcp_connect(
-    const char *host,
+    const char *hostname,
     const char *port)
 {
-    int sockfd, n;
-    struct addrinfo hints, *res;
+    struct hostent *he;
+    int sockfd;
+    struct sockaddr_in server_addr;
+    int port_num = atoi(port);
 
     sockfd = socket(AF_INET, SOCK_STREAM, 0);
     if (sockfd == -1)
         return -1;
 
-    if ( (n = getaddrinfo(host, port, &hints, &res)) != 0)
+    // Resolve the hostname to an IP address
+    if ((he = gethostbyname(hostname)) == NULL)
         return -1;
 
-    if (connect(sockfd, res->ai_addr, res->ai_addrlen) != 0)
+    // Set up the server address structure
+    memset(&server_addr, 0, sizeof(server_addr));
+    server_addr.sin_family = AF_INET;
+    server_addr.sin_port = htons(port_num);
+    server_addr.sin_addr = *((struct in_addr *)he->h_addr);
+
+    if (connect(sockfd, (struct sockaddr *)&server_addr, sizeof(server_addr)) == -1)
         return -1;
 
     return sockfd;


### PR DESCRIPTION
- This will keep the API and modifies the implementation under the hood.
- Move blocking code from avpipe_init() into avpipe_xc(). This will allow to obtain the handle for cancellation.
- Add some unit tests for the hanging cases with SRT and RTMP.

Nate will continue to enhance corner cases and memory cleanup.