### PR TITLE
fix-side-data

### DIFF
--- a/avpipe.go
+++ b/avpipe.go
@@ -365,7 +365,7 @@ type StreamInfo struct {
 	FieldOrder         string            `json:"field_order,omitempty"`
 	Profile            int               `json:"profile,omitempty"`
 	Level              int               `json:"level,omitempty"`
-	SideDataList       []interface{}     `json:"side_data_list,omitempty"`
+	SideData           []interface{}     `json:"side_data,omitempty"`
 	Tags               map[string]string `json:"tags,omitempty"`
 }
 
@@ -1459,15 +1459,15 @@ func Probe(params *XcParams) (*ProbeInfo, error) {
 
 		rot := float64(probeArray[i].side_data.display_matrix.rotation)
 		if rot != 0.0 {
-			probeInfo.StreamInfo[i].SideDataList = make([]interface{}, 1)
+			probeInfo.StreamInfo[i].SideData = make([]interface{}, 1)
 			displayMatrix := SideDataDisplayMatrix{
 				Type:       "Display Matrix",
 				Rotation:   rot,
 				RotationCw: float64(probeArray[i].side_data.display_matrix.rotation_cw),
 			}
-			probeInfo.StreamInfo[i].SideDataList[0] = displayMatrix
+			probeInfo.StreamInfo[i].SideData[0] = displayMatrix
 		} else {
-			probeInfo.StreamInfo[i].SideDataList = make([]interface{}, 0)
+			probeInfo.StreamInfo[i].SideData = make([]interface{}, 0)
 		}
 
 		// Convert AVDictionary data to Tags of type map[string]string using the built in av_dict_get() iterator

--- a/elvxc/cmd/probe.go
+++ b/elvxc/cmd/probe.go
@@ -98,11 +98,15 @@ func doProbe(cmd *cobra.Command, args []string) error {
 		fmt.Printf("\tsample_aspect_ratio: %d:%d\n", info.SampleAspectRatio.Num(), info.SampleAspectRatio.Denom())
 		fmt.Printf("\tdisplay_aspect_ratio: %d:%d\n", info.DisplayAspectRatio.Num(), info.DisplayAspectRatio.Denom())
 		fmt.Printf("\tfield_order: %s\n", info.FieldOrder)
-		if info.SideData.DisplayMatrix.Rotation != 0 {
-			fmt.Printf("\tside_data:\n")
-			fmt.Printf("\t\tdisplay_matrix:\n")
-			fmt.Printf("\t\t\trotation: %f\n", info.SideData.DisplayMatrix.Rotation)
-			fmt.Printf("\t\t\trotation_cw: %f\n", info.SideData.DisplayMatrix.RotationCw)
+		/* TODO: Make this a switch based on different SideData */
+		if info.SideData != nil && len(info.SideData) > 0 {
+			displayMatrix, ok := info.SideData[0].(avpipe.SideDataDisplayMatrix)
+			if ok {
+				fmt.Printf("\tside_data:\n")
+				fmt.Printf("\t\tdisplay_matrix:\n")
+				fmt.Printf("\t\t\trotation: %f\n", displayMatrix.Rotation)
+				fmt.Printf("\t\t\trotation_cw: %f\n", displayMatrix.RotationCw)
+			}
 		}
 		if info.Tags != nil {
 			fmt.Printf("\ttags:\n")


### PR DESCRIPTION
This fixes and completes the changes in side data in the previous commit.

Here is the compile error with previous change set:
```
e.go $WORK/b085/_cgo_gotypes.go $WORK/b085/mux.cgo1.go $WORK/b085/_cgo_import.go
# github.com/eluv-io/avpipe/elvxc/cmd
cmd/probe.go:101:11: info.SideData undefined (type avpipe.StreamInfo has no field or method SideData)
cmd/probe.go:104:44: info.SideData undefined (type avpipe.StreamInfo has no field or method SideData)
cmd/probe.go:105:47: info.SideData undefined (type avpipe.StreamInfo has no field or method SideData)

```