### PR TITLE
Clean up audio index

### DIFF
--- a/avpipe.go
+++ b/avpipe.go
@@ -222,8 +222,8 @@ type XcParams struct {
 	WatermarkOverlayLen    int         `json:"watermark_overlay_len,omitempty"`  // Length of overlay image
 	WatermarkOverlayType   ImageType   `json:"watermark_overlay_type,omitempty"` // Type of overlay image (i.e PngImage, ...)
 	StreamId               int32       `json:"stream_id"`                        // Specify stream by ID (instead of index)
-	AudioIndex             []int32     `json:"audio_index"`
-	ChannelLayout          int         `json:"channel_layout"` // Audio channel layout
+	AudioIndex             []int32     `json:"audio_index"`                      // the length of this is equal to the number of audios
+	ChannelLayout          int         `json:"channel_layout"`                   // Audio channel layout
 	MaxCLL                 string      `json:"max_cll,omitempty"`
 	MasterDisplay          string      `json:"master_display,omitempty"`
 	BitDepth               int32       `json:"bitdepth,omitempty"`

--- a/avpipe.go
+++ b/avpipe.go
@@ -222,8 +222,7 @@ type XcParams struct {
 	WatermarkOverlayLen    int         `json:"watermark_overlay_len,omitempty"`  // Length of overlay image
 	WatermarkOverlayType   ImageType   `json:"watermark_overlay_type,omitempty"` // Type of overlay image (i.e PngImage, ...)
 	StreamId               int32       `json:"stream_id"`                        // Specify stream by ID (instead of index)
-	AudioIndex             []int32     `json:"audio_index,omitempty"`
-	NumAudio               int32       `json:"n_audio"`
+	AudioIndex             []int32     `json:"audio_index"`
 	ChannelLayout          int         `json:"channel_layout"` // Audio channel layout
 	MaxCLL                 string      `json:"max_cll,omitempty"`
 	MasterDisplay          string      `json:"master_display,omitempty"`
@@ -1235,7 +1234,7 @@ func getCParams(params *XcParams) (*C.xcparams_t, error) {
 		watermark_overlay:         C.CString(params.WatermarkOverlay),
 		watermark_overlay_len:     C.int(params.WatermarkOverlayLen),
 		watermark_overlay_type:    C.image_type(params.WatermarkOverlayType),
-		n_audio:                   C.int(params.NumAudio),
+		n_audio:                   C.int(len(params.AudioIndex)),
 		channel_layout:            C.int(params.ChannelLayout),
 		stream_id:                 C.int(params.StreamId),
 		bypass_transcoding:        C.int(0),
@@ -1283,15 +1282,15 @@ func getCParams(params *XcParams) (*C.xcparams_t, error) {
 		cparams.listen = C.int(1)
 	}
 
-	if params.NumAudio > MaxAudioMux || int(params.NumAudio) != len(params.AudioIndex) {
-		return nil, fmt.Errorf("Invalid number of audio streams NumAudio=%d, AudioIndexLen=%d", params.NumAudio, len(params.AudioIndex))
+	if int32(len(params.AudioIndex)) > MaxAudioMux {
+		return nil, fmt.Errorf("Invalid number of audio streams NumAudio=%d", len(params.AudioIndex))
 	}
 
 	if params.DebugFrameLevel {
 		cparams.debug_frame_level = C.int(1)
 	}
 
-	for i := 0; i < int(params.NumAudio); i++ {
+	for i := 0; i < len(params.AudioIndex); i++ {
 		cparams.audio_index[i] = C.int(params.AudioIndex[i])
 	}
 

--- a/avpipe.go
+++ b/avpipe.go
@@ -176,71 +176,71 @@ const MaxAudioMux = C.MAX_STREAMS
 
 // XcParams should match with txparams_t in avpipe_xc.h
 type XcParams struct {
-	Url                    string             `json:"url"`
-	BypassTranscoding      bool               `json:"bypass,omitempty"`
-	Format                 string             `json:"format,omitempty"`
-	StartTimeTs            int64              `json:"start_time_ts,omitempty"`
-	StartPts               int64              `json:"start_pts,omitempty"` // Start PTS for output
-	DurationTs             int64              `json:"duration_ts,omitempty"`
-	StartSegmentStr        string             `json:"start_segment_str,omitempty"`
-	VideoBitrate           int32              `json:"video_bitrate,omitempty"`
-	AudioBitrate           int32              `json:"audio_bitrate,omitempty"`
-	SampleRate             int32              `json:"sample_rate,omitempty"` // Audio sampling rate
-	RcMaxRate              int32              `json:"rc_max_rate,omitempty"`
-	RcBufferSize           int32              `json:"rc_buffer_size,omitempty"`
-	CrfStr                 string             `json:"crf_str,omitempty"`
-	Preset                 string             `json:"preset,omitempty"`
-	AudioSegDurationTs     int64              `json:"audio_seg_duration_ts,omitempty"`
-	VideoSegDurationTs     int64              `json:"video_seg_duration_ts,omitempty"`
-	SegDuration            string             `json:"seg_duration,omitempty"`
-	StartFragmentIndex     int32              `json:"start_fragment_index,omitempty"`
-	ForceKeyInt            int32              `json:"force_keyint,omitempty"`
-	Ecodec                 string             `json:"ecodec,omitempty"`    // Video encoder
-	Ecodec2                string             `json:"ecodec2,omitempty"`   // Audio encoder
-	Dcodec                 string             `json:"dcodec,omitempty"`    // Video decoder
-	Dcodec2                string             `json:"dcodec2,omitempty"`   // Audio decoder
-	GPUIndex               int32              `json:"gpu_index,omitempty"` // GPU index if encoder/decoder is GPU (nvidia)
-	EncHeight              int32              `json:"enc_height,omitempty"`
-	EncWidth               int32              `json:"enc_width,omitempty"`
-	CryptIV                string             `json:"crypt_iv,omitempty"`
-	CryptKey               string             `json:"crypt_key,omitempty"`
-	CryptKID               string             `json:"crypt_kid,omitempty"`
-	CryptKeyURL            string             `json:"crypt_key_url,omitempty"`
-	CryptScheme            CryptScheme        `json:"crypt_scheme,omitempty"`
-	XcType                 XcType             `json:"xc_type,omitempty"`
-	Seekable               bool               `json:"seekable,omitempty"`
-	WatermarkText          string             `json:"watermark_text,omitempty"`
-	WatermarkTimecode      string             `json:"watermark_timecode,omitempty"`
-	WatermarkTimecodeRate  float32            `json:"watermark_timecode_rate,omitempty"`
-	WatermarkXLoc          string             `json:"watermark_xloc,omitempty"`
-	WatermarkYLoc          string             `json:"watermark_yloc,omitempty"`
-	WatermarkRelativeSize  float32            `json:"watermark_relative_size,omitempty"`
-	WatermarkFontColor     string             `json:"watermark_font_color,omitempty"`
-	WatermarkShadow        bool               `json:"watermark_shadow,omitempty"`
-	WatermarkShadowColor   string             `json:"watermark_shadow_color,omitempty"`
-	WatermarkOverlay       string             `json:"watermark_overlay,omitempty"`      // Buffer containing overlay image
-	WatermarkOverlayLen    int                `json:"watermark_overlay_len,omitempty"`  // Length of overlay image
-	WatermarkOverlayType   ImageType          `json:"watermark_overlay_type,omitempty"` // Type of overlay image (i.e PngImage, ...)
-	StreamId               int32              `json:"stream_id"`                        // Specify stream by ID (instead of index)
-	AudioIndex             [MaxAudioMux]int32 `json:"audio_index,omitempty"`
-	NumAudio               int32              `json:"n_audio"`
-	ChannelLayout          int                `json:"channel_layout"` // Audio channel layout
-	MaxCLL                 string             `json:"max_cll,omitempty"`
-	MasterDisplay          string             `json:"master_display,omitempty"`
-	BitDepth               int32              `json:"bitdepth,omitempty"`
-	SyncAudioToStreamId    int                `json:"sync_audio_to_stream_id"`
-	ForceEqualFDuration    bool               `json:"force_equal_frame_duration,omitempty"`
-	MuxingSpec             string             `json:"muxing_spec,omitempty"`
-	Listen                 bool               `json:"listen"`
-	ConnectionTimeout      int                `json:"connection_timeout"`
-	FilterDescriptor       string             `json:"filter_descriptor"`
-	SkipDecoding           bool               `json:"skip_decoding"`
-	DebugFrameLevel        bool               `json:"debug_frame_level"`
-	ExtractImageIntervalTs int64              `json:"extract_image_interval_ts,omitempty"`
-	ExtractImagesTs        []int64            `json:"extract_images_ts,omitempty"`
-	VideoTimeBase          int                `json:"video_time_base"`
-	VideoFrameDurationTs   int                `json:"video_frame_duration_ts"`
-	Rotate                 int                `json:"rotate"`
+	Url                    string      `json:"url"`
+	BypassTranscoding      bool        `json:"bypass,omitempty"`
+	Format                 string      `json:"format,omitempty"`
+	StartTimeTs            int64       `json:"start_time_ts,omitempty"`
+	StartPts               int64       `json:"start_pts,omitempty"` // Start PTS for output
+	DurationTs             int64       `json:"duration_ts,omitempty"`
+	StartSegmentStr        string      `json:"start_segment_str,omitempty"`
+	VideoBitrate           int32       `json:"video_bitrate,omitempty"`
+	AudioBitrate           int32       `json:"audio_bitrate,omitempty"`
+	SampleRate             int32       `json:"sample_rate,omitempty"` // Audio sampling rate
+	RcMaxRate              int32       `json:"rc_max_rate,omitempty"`
+	RcBufferSize           int32       `json:"rc_buffer_size,omitempty"`
+	CrfStr                 string      `json:"crf_str,omitempty"`
+	Preset                 string      `json:"preset,omitempty"`
+	AudioSegDurationTs     int64       `json:"audio_seg_duration_ts,omitempty"`
+	VideoSegDurationTs     int64       `json:"video_seg_duration_ts,omitempty"`
+	SegDuration            string      `json:"seg_duration,omitempty"`
+	StartFragmentIndex     int32       `json:"start_fragment_index,omitempty"`
+	ForceKeyInt            int32       `json:"force_keyint,omitempty"`
+	Ecodec                 string      `json:"ecodec,omitempty"`    // Video encoder
+	Ecodec2                string      `json:"ecodec2,omitempty"`   // Audio encoder
+	Dcodec                 string      `json:"dcodec,omitempty"`    // Video decoder
+	Dcodec2                string      `json:"dcodec2,omitempty"`   // Audio decoder
+	GPUIndex               int32       `json:"gpu_index,omitempty"` // GPU index if encoder/decoder is GPU (nvidia)
+	EncHeight              int32       `json:"enc_height,omitempty"`
+	EncWidth               int32       `json:"enc_width,omitempty"`
+	CryptIV                string      `json:"crypt_iv,omitempty"`
+	CryptKey               string      `json:"crypt_key,omitempty"`
+	CryptKID               string      `json:"crypt_kid,omitempty"`
+	CryptKeyURL            string      `json:"crypt_key_url,omitempty"`
+	CryptScheme            CryptScheme `json:"crypt_scheme,omitempty"`
+	XcType                 XcType      `json:"xc_type,omitempty"`
+	Seekable               bool        `json:"seekable,omitempty"`
+	WatermarkText          string      `json:"watermark_text,omitempty"`
+	WatermarkTimecode      string      `json:"watermark_timecode,omitempty"`
+	WatermarkTimecodeRate  float32     `json:"watermark_timecode_rate,omitempty"`
+	WatermarkXLoc          string      `json:"watermark_xloc,omitempty"`
+	WatermarkYLoc          string      `json:"watermark_yloc,omitempty"`
+	WatermarkRelativeSize  float32     `json:"watermark_relative_size,omitempty"`
+	WatermarkFontColor     string      `json:"watermark_font_color,omitempty"`
+	WatermarkShadow        bool        `json:"watermark_shadow,omitempty"`
+	WatermarkShadowColor   string      `json:"watermark_shadow_color,omitempty"`
+	WatermarkOverlay       string      `json:"watermark_overlay,omitempty"`      // Buffer containing overlay image
+	WatermarkOverlayLen    int         `json:"watermark_overlay_len,omitempty"`  // Length of overlay image
+	WatermarkOverlayType   ImageType   `json:"watermark_overlay_type,omitempty"` // Type of overlay image (i.e PngImage, ...)
+	StreamId               int32       `json:"stream_id"`                        // Specify stream by ID (instead of index)
+	AudioIndex             []int32     `json:"audio_index,omitempty"`
+	NumAudio               int32       `json:"n_audio"`
+	ChannelLayout          int         `json:"channel_layout"` // Audio channel layout
+	MaxCLL                 string      `json:"max_cll,omitempty"`
+	MasterDisplay          string      `json:"master_display,omitempty"`
+	BitDepth               int32       `json:"bitdepth,omitempty"`
+	SyncAudioToStreamId    int         `json:"sync_audio_to_stream_id"`
+	ForceEqualFDuration    bool        `json:"force_equal_frame_duration,omitempty"`
+	MuxingSpec             string      `json:"muxing_spec,omitempty"`
+	Listen                 bool        `json:"listen"`
+	ConnectionTimeout      int         `json:"connection_timeout"`
+	FilterDescriptor       string      `json:"filter_descriptor"`
+	SkipDecoding           bool        `json:"skip_decoding"`
+	DebugFrameLevel        bool        `json:"debug_frame_level"`
+	ExtractImageIntervalTs int64       `json:"extract_image_interval_ts,omitempty"`
+	ExtractImagesTs        []int64     `json:"extract_images_ts,omitempty"`
+	VideoTimeBase          int         `json:"video_time_base"`
+	VideoFrameDurationTs   int         `json:"video_frame_duration_ts"`
+	Rotate                 int         `json:"rotate"`
 }
 
 // NewXcParams initializes a XcParams struct with unset/default values
@@ -1283,8 +1283,8 @@ func getCParams(params *XcParams) (*C.xcparams_t, error) {
 		cparams.listen = C.int(1)
 	}
 
-	if params.NumAudio > MaxAudioMux {
-		return nil, fmt.Errorf("Invalid number of audio streams NumAudio=%d", params.NumAudio)
+	if params.NumAudio > MaxAudioMux || int(params.NumAudio) != len(params.AudioIndex) {
+		return nil, fmt.Errorf("Invalid number of audio streams NumAudio=%d, AudioIndexLen=%d", params.NumAudio, len(params.AudioIndex))
 	}
 
 	if params.DebugFrameLevel {

--- a/avpipe_test.go
+++ b/avpipe_test.go
@@ -514,7 +514,7 @@ func TestSingleABRTranscode(t *testing.T) {
 
 	params.XcType = avpipe.XcAudio
 	params.Ecodec2 = "aac"
-	params.NumAudio = -1
+	params.NumAudio = 0
 	xcTest(t, outputDir, params, nil, false)
 }
 
@@ -541,7 +541,7 @@ func TestSingleABRTranscodeByStreamId(t *testing.T) {
 		EncHeight:          720,
 		EncWidth:           1280,
 		StreamId:           1,
-		NumAudio:           -1,
+		NumAudio:           0,
 		Url:                url,
 		DebugFrameLevel:    debugFrameLevel,
 	}
@@ -661,7 +661,7 @@ func TestV2SingleABRTranscode(t *testing.T) {
 	params.XcType = avpipe.XcAudio
 	params.Ecodec2 = "aac"
 	params.NumAudio = 1
-	params.AudioIndex[0] = 1
+	params.AudioIndex = []int32{1}
 	xcTest(t, outputDir, params, nil, false)
 }
 
@@ -698,7 +698,7 @@ func TestV2SingleABRTranscodeIOHandler(t *testing.T) {
 	params.XcType = avpipe.XcAudio
 	params.Ecodec2 = "aac"
 	params.NumAudio = 1
-	params.AudioIndex[0] = 1
+	params.AudioIndex = []int32{1}
 	xcTest(t, outputDir, params, nil, false)
 }
 
@@ -749,7 +749,7 @@ func TestV2SingleABRTranscodeCancelling(t *testing.T) {
 	params.XcType = avpipe.XcAudio
 	params.Ecodec2 = "aac"
 	params.NumAudio = 1
-	params.AudioIndex[0] = 1
+	params.AudioIndex = []int32{1}
 	handleA, err := avpipe.XcInit(params)
 	assert.NoError(t, err)
 	assert.Greater(t, handleA, int32(0))
@@ -1051,7 +1051,7 @@ func TestAudioAC3Ts2AC3MezMaker(t *testing.T) {
 		Url:                 url,
 		DebugFrameLevel:     debugFrameLevel,
 	}
-	params.AudioIndex[0] = 2
+	params.AudioIndex = []int32{2}
 
 	xcTestResult := &XcTestResult{
 		mezFile:    []string{fmt.Sprintf("%s/asegment0-1.mp4", outputDir)},
@@ -1089,7 +1089,7 @@ func TestAudioAC3Ts2AACMezMaker(t *testing.T) {
 		Url:                 url,
 		DebugFrameLevel:     debugFrameLevel,
 	}
-	params.AudioIndex[0] = 2
+	params.AudioIndex = []int32{2}
 
 	xcTestResult := &XcTestResult{
 		mezFile:    []string{fmt.Sprintf("%s/asegment0-1.mp4", outputDir)},
@@ -1128,7 +1128,7 @@ func TestAudioMP3Ts2AACMezMaker(t *testing.T) {
 		Url:                 url,
 		DebugFrameLevel:     debugFrameLevel,
 	}
-	params.AudioIndex[0] = 1
+	params.AudioIndex = []int32{1}
 
 	xcTestResult := &XcTestResult{
 		mezFile:    []string{fmt.Sprintf("%s/asegment0-1.mp4", outputDir)},
@@ -1168,7 +1168,7 @@ func TestAudioDownmix2AACMezMaker(t *testing.T) {
 		Url:                 url,
 		DebugFrameLevel:     debugFrameLevel,
 	}
-	params.AudioIndex[0] = 6
+	params.AudioIndex = []int32{6}
 
 	xcTestResult := &XcTestResult{
 		mezFile:           []string{fmt.Sprintf("%s/asegment0-1.mp4", outputDir)},
@@ -1205,8 +1205,7 @@ func TestAudio2MonoTo1Stereo(t *testing.T) {
 		Url:                 url,
 		DebugFrameLevel:     debugFrameLevel,
 	}
-	params.AudioIndex[0] = 0
-	params.AudioIndex[1] = 1
+	params.AudioIndex = []int32{0, 1}
 
 	xcTestResult := &XcTestResult{
 		timeScale:         44100,
@@ -1319,7 +1318,7 @@ func TestAudioMonoToMono(t *testing.T) {
 		Url:                 url,
 		DebugFrameLevel:     debugFrameLevel,
 	}
-	params.AudioIndex[0] = 1
+	params.AudioIndex = []int32{1}
 
 	xcTestResult := &XcTestResult{
 		timeScale:         22050,
@@ -1358,7 +1357,7 @@ func TestAudioQuadToQuad(t *testing.T) {
 		Url:                 url,
 		DebugFrameLevel:     debugFrameLevel,
 	}
-	params.AudioIndex[0] = 1
+	params.AudioIndex = []int32{1}
 
 	xcTestResult := &XcTestResult{
 		timeScale:         22050,
@@ -1398,12 +1397,7 @@ func TestAudio6MonoTo5_1(t *testing.T) {
 		Url:                 url,
 		DebugFrameLevel:     debugFrameLevel,
 	}
-	params.AudioIndex[0] = 3
-	params.AudioIndex[1] = 4
-	params.AudioIndex[2] = 5
-	params.AudioIndex[3] = 6
-	params.AudioIndex[4] = 7
-	params.AudioIndex[5] = 8
+	params.AudioIndex = []int32{3, 4, 5, 6, 7, 8}
 
 	xcTestResult := &XcTestResult{
 		timeScale:         44100,
@@ -1443,12 +1437,7 @@ func TestAudio6MonoUnequalChannelLayoutsTo5_1(t *testing.T) {
 		Url:                 url,
 		DebugFrameLevel:     debugFrameLevel,
 	}
-	params.AudioIndex[0] = 0
-	params.AudioIndex[1] = 1
-	params.AudioIndex[2] = 2
-	params.AudioIndex[3] = 3
-	params.AudioIndex[4] = 4
-	params.AudioIndex[5] = 5
+	params.AudioIndex = []int32{0, 1, 2, 3, 4, 5}
 
 	xcTestResult := &XcTestResult{
 		timeScale:         48000,
@@ -1488,7 +1477,7 @@ func TestAudio10Channel_s16To6Channel_5_1(t *testing.T) {
 		Url:                 url,
 		DebugFrameLevel:     debugFrameLevel,
 	}
-	params.AudioIndex[0] = 0
+	params.AudioIndex = []int32{0}
 
 	xcTestResult := &XcTestResult{
 		timeScale:         44100,
@@ -1528,7 +1517,7 @@ func TestAudio2Channel1Stereo(t *testing.T) {
 		Url:                 url,
 		DebugFrameLevel:     debugFrameLevel,
 	}
-	params.AudioIndex[0] = 1
+	params.AudioIndex = []int32{1}
 
 	xcTestResult := &XcTestResult{
 		timeScale:         48000,
@@ -1571,7 +1560,7 @@ func TestAudioPan2Channel1Stereo_pcm_60000(t *testing.T) {
 		Url:                 url,
 		DebugFrameLevel:     debugFrameLevel,
 	}
-	params.AudioIndex[0] = 6
+	params.AudioIndex = []int32{6}
 
 	xcTestResult := &XcTestResult{
 		timeScale:         48000,
@@ -1613,7 +1602,7 @@ func TestAudioMonoToStereo_pcm_60000(t *testing.T) {
 		Url:                 url,
 		DebugFrameLevel:     debugFrameLevel,
 	}
-	params.AudioIndex[0] = 3
+	params.AudioIndex = []int32{3}
 
 	xcTestResult := &XcTestResult{
 		timeScale:         48000,
@@ -1659,9 +1648,7 @@ func TestMultiAudioXc(t *testing.T) {
 		NumAudio:            3,
 	}
 
-	params.AudioIndex[0] = 1
-	params.AudioIndex[1] = 2
-	params.AudioIndex[2] = 3
+	params.AudioIndex = []int32{1, 2, 3}
 
 	xcTestResult := &XcTestResult{
 		timeScale: 15360,

--- a/avpipe_test.go
+++ b/avpipe_test.go
@@ -514,7 +514,6 @@ func TestSingleABRTranscode(t *testing.T) {
 
 	params.XcType = avpipe.XcAudio
 	params.Ecodec2 = "aac"
-	params.NumAudio = 0
 	xcTest(t, outputDir, params, nil, false)
 }
 
@@ -541,7 +540,6 @@ func TestSingleABRTranscodeByStreamId(t *testing.T) {
 		EncHeight:          720,
 		EncWidth:           1280,
 		StreamId:           1,
-		NumAudio:           0,
 		Url:                url,
 		DebugFrameLevel:    debugFrameLevel,
 	}
@@ -660,7 +658,6 @@ func TestV2SingleABRTranscode(t *testing.T) {
 
 	params.XcType = avpipe.XcAudio
 	params.Ecodec2 = "aac"
-	params.NumAudio = 1
 	params.AudioIndex = []int32{1}
 	xcTest(t, outputDir, params, nil, false)
 }
@@ -697,7 +694,6 @@ func TestV2SingleABRTranscodeIOHandler(t *testing.T) {
 
 	params.XcType = avpipe.XcAudio
 	params.Ecodec2 = "aac"
-	params.NumAudio = 1
 	params.AudioIndex = []int32{1}
 	xcTest(t, outputDir, params, nil, false)
 }
@@ -748,7 +744,6 @@ func TestV2SingleABRTranscodeCancelling(t *testing.T) {
 
 	params.XcType = avpipe.XcAudio
 	params.Ecodec2 = "aac"
-	params.NumAudio = 1
 	params.AudioIndex = []int32{1}
 	handleA, err := avpipe.XcInit(params)
 	assert.NoError(t, err)
@@ -1045,7 +1040,6 @@ func TestAudioAC3Ts2AC3MezMaker(t *testing.T) {
 		EncHeight:           -1,
 		EncWidth:            -1,
 		XcType:              avpipe.XcAudio,
-		NumAudio:            1,
 		StreamId:            -1,
 		SyncAudioToStreamId: -1,
 		Url:                 url,
@@ -1083,7 +1077,6 @@ func TestAudioAC3Ts2AACMezMaker(t *testing.T) {
 		EncHeight:           -1,
 		EncWidth:            -1,
 		XcType:              avpipe.XcAudio,
-		NumAudio:            1,
 		StreamId:            -1,
 		SyncAudioToStreamId: -1,
 		Url:                 url,
@@ -1122,7 +1115,6 @@ func TestAudioMP3Ts2AACMezMaker(t *testing.T) {
 		EncHeight:           -1,
 		EncWidth:            -1,
 		XcType:              avpipe.XcAudio,
-		NumAudio:            1,
 		StreamId:            -1,
 		SyncAudioToStreamId: -1,
 		Url:                 url,
@@ -1162,7 +1154,6 @@ func TestAudioDownmix2AACMezMaker(t *testing.T) {
 		EncWidth:            -1,
 		XcType:              avpipe.XcAudio,
 		ChannelLayout:       avpipe.ChannelLayout("stereo"),
-		NumAudio:            1,
 		StreamId:            -1,
 		SyncAudioToStreamId: -1,
 		Url:                 url,
@@ -1199,7 +1190,6 @@ func TestAudio2MonoTo1Stereo(t *testing.T) {
 		Dcodec2:             "",
 		XcType:              avpipe.XcAudioJoin,
 		ChannelLayout:       avpipe.ChannelLayout("stereo"),
-		NumAudio:            2,
 		StreamId:            -1,
 		SyncAudioToStreamId: -1,
 		Url:                 url,
@@ -1311,7 +1301,6 @@ func TestAudioMonoToMono(t *testing.T) {
 		Ecodec2:             "aac",
 		Dcodec2:             "",
 		XcType:              avpipe.XcAudio,
-		NumAudio:            1,
 		ChannelLayout:       avpipe.ChannelLayout("mono"),
 		StreamId:            -1,
 		SyncAudioToStreamId: -1,
@@ -1350,7 +1339,6 @@ func TestAudioQuadToQuad(t *testing.T) {
 		Ecodec2:             "aac",
 		Dcodec2:             "",
 		XcType:              avpipe.XcAudio,
-		NumAudio:            1,
 		ChannelLayout:       avpipe.ChannelLayout("quad"),
 		StreamId:            -1,
 		SyncAudioToStreamId: -1,
@@ -1389,7 +1377,6 @@ func TestAudio6MonoTo5_1(t *testing.T) {
 		Ecodec2:             "aac",
 		Dcodec2:             "",
 		XcType:              avpipe.XcAudioMerge,
-		NumAudio:            6,
 		ChannelLayout:       avpipe.ChannelLayout("5.1"),
 		FilterDescriptor:    "[0:3][0:4][0:5][0:6][0:7][0:8]amerge=inputs=6,pan=5.1|c0=c0|c1=c1|c2=c2| c3=c3|c4=c4|c5=c5[aout]",
 		StreamId:            -1,
@@ -1429,7 +1416,6 @@ func TestAudio6MonoUnequalChannelLayoutsTo5_1(t *testing.T) {
 		Ecodec2:             "aac",
 		Dcodec2:             "",
 		XcType:              avpipe.XcAudioMerge,
-		NumAudio:            6,
 		ChannelLayout:       avpipe.ChannelLayout("5.1"),
 		FilterDescriptor:    "[0:0][0:1][0:2][0:3][0:4][0:5]amerge=inputs=6,pan=5.1|c0=c0|c1=c1|c2=c2|c3=c3|c4=c4|c5=c5[aout]",
 		StreamId:            -1,
@@ -1469,7 +1455,6 @@ func TestAudio10Channel_s16To6Channel_5_1(t *testing.T) {
 		Ecodec2:             "aac",
 		Dcodec2:             "",
 		XcType:              avpipe.XcAudioPan,
-		NumAudio:            1,
 		ChannelLayout:       avpipe.ChannelLayout("5.1"),
 		FilterDescriptor:    "[0:1]pan=5.1|c0=c3|c1=c4|c2=c5|c3=c6|c4=c7|c5=c8[aout]",
 		StreamId:            -1,
@@ -1510,7 +1495,6 @@ func TestAudio2Channel1Stereo(t *testing.T) {
 		Dcodec2:             "",
 		XcType:              avpipe.XcAudioPan,
 		ChannelLayout:       avpipe.ChannelLayout("stereo"),
-		NumAudio:            1,
 		StreamId:            -1,
 		SyncAudioToStreamId: -1,
 		FilterDescriptor:    "[0:1]pan=stereo|c0<c1+0.707*c2|c1<c2+0.707*c1[aout]",
@@ -1553,7 +1537,6 @@ func TestAudioPan2Channel1Stereo_pcm_60000(t *testing.T) {
 		Dcodec2:             "",
 		XcType:              avpipe.XcAudioPan,
 		ChannelLayout:       avpipe.ChannelLayout("stereo"),
-		NumAudio:            1,
 		StreamId:            -1,
 		SyncAudioToStreamId: -1,
 		FilterDescriptor:    "[0:6]pan=stereo|c0=c0|c1=c0[aout]",
@@ -1596,7 +1579,6 @@ func TestAudioMonoToStereo_pcm_60000(t *testing.T) {
 		Dcodec2:             "",
 		XcType:              avpipe.XcAudio,
 		ChannelLayout:       avpipe.ChannelLayout("stereo"),
-		NumAudio:            1,
 		StreamId:            -1,
 		SyncAudioToStreamId: -1,
 		Url:                 url,
@@ -1645,7 +1627,6 @@ func TestMultiAudioXc(t *testing.T) {
 		ForceKeyInt:         60,
 		Url:                 url,
 		DebugFrameLevel:     debugFrameLevel,
-		NumAudio:            3,
 	}
 
 	params.AudioIndex = []int32{1, 2, 3}
@@ -2123,7 +2104,6 @@ func TestABRMuxing(t *testing.T) {
 		EncWidth:           1280,
 		XcType:             avpipe.XcVideo,
 		StreamId:           -1,
-		NumAudio:           -1,
 		Url:                url,
 		DebugFrameLevel:    debugFrameLevel,
 		ForceKeyInt:        48,

--- a/elvxc/cmd/transcode.go
+++ b/elvxc/cmd/transcode.go
@@ -215,7 +215,6 @@ func (o *elvxcOutput) Stat(streamIndex int, avType avpipe.AVType, statType avpip
 }
 
 func getAudioIndexes(params *avpipe.XcParams, audioIndexes string) (err error) {
-	params.NumAudio = 0
 	if len(audioIndexes) == 0 {
 		return
 	}
@@ -227,7 +226,6 @@ func getAudioIndexes(params *avpipe.XcParams, audioIndexes string) (err error) {
 			return fmt.Errorf("Invalid audio indexes")
 		}
 		params.AudioIndex = append(params.AudioIndex, int32(index))
-		params.NumAudio++
 	}
 
 	return nil

--- a/elvxc/cmd/transcode.go
+++ b/elvxc/cmd/transcode.go
@@ -226,7 +226,7 @@ func getAudioIndexes(params *avpipe.XcParams, audioIndexes string) (err error) {
 		if err != nil {
 			return fmt.Errorf("Invalid audio indexes")
 		}
-		params.AudioIndex[params.NumAudio] = int32(index)
+		params.AudioIndex = append(params.AudioIndex, int32(index))
 		params.NumAudio++
 	}
 

--- a/live/lhr_tool_test.go
+++ b/live/lhr_tool_test.go
@@ -184,7 +184,7 @@ func TestHLSAudioOnly(t *testing.T) {
 	}
 
 	params.NumAudio = 1
-	params.AudioIndex[0] = 1
+	params.AudioIndex = []int32{1}
 
 	setupLogging()
 	outputDir := path.Join(baseOutPath, fn())
@@ -261,7 +261,7 @@ func TestHLSAudioVideoLive(t *testing.T) {
 	}
 
 	audioParams.NumAudio = 1
-	audioParams.AudioIndex[0] = 1
+	audioParams.AudioIndex = []int32{1}
 
 	go func(reader io.Reader) {
 		tlog.Info("audio mez Xc start", "params", fmt.Sprintf("%+v", *audioParams))
@@ -316,7 +316,7 @@ func TestHLSAudioVideoLive(t *testing.T) {
 
 	// Create audio dash segments out of audio mezzanines
 	audioParams.Format = "dash"
-	audioParams.AudioIndex[0] = 0
+	audioParams.AudioIndex = []int32{0}
 	audioParams.AudioSegDurationTs = 2 * 48000
 	audioMezFiles := [3]string{"audio-mez-segment-1.mp4", "audio-mez-segment-2.mp4", "audio-mez-segment-3.mp4"}
 	go func() {

--- a/live/lhr_tool_test.go
+++ b/live/lhr_tool_test.go
@@ -183,7 +183,6 @@ func TestHLSAudioOnly(t *testing.T) {
 		StreamId:        -1,
 	}
 
-	params.NumAudio = 1
 	params.AudioIndex = []int32{1}
 
 	setupLogging()
@@ -260,7 +259,6 @@ func TestHLSAudioVideoLive(t *testing.T) {
 		StreamId:        -1,
 	}
 
-	audioParams.NumAudio = 1
 	audioParams.AudioIndex = []int32{1}
 
 	go func(reader io.Reader) {

--- a/live/rtmp_recorder_test.go
+++ b/live/rtmp_recorder_test.go
@@ -2,10 +2,11 @@ package live
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"path"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/eluv-io/avpipe"
 )
@@ -44,7 +45,7 @@ func TestRtmpToMp4_1(t *testing.T) {
 	}
 
 	xcParams.NumAudio = 1
-	xcParams.AudioIndex[0] = 1
+	xcParams.AudioIndex = []int32{1}
 	// Transcode audio mez files in background
 	reqCtx := &testCtx{url: url}
 	putReqCtxByURL(url, reqCtx)
@@ -165,7 +166,7 @@ func TestRtmpToMp4WithCancelling0(t *testing.T) {
 	}
 
 	xcParams.NumAudio = 1
-	xcParams.AudioIndex[0] = 1
+	xcParams.AudioIndex = []int32{1}
 	// Transcode audio/video mez files in background
 	reqCtx := &testCtx{url: url}
 	putReqCtxByURL(url, reqCtx)
@@ -236,7 +237,7 @@ func TestRtmpToMp4WithCancelling1(t *testing.T) {
 	}
 
 	xcParams.NumAudio = 1
-	xcParams.AudioIndex[0] = 1
+	xcParams.AudioIndex = []int32{1}
 	// Transcode audio/video mez files in background
 	reqCtx := &testCtx{url: url}
 	putReqCtxByURL(url, reqCtx)
@@ -307,7 +308,7 @@ func TestRtmpToMp4WithCancelling2(t *testing.T) {
 	}
 
 	xcParams.NumAudio = 1
-	xcParams.AudioIndex[0] = 1
+	xcParams.AudioIndex = []int32{1}
 	// Transcode audio/video mez files in background
 	reqCtx := &testCtx{url: url}
 	putReqCtxByURL(url, reqCtx)

--- a/live/rtmp_recorder_test.go
+++ b/live/rtmp_recorder_test.go
@@ -44,7 +44,6 @@ func TestRtmpToMp4_1(t *testing.T) {
 		Listen:              true,
 	}
 
-	xcParams.NumAudio = 1
 	xcParams.AudioIndex = []int32{1}
 	// Transcode audio mez files in background
 	reqCtx := &testCtx{url: url}
@@ -75,7 +74,6 @@ func TestRtmpToMp4_1(t *testing.T) {
 
 	xcParams.Format = "dash"
 	xcParams.Dcodec2 = "aac"
-	xcParams.NumAudio = 0
 	xcParams.AudioSegDurationTs = 96000 // almost 2 * 48000
 	xcParams.XcType = avpipe.XcAudio
 	audioMezFiles := [2]string{"audio-mez-segment0-1.mp4", "audio-mez-segment0-2.mp4"}
@@ -165,7 +163,6 @@ func TestRtmpToMp4WithCancelling0(t *testing.T) {
 		Listen:              true,
 	}
 
-	xcParams.NumAudio = 1
 	xcParams.AudioIndex = []int32{1}
 	// Transcode audio/video mez files in background
 	reqCtx := &testCtx{url: url}
@@ -236,7 +233,6 @@ func TestRtmpToMp4WithCancelling1(t *testing.T) {
 		Listen:              true,
 	}
 
-	xcParams.NumAudio = 1
 	xcParams.AudioIndex = []int32{1}
 	// Transcode audio/video mez files in background
 	reqCtx := &testCtx{url: url}
@@ -307,7 +303,6 @@ func TestRtmpToMp4WithCancelling2(t *testing.T) {
 		Listen:              true,
 	}
 
-	xcParams.NumAudio = 1
 	xcParams.AudioIndex = []int32{1}
 	// Transcode audio/video mez files in background
 	reqCtx := &testCtx{url: url}

--- a/live/rtmp_recorder_test.go
+++ b/live/rtmp_recorder_test.go
@@ -74,6 +74,7 @@ func TestRtmpToMp4_1(t *testing.T) {
 
 	xcParams.Format = "dash"
 	xcParams.Dcodec2 = "aac"
+	xcParams.AudioIndex = nil
 	xcParams.AudioSegDurationTs = 96000 // almost 2 * 48000
 	xcParams.XcType = avpipe.XcAudio
 	audioMezFiles := [2]string{"audio-mez-segment0-1.mp4", "audio-mez-segment0-2.mp4"}

--- a/live/ts_recorder_test.go
+++ b/live/ts_recorder_test.go
@@ -2,10 +2,11 @@ package live
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"path"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/eluv-io/avpipe"
 )
@@ -151,9 +152,7 @@ func TestMultiAudioUdpToMp4(t *testing.T) {
 		NumAudio:            3,
 	}
 
-	xcParams.AudioIndex[0] = 1
-	xcParams.AudioIndex[1] = 2
-	xcParams.AudioIndex[2] = 3
+	xcParams.AudioIndex = []int32{1, 2, 3}
 
 	// Transcode audio mez files in background
 	reqCtx := &testCtx{url: url}
@@ -171,7 +170,7 @@ func TestMultiAudioUdpToMp4(t *testing.T) {
 	done := make(chan bool, 1)
 
 	xcParams.NumAudio = 1
-	xcParams.AudioIndex[0] = 0
+	xcParams.AudioIndex = []int32{0}
 	xcParams.Format = "dash"
 	xcParams.Dcodec2 = "aac"
 	xcParams.AudioSegDurationTs = 96106 // almost 2 * 48000

--- a/live/ts_recorder_test.go
+++ b/live/ts_recorder_test.go
@@ -149,7 +149,6 @@ func TestMultiAudioUdpToMp4(t *testing.T) {
 		Url:                 url,
 		SyncAudioToStreamId: -1,
 		DebugFrameLevel:     debugFrameLevel,
-		NumAudio:            3,
 	}
 
 	xcParams.AudioIndex = []int32{1, 2, 3}
@@ -169,7 +168,6 @@ func TestMultiAudioUdpToMp4(t *testing.T) {
 
 	done := make(chan bool, 1)
 
-	xcParams.NumAudio = 1
 	xcParams.AudioIndex = []int32{0}
 	xcParams.Format = "dash"
 	xcParams.Dcodec2 = "aac"


### PR DESCRIPTION
The go side of the audio index is a little awkward because of the audio index array always taking up the full amount of audios, which makes the marshalled transcode parameters harder to read. Additionally, there can be a mismatch between the number of audios and the number of assigned audio indices, which this PR removes.

This is largely a nonfunctional PR, as everything should really remain the same. The C side should be identical.

It corresponds to another PR of the same branch name on content-fabric.