### PR TITLE
Detect missing codec parameters

### DIFF
--- a/avpipe.c
+++ b/avpipe.c
@@ -446,7 +446,7 @@ read_channel_again:
         if (rc == ETIMEDOUT) {
             if (c->is_udp_started) {
                 elv_log("TIMEDOUT in UDP rcv channel, url=%s", c->url);
-                return -1;
+                return AVERROR(ETIMEDOUT);
             }
             goto read_channel_again;
         }

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -504,7 +504,8 @@ prepare_decoder(
                  * fail in this case, as it assumes that height/width/pixel info is set accurately.
                  * 
                  * In particular, this case can sometimes be triggered by the content-fabric
-                 * integration test that tests live restarts.
+                 * integration test that tests live restarts. In that case, it's been observed that
+                 * retrying the probe entirely fixes the issue.
                  * 
                  * See libavformat/utils.c:has_codec_parameters for the checks in ffmpeg internals. */
                 elv_err("avformat_find_stream_info failed to get input stream info");

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -509,7 +509,7 @@ prepare_decoder(
                  * 
                  * See libavformat/utils.c:has_codec_parameters for the checks in ffmpeg internals. */
                 elv_err("avformat_find_stream_info failed to get input stream info");
-                return eav_read_input;
+                return eav_stream_info;
             }
             break;
 

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -3705,9 +3705,10 @@ avpipe_xc(
         if (rc < 0) {
             av_packet_free(&input_packet);
             av_read_frame_rc = rc;
-            if (rc == AVERROR_EOF || rc == -1)
+            if (rc == AVERROR_EOF || rc == -1) {
+                elv_log("av_read_frame() EOF or -1 rc=%d, url=%s", rc, params->url);
                 rc = eav_success;
-            else {
+            } else {
                 elv_err("av_read_frame() rc=%d, url=%s", rc, params->url);
                 rc = eav_read_input;
             }

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -453,7 +453,8 @@ prepare_decoder(
         av_dict_set(&opts, "timeout", timeout, 0);
     } else if (decoder_context->is_srt && params->listen && params->connection_timeout > 0) {
         char timeout[32];
-        sprintf(timeout, "%d", params->connection_timeout * 1000000);
+        long long int connection_timeout_micros = MICRO_IN_SEC * params->connection_timeout;
+        sprintf(timeout, "%lld", connection_timeout_micros);
         /* SRT timeout is in microseconds */
         av_dict_set(&opts, "listen_timeout", timeout, 0);
     }

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -451,6 +451,11 @@ prepare_decoder(
         char timeout[32];
         sprintf(timeout, "%d", params->connection_timeout);
         av_dict_set(&opts, "timeout", timeout, 0);
+    } else if (decoder_context->is_srt && params->listen && params->connection_timeout > 0) {
+        char timeout[32];
+        sprintf(timeout, "%d", params->connection_timeout * 1000000);
+        /* SRT timeout is in microseconds */
+        av_dict_set(&opts, "listen_timeout", timeout, 0);
     }
 
     /* Allocate AVFormatContext in format_context and find input file format */


### PR DESCRIPTION
The comment describes how this happens pretty well. This change, and the error that it returns being recoverable together result in the removal of `eav_filter_init` from the list of recoverable errors.

I'm open to suggestions on which type of error, but I think either `eav_read_input` or `eav_open_input` are the correct ones. It's hard to say.