### PR TITLE
Address deprecation warning

### DIFF
--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -2009,12 +2009,6 @@ encode_frame(
     if (skip)
         return eav_success;
 
-    AVPacket *output_packet = av_packet_alloc();
-    if (!output_packet) {
-        elv_dbg("could not allocate memory for output packet");
-        return eav_mem_alloc;
-    }
-
     // Prepare packet before encoding - adjust PTS and IDR frame signaling
     if (frame) {
 
@@ -2098,12 +2092,13 @@ encode_frame(
             encoder_context->video_last_pts_sent_encode = frame->pts;
     }
 
-    while (ret >= 0) {
-        /* The packet must be initialized before receiving */
-        av_init_packet(output_packet);
-        output_packet->data = NULL;
-        output_packet->size = 0;
+    AVPacket *output_packet = av_packet_alloc();
+    if (!output_packet) {
+        elv_dbg("could not allocate memory for output packet");
+        return eav_mem_alloc;
+    }
 
+    while (ret >= 0) {
         // Get the output packet from encoder
         ret = avcodec_receive_packet(codec_context, output_packet);
 
@@ -2272,6 +2267,9 @@ encode_frame(
             rc = eav_write_frame;
             break;
         }
+
+        /* Reset the packet to receive the next frame */
+        av_packet_unref(output_packet);
     }
 
 end_encode_frame:


### PR DESCRIPTION
Remove use of deprecated `av_init_packet`. 

I also updated the examples, but the real codepath is only in `avpipe_xc.c`. `av_packet_alloc` initializes all fields to default, and `av_packet_unref` will also reset fields to default. 

Went over this in detail with Serban, so it should be safe. 