### PR TITLE
Set profile/level if exist in the parameters

### DIFF
--- a/avpipe.go
+++ b/avpipe.go
@@ -241,6 +241,8 @@ type XcParams struct {
 	VideoTimeBase          int         `json:"video_time_base"`
 	VideoFrameDurationTs   int         `json:"video_frame_duration_ts"`
 	Rotate                 int         `json:"rotate"`
+	Profile                string      `json:"profile"`
+	Level                  int         `json:"level"`
 }
 
 // NewXcParams initializes a XcParams struct with unset/default values
@@ -1294,6 +1296,8 @@ func getCParams(params *XcParams) (*C.xcparams_t, error) {
 		video_time_base:           C.int(params.VideoTimeBase),
 		video_frame_duration_ts:   C.int(params.VideoFrameDurationTs),
 		rotate:                    C.int(params.Rotate),
+		profile:                   C.CString(params.Profile),
+		level:                     C.int(params.Level),
 
 		// All boolean params are handled below
 	}

--- a/elvxc/cmd/transcode.go
+++ b/elvxc/cmd/transcode.go
@@ -324,6 +324,8 @@ func InitTranscode(cmdRoot *cobra.Command) error {
 	cmdTranscode.PersistentFlags().StringP("extract-images-ts", "", "", "the frames to extract (PTS, comma separated).")
 	cmdTranscode.PersistentFlags().BoolP("seekable", "", true, "seekable stream.")
 	cmdTranscode.PersistentFlags().Int32("rotate", 0, "Rotate the output video frame (valid values 0, 90, 180, 270).")
+	cmdTranscode.PersistentFlags().StringP("profile", "", "", "Encoding profile for video. If it is not determined, it will be set automatically.")
+	cmdTranscode.PersistentFlags().Int32("level", 0, "Encoding level for video. If it is not determined, it will be set automatically.")
 
 	return nil
 }
@@ -602,6 +604,13 @@ func doTranscode(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Invalid rotate value")
 	}
 
+	level, err := cmd.Flags().GetInt32("level")
+	if err != nil {
+		return fmt.Errorf("Invalid level value")
+	}
+
+	profile := cmd.Flag("profile").Value.String()
+
 	cryptScheme := avpipe.CryptNone
 	val := cmd.Flag("crypt-scheme").Value.String()
 	if len(val) > 0 {
@@ -698,6 +707,8 @@ func doTranscode(cmd *cobra.Command, args []string) error {
 		VideoFrameDurationTs:   int(videoFrameDurationTs),
 		Seekable:               seekable,
 		Rotate:                 int(rotate),
+		Profile:                profile,
+		Level:                  int(level),
 	}
 
 	err = getAudioIndexes(params, audioIndex)

--- a/exc/elv_xc.c
+++ b/exc/elv_xc.c
@@ -1045,6 +1045,7 @@ usage(
         "\t                                    Using \"fmp4-segment\" generates segments that are appropriate for live streaming.\n"
         "\t-force-keyint :          (optional) Force IDR key frame in this interval.\n"
         "\t-gpu-index :             (optional) Use the GPU with specified index for transcoding (export CUDA_DEVICE_ORDER=PCI_BUS_ID would use smi index).\n"
+        "\t-level:                  (optional) Encoding level for video. If it is not determined, it will be set automatically.\n"
         "\t-listen:                 (optional) Listen mode for RTMP. Must be 0 or 1, by default is on (value 1)\n"
         "\t-log-size:               (optional) Log size in MB. Default is 100MB.\n"
         "\t-master-display :        (optional) Master display, only valid if encoder is libx265.\n"
@@ -1053,6 +1054,10 @@ usage(
         "\t-mux-spec :              (optional) Muxing spec file.\n"
         "\t-preset :                (optional) Preset string to determine compression speed. Default is \"medium\". Valid values are: \"ultrafast\", \"superfast\",\n"
         "\t                                    \"veryfast\", \"faster\", \"fast\", \"medium\", \"slow\", \"slower\", \"veryslow\".\n"
+        "\t-profile :               (optional) Encoding profile for video. If it is not determined, it will be set automatically.\n"
+        "\t                                    Valid H264 profiles: \"baseline\", \"main\", \"extended\", \"high\", \"high10\", \"high422\", \"high444\"\n"
+        "\t                                    Valid H265 profiles: \"main\", \"main10\"\n"
+        "\t                                    Valid NVIDIA H264 profiles: \"baseline\", \"main\", \"high\", \"high444p\"\n"
         "\t-r :                     (optional) number of repeats. Default is 1 repeat, must be bigger than 1\n"
         "\t-rc-buffer-size :        (optional) Determines the interval used to limit bit rate\n"
         "\t-rc-max-rate :           (optional) Maximum encoding bit rate, used in conjuction with rc-buffer-size\n"
@@ -1356,7 +1361,11 @@ main(
             }
             break;
         case 'l':
-            if (!strcmp(argv[i], "-listen")) {
+            if (!strcmp(argv[i], "-level")) {
+                if (sscanf(argv[i+1], "%d", &p.level) != 1) {
+                    usage(argv[0], argv[i], EXIT_FAILURE);
+                }
+            } else if (!strcmp(argv[i], "-listen")) {
                 if (sscanf(argv[i+1], "%d", &p.listen) != 1) {
                     usage(argv[0], argv[i], EXIT_FAILURE);
                 }
@@ -1388,6 +1397,8 @@ main(
         case 'p':
             if (!strcmp(argv[i], "-preset")) {
                 p.preset = strdup(argv[i+1]);
+            } else if (!strcmp(argv[i], "-profile")) {
+                p.profile = strdup(argv[i+1]);
             } else {
                 usage(argv[0], argv[i], EXIT_FAILURE);
             }

--- a/libavpipe/include/avpipe_xc.h
+++ b/libavpipe/include/avpipe_xc.h
@@ -25,6 +25,14 @@
 
 //#define DEBUG_UDP_PACKET  // Uncomment for development, debugging and testing
 
+/* Borrowed from libavcodec/nvenc.h since it is not exposed */
+enum {
+    NV_ENC_H264_PROFILE_BASELINE,
+    NV_ENC_H264_PROFILE_MAIN,
+    NV_ENC_H264_PROFILE_HIGH,
+    NV_ENC_H264_PROFILE_HIGH_444P,
+};
+
 /*
  * Adding/deleting an error code needs adding/deleting corresponding GO
  * error in avpipe_errors.go
@@ -442,6 +450,8 @@ typedef struct xcparams_t {
     int         debug_frame_level;
     int         connection_timeout;         // Connection timeout in sec for RTMP or MPEGTS protocols
     int         rotate;                     // For video transpose or rotation
+    char        *profile;
+    int         level;
 } xcparams_t;
 
 #define MAX_CODEC_NAME  256
@@ -450,9 +460,11 @@ typedef struct side_data_display_matrix_t {
     double rotation;    // Original rotation is CCW with values from -180 to 180
     double rotation_cw; // Computed CW rotation with values 0 to 360
 } side_data_display_matrix_t;
+
 typedef struct side_data_t {
     side_data_display_matrix_t display_matrix;
 } side_data_t;
+
 typedef struct stream_info_t {
     int         stream_index;       // Stream index in AVFormatContext
     int         stream_id;          // Format-specific stream ID, set by libavformat during decoding
@@ -740,6 +752,51 @@ avpipe_h264_guess_profile(
     int bitdepth,
     int width,
     int height);
+
+/**
+ * @brief   Helper function to obtain FFmpeg constant for an h264 profile name. 
+ * 
+ * @param   profile_name  A pointer to the profile name.
+ * @return  Returns the FFmpeg constant if profile name is valid.
+ *          Returns 0 if profile name is NULL. For invalid profile name return -1.
+ */
+int
+avpipe_h264_profile(
+    char *profile_name);
+
+
+/**
+ * @brief   Helper function to obtain FFmpeg constant for an h265 profile name. 
+ * 
+ * @param   profile_name  A pointer to the profile name.
+ * @return  Returns the FFmpeg constant if profile name is valid.
+ *          Returns 0 if profile name is NULL. For invalid profile name return -1.
+ */
+int
+avpipe_h265_profile(
+    char *profile_name);
+
+/**
+ * @brief   Helper function to obtain FFmpeg constant for an nvidia h265 profile name. 
+ * 
+ * @param   profile_name  A pointer to the profile name.
+ * @return  Returns the FFmpeg constant if profile name is valid.
+ *          Returns 0 if profile name is NULL. For invalid profile name return -1.
+ */
+int
+avpipe_nvh264_profile(
+    char *profile_name);
+
+/**
+ * @brief   Helper function to check level. 
+ * 
+ * @param   level
+ * @return  Returns the FFmpeg constant if profile name is valid.
+ *          Returns 0 if profile name is NULL. For invalid profile name return -1.
+ */
+int
+avpipe_check_level(
+    int level);
 
 /**
  * @brief   Helper function to deep copy an xc_params. In the case of OOM, may fail to initialize

--- a/libavpipe/include/avpipe_xc.h
+++ b/libavpipe/include/avpipe_xc.h
@@ -777,7 +777,7 @@ avpipe_h265_profile(
     char *profile_name);
 
 /**
- * @brief   Helper function to obtain FFmpeg constant for an nvidia h265 profile name. 
+ * @brief   Helper function to obtain FFmpeg constant for an nvidia h264 profile name. 
  * 
  * @param   profile_name  A pointer to the profile name.
  * @return  Returns the FFmpeg constant if profile name is valid.
@@ -791,8 +791,7 @@ avpipe_nvh264_profile(
  * @brief   Helper function to check level. 
  * 
  * @param   level
- * @return  Returns the FFmpeg constant if profile name is valid.
- *          Returns 0 if profile name is NULL. For invalid profile name return -1.
+ * @return  Returns 1 if the level is valid, otherwise return -1 for an invalid level.
  */
 int
 avpipe_check_level(

--- a/libavpipe/src/avpipe_level.c
+++ b/libavpipe/src/avpipe_level.c
@@ -317,5 +317,5 @@ avpipe_check_level(
             return 1;
     }
 
-    return 0;
+    return -1;
 }

--- a/libavpipe/src/avpipe_level.c
+++ b/libavpipe/src/avpipe_level.c
@@ -307,7 +307,7 @@ int
 avpipe_check_level(
     int level)
 {
-    static int levels[] = {10, 11, 12, 13, 20, 21, 22, 30, 31, 32, 40, 41, 42, 50, 51, 52, 60, 61, 62};
+    static int levels[] = {9, 10, 11, 12, 13, 20, 21, 22, 30, 31, 32, 40, 41, 42, 50, 51, 52, 60, 61, 62};
 
     if (level <= 0)
         return 1;

--- a/libavpipe/src/avpipe_level.c
+++ b/libavpipe/src/avpipe_level.c
@@ -217,3 +217,105 @@ avpipe_h264_guess_profile(
 
     return profile;
 }
+
+/*
+ * Returns corresponding h264 FFmpeg profile constant if it does exist.
+ * Returns 0 if profile name is not set.
+ * Returns -1 if the profile name is set but not supported.
+ */
+int
+avpipe_h264_profile(
+    char *profile_name)
+{
+    if (!profile_name || strlen(profile_name) == 0)
+        return 0;
+
+    if (!strcmp(profile_name, "baseline"))
+        return FF_PROFILE_H264_BASELINE;
+
+    if (!strcmp(profile_name, "main"))
+        return FF_PROFILE_H264_MAIN;
+
+    if (!strcmp(profile_name, "extended"))
+        return FF_PROFILE_H264_EXTENDED;
+
+    if (!strcmp(profile_name, "high"))
+        return FF_PROFILE_H264_HIGH;
+
+    if (!strcmp(profile_name, "high10"))
+        return FF_PROFILE_H264_HIGH_10;
+
+    if (!strcmp(profile_name, "high422"))
+        return FF_PROFILE_H264_HIGH_422;
+
+    if (!strcmp(profile_name, "high444"))
+        return FF_PROFILE_H264_HIGH_444;
+
+    return -1;
+}
+
+
+/*
+ * Returns corresponding h265 FFmpeg profile constant if it does exist.
+ * Returns 0 if profile name is not set.
+ * Returns -1 if the profile name is set but not supported.
+ */
+int
+avpipe_h265_profile(
+    char *profile_name)
+{
+    if (!profile_name || strlen(profile_name) == 0)
+        return 0;
+
+    if (!strcmp(profile_name, "main"))
+        return FF_PROFILE_HEVC_MAIN;
+
+    if (!strcmp(profile_name, "main10"))
+        return FF_PROFILE_HEVC_MAIN_10;
+
+    return -1;
+}
+
+/*
+ * Returns corresponding nvidia h264 FFmpeg profile constant if it does exist.
+ * Returns 0 if profile name is not set.
+ * Returns -1 if the profile name is set but not supported.
+ */
+int
+avpipe_nvh264_profile(
+    char *profile_name)
+{
+    if (!profile_name || strlen(profile_name) == 0)
+        return 0;
+
+    if (!strcmp(profile_name, "baseline"))
+        return NV_ENC_H264_PROFILE_BASELINE;
+
+    if (!strcmp(profile_name, "main"))
+        return NV_ENC_H264_PROFILE_MAIN;
+
+    if (!strcmp(profile_name, "high"))
+        return NV_ENC_H264_PROFILE_HIGH;
+
+    if (!strcmp(profile_name, "high444p"))
+        return NV_ENC_H264_PROFILE_HIGH_444P;
+
+    return -1;
+}
+
+int
+avpipe_check_level(
+    int level)
+{
+    static int levels[] = {10, 11, 12, 13, 20, 21, 22, 30, 31, 32, 40, 41, 42, 50, 51, 52, 60, 61, 62};
+
+    if (level <= 0)
+        return 1;
+
+    for (int i=0; i<sizeof(levels)/sizeof(int); i++) {
+        if (levels[i] == level)
+            return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
issue: https://github.com/eluv-io/avpipe/issues/61

- Add new fields profile/level to xc params
- Enforce profile/level if they exist in the xc params
- Add a unit test for setting profile/level