### PR TITLE
Mux modification

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ The following repositories can be checked out in any directory, but for better o
   - `gsutil -m cp 'gs://eluvio-test-assets/*' .`
 - Inside _<avpipe-path>_ run
   - `go test -timeout 2000s`
+- Instead of the above commands, you can run the following scripts:
+  - `run_tests.sh` to run avpipe core functionality and transcoding tests.
+  - `run_live_tests.sh`: to run avipe live-streaming functionality tests.
   
 # Design
 - Avpipe library has been built on top of the different libraries of ffmpeg, the most important ones are libx264, libx265, libavcodec, libavformat, libavfilter and libswresample. But in order to achieve all the features and capabilities some parts of ffmpeg library have been changed. Avpipe library is capable of transcoding or probing an input source (i.e a media file, or an UDP/RTMP stream) and producing output media or probe results. In order to start a transcoding job the transcoding parameters have to be set.
@@ -152,7 +155,7 @@ typedef struct xcparams_t {
 - **Extracting images:** avpipe library can extract images either using a time interval or specific timestamps. 
 - **HDR support:** avpipe library allows to create HDR output while transcoding with H.265 encoder. To make an HDR content two parameters max_cll and master_display have to be set.
 - **Bypass feature:** setting bypass_transcoding to 1, would avoid transcoding and copies the input packets to output. This feature is very useful (saves a lot of CPU and time) when input data matches with output and we can skip transcoding.
-- **Muxing audio/video ABR segments and creating MP4 files:** this feature allows the creation of MP4 files from transcoded audio/video segments. In order to do this a muxing spec has to be made to tell avpipe which ABR segments should be stitched together to produce the final MP4. To make this feature working xc_type should be set to xc_mux and the mux_spec param should point to a buffer containing muxing spec.
+- **Muxing audio/video ABR segments and creating fMP4/MP4 files:** this feature allows the creation of fMP4/MP4 files from transcoded audio/video segments. In order to do this a muxing spec has to be made to tell avpipe which ABR segments should be stitched together to produce the final fMP4/MP4. To make this feature working xc_type should be set to xc_mux and the mux_spec param should point to a buffer containing muxing spec. If the format is 'fmp4-segment' the output will be fMP4, otherwise MP4.
 - **Transcoding from specific timebase offset:** the parameter start_time_ts can be used to skip some input and transcode from specified TS in start_time_ts. This feature is also very useful to start transcoding from a certain point and not from the beginning of file/stream.
 - **Audio join/pan/merge filters:**
   - setting xc_type = xc_audio_join would join 2 or more audio inputs and create a new audio output (for example joining two mono streams and creating one stereo).

--- a/avpipe.c
+++ b/avpipe.c
@@ -473,7 +473,7 @@ read_channel_again:
             free(udp_packet);
         }
         if (debug_frame_level)
-            elv_dbg("IN READ UDP read=%d pos=%"PRId64" total=%"PRId64", url=%s", r, c->read_pos, c->read_bytes, c->url);
+            elv_dbg("IN READ UDP read=%d, pos=%"PRId64", total=%"PRId64", url=%s", r, c->read_pos, c->read_bytes, c->url);
     }
 
     return r;
@@ -651,7 +651,7 @@ out_write_packet(
     }
 
     if (xcparams && xcparams->debug_frame_level)
-        elv_dbg("OUT WRITE stream_index=%d, fd=%"PRId64", size=%d written=%d pos=%d total=%d",
+        elv_dbg("OUT WRITE stream_index=%d, fd=%"PRId64", size=%d, written=%d, pos=%d, total=%d",
             outctx->stream_index, fd, buf_size, bwritten, outctx->write_pos, outctx->written_bytes);
 
     return buf_size;
@@ -667,7 +667,7 @@ out_seek(
     ioctx_t *inctx = outctx->inctx;
     int64_t h = *((int64_t *)(inctx->opaque));
     int64_t fd = *(int64_t *)outctx->opaque;
-    int rc = AVPipeSeekOutput(h, fd, offset, whence);
+    int64_t rc = AVPipeSeekOutput(h, fd, offset, whence);
     whence = whence & 0xFFFF; /* Mask out AVSEEK_SIZE and AVSEEK_FORCE */
     switch (whence) {
     case SEEK_SET:
@@ -680,7 +680,7 @@ out_seek(
         elv_dbg("OUT SEEK - weird seek\n");
     }
 
-    elv_dbg("OUT SEEK fd=%"PRId64" offset=%d whence=%d", fd, offset, whence);
+    elv_dbg("OUT SEEK fd=%"PRId64", offset=%d, whence=%d, rc=%"PRId64, fd, offset, whence, rc);
 
     return rc;
 }

--- a/avpipe.c
+++ b/avpipe.c
@@ -1100,18 +1100,18 @@ read_next_input:
         if (index == 0) {
             /* Reached end of videos */
             if (in_mux_ctx->video.index >= in_mux_ctx->video.n_parts)
-                return -1;
+                return AVERROR_EOF;
             filepath = in_mux_ctx->video.parts[in_mux_ctx->video.index];
             in_mux_ctx->video.index++;
         } else if (index <= in_mux_ctx->last_audio_index) {
             if (in_mux_ctx->audios[index-1].index >= in_mux_ctx->audios[index-1].n_parts)
-                return -1;
+                return AVERROR_EOF;
             filepath = in_mux_ctx->audios[index-1].parts[in_mux_ctx->audios[index-1].index];
             in_mux_ctx->audios[index-1].index++;
         } else if (index <= in_mux_ctx->last_audio_index+in_mux_ctx->last_caption_index) {
             i = index - in_mux_ctx->last_audio_index - 1;
             if (in_mux_ctx->captions[i].index >= in_mux_ctx->captions[i].n_parts)
-                return -1;
+                return AVERROR_EOF;
             filepath = in_mux_ctx->captions[i].parts[in_mux_ctx->captions[i].index];
             in_mux_ctx->captions[i].index++;
         } else {

--- a/avpipe.c
+++ b/avpipe.c
@@ -607,7 +607,7 @@ out_opener(
         return -1;
     }
 
-    outctx->opaque = (int *) malloc(sizeof(int64_t));
+    outctx->opaque = (int64_t *) malloc(sizeof(int64_t));
     *((int64_t *)(outctx->opaque)) = fd;
 
     return 0;

--- a/avpipe.c
+++ b/avpipe.c
@@ -61,8 +61,8 @@ int64_t AVPipeOpenOutput(int64_t, int, int, int64_t, int);
 int64_t AVPipeOpenMuxOutput(char *, int);
 int     AVPipeWriteOutput(int64_t, int64_t, uint8_t *, int);
 int     AVPipeWriteMuxOutput(int64_t, uint8_t *, int);
-int     AVPipeSeekOutput(int64_t, int64_t, int64_t, int);
-int     AVPipeSeekMuxOutput(int64_t, int64_t, int);
+int64_t AVPipeSeekOutput(int64_t, int64_t, int64_t, int);
+int64_t AVPipeSeekMuxOutput(int64_t, int64_t, int);
 int     AVPipeCloseOutput(int64_t, int64_t);
 int     AVPipeCloseMuxOutput(int64_t);
 int     AVPipeStatOutput(int64_t, int64_t, int, avpipe_buftype_t, avp_stat_t, void *);
@@ -1255,7 +1255,7 @@ out_mux_seek(
     ioctx_t *inctx = outctx->inctx;
     xcparams_t *xcparams = (inctx != NULL) ? inctx->params : NULL;
     int64_t fd = *(int64_t *)outctx->opaque;
-    int rc = AVPipeSeekMuxOutput(fd, offset, whence);
+    int64_t rc = AVPipeSeekMuxOutput(fd, offset, whence);
     if (xcparams != NULL && xcparams->debug_frame_level)
         elv_dbg("OUT MUX SEEK fd=%"PRId64" offset=%d whence=%d", fd, offset, whence);
     return rc;

--- a/avpipe.go
+++ b/avpipe.go
@@ -1015,36 +1015,36 @@ func (h *ioHandler) OutWriter(fd C.int64_t, buf []byte) (int, error) {
 }
 
 //export AVPipeSeekOutput
-func AVPipeSeekOutput(handler C.int64_t, fd C.int64_t, offset C.int64_t, whence C.int) C.int {
+func AVPipeSeekOutput(handler C.int64_t, fd C.int64_t, offset C.int64_t, whence C.int) C.int64_t {
 	gMutex.Lock()
 	h := gHandlers[int64(handler)]
 	if h == nil {
 		gMutex.Unlock()
-		return C.int(-1)
+		return C.int64_t(-1)
 	}
 	gMutex.Unlock()
 	n, err := h.OutSeeker(fd, offset, whence)
 	if err != nil {
-		return C.int(-1)
+		return C.int64_t(-1)
 	}
-	return C.int(n)
+	return C.int64_t(n)
 }
 
 //export AVPipeSeekMuxOutput
-func AVPipeSeekMuxOutput(fd C.int64_t, offset C.int64_t, whence C.int) C.int {
+func AVPipeSeekMuxOutput(fd C.int64_t, offset C.int64_t, whence C.int) C.int64_t {
 	gMutex.Lock()
 	outHandler := gMuxHandlers[int64(fd)]
 	if outHandler == nil {
 		gMutex.Unlock()
-		return C.int(-1)
+		return C.int64_t(-1)
 	}
 	gMutex.Unlock()
 
 	n, err := outHandler.Seek(int64(offset), int(whence))
 	if err != nil {
-		return C.int(-1)
+		return C.int64_t(-1)
 	}
-	return C.int(n)
+	return C.int64_t(n)
 }
 
 func (h *ioHandler) OutSeeker(fd C.int64_t, offset C.int64_t, whence C.int) (int64, error) {

--- a/avpipe.go
+++ b/avpipe.go
@@ -39,6 +39,7 @@ import "C"
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"math/big"
 	"sync"
 	"unsafe"
@@ -117,6 +118,13 @@ const (
 	XcProfileH264Heigh              = C.FF_PROFILE_H264_HIGH     // 100
 	XcProfileH264Heigh10            = C.FF_PROFILE_H264_HIGH_10  // 110
 )
+
+type SeekReadWriteCloser interface {
+	io.Seeker
+	io.Reader
+	io.Writer
+	io.Closer
+}
 
 func XcTypeFromString(xcTypeStr string) XcType {
 	var xcType XcType

--- a/avpipe.go
+++ b/avpipe.go
@@ -1380,6 +1380,7 @@ func Mux(params *XcParams) error {
 		return EAV_PARAM
 	}
 
+	params.XcType = XcMux
 	cparams, err := getCParams(params)
 	if err != nil {
 		log.Error("Muxing failed", err, "url", params.Url)

--- a/elvxc/cmd/mux.go
+++ b/elvxc/cmd/mux.go
@@ -218,6 +218,7 @@ func doMux(cmd *cobra.Command, args []string) error {
 		MuxingSpec:      string(muxSpec),
 		Url:             filename,
 		DebugFrameLevel: true,
+		Format:          "fmp4-segment",
 	}
 
 	avpipe.InitUrlMuxIOHandler(filename, &AVCmdMuxInputOpener{URL: filename}, &AVCmdMuxOutputOpener{})

--- a/elvxc/cmd/mux.go
+++ b/elvxc/cmd/mux.go
@@ -192,6 +192,7 @@ func InitMux(cmdRoot *cobra.Command) error {
 
 	cmdTranscode.PersistentFlags().StringP("filename", "f", "", "(mandatory) muxing output filename.")
 	cmdTranscode.PersistentFlags().String("mux-spec", "", "(mandatory) muxing spec file.")
+	cmdTranscode.PersistentFlags().StringP("format", "", "fmp4-segment", "package format, can be 'dash', 'hls', 'mp4', 'fmp4', 'segment', 'fmp4-segment', or 'image2'.")
 
 	return nil
 }
@@ -208,6 +209,10 @@ func doMux(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("mux-spec is needed to do muxing")
 	}
 
+	format := cmd.Flag("format").Value.String()
+	if format != "dash" && format != "hls" && format != "mp4" && format != "fmp4" && format != "segment" && format != "fmp4-segment" && format != "image2" {
+		return fmt.Errorf("Package format is not valid, can be 'dash', 'hls', 'mp4', 'fmp4', 'segment', 'fmp4-segment', or 'image2'")
+	}
 	muxSpec, err := ioutil.ReadFile(muxSpecFile)
 	if err != nil {
 		return fmt.Errorf("Could not read mux-spec file %s", muxSpecFile)
@@ -218,7 +223,7 @@ func doMux(cmd *cobra.Command, args []string) error {
 		MuxingSpec:      string(muxSpec),
 		Url:             filename,
 		DebugFrameLevel: true,
-		Format:          "fmp4-segment",
+		Format:          format,
 	}
 
 	avpipe.InitUrlMuxIOHandler(filename, &AVCmdMuxInputOpener{URL: filename}, &AVCmdMuxOutputOpener{})

--- a/exc/elv_mux.c
+++ b/exc/elv_mux.c
@@ -99,18 +99,18 @@ read_next_input:
         if (index == 0) {
             /* Reached end of videos */
             if (in_mux_ctx->video.index >= in_mux_ctx->video.n_parts)
-                return -1;
+                return AVERROR_EOF;
             filepath = in_mux_ctx->video.parts[in_mux_ctx->video.index];
             in_mux_ctx->video.index++;
         } else if (index <= in_mux_ctx->last_audio_index) {
             if (in_mux_ctx->audios[index-1].index >= in_mux_ctx->audios[index-1].n_parts)
-                return -1;
+                return AVERROR_EOF;
             filepath = in_mux_ctx->audios[index-1].parts[in_mux_ctx->audios[index-1].index];
             in_mux_ctx->audios[index-1].index++;
         } else if (index <= in_mux_ctx->last_audio_index+in_mux_ctx->last_caption_index) {
             if (in_mux_ctx->captions[index - in_mux_ctx->last_audio_index - 1].index >=
                 in_mux_ctx->captions[index - in_mux_ctx->last_audio_index - 1].n_parts)
-                return -1;
+                return AVERROR_EOF;
             filepath = in_mux_ctx->captions[index - in_mux_ctx->last_audio_index - 1].parts[in_mux_ctx->captions[index - in_mux_ctx->last_audio_index - 1].index];
             in_mux_ctx->captions[index - in_mux_ctx->last_audio_index - 1].index++;
         } else {

--- a/exc/elv_mux.c
+++ b/exc/elv_mux.c
@@ -266,7 +266,7 @@ out_mux_seek(
     ioctx_t *outctx = (ioctx_t *)opaque;
     int fd = *(int *)outctx->opaque;
 
-    int rc = lseek(fd, offset, whence);
+    int64_t rc = lseek(fd, offset, whence);
     whence = whence & 0xFFFF; /* Mask out AVSEEK_SIZE and AVSEEK_FORCE */
     switch (whence) {
     case SEEK_SET:
@@ -281,7 +281,7 @@ out_mux_seek(
         elv_err("OUT MUX SEEK - weird seek\n");
     }
 
-    elv_dbg("OUT MUX SEEK offset=%"PRId64" whence=%d rc=%d", offset, whence, rc);
+    elv_dbg("OUT MUX SEEK offset=%"PRId64" whence=%d rc=%"PRId64, offset, whence, rc);
     return rc;
 }
 

--- a/exc/elv_xc.c
+++ b/exc/elv_xc.c
@@ -1590,7 +1590,6 @@ main(
         return do_probe(&p);
     } else if (!strcmp(command, "mux")) {
         p.xc_type = xc_mux;
-        p.format = strdup("fmp4-segment");
         return do_mux(&p, filename);
     }
 

--- a/exc/elv_xc.c
+++ b/exc/elv_xc.c
@@ -1579,6 +1579,7 @@ main(
         return do_probe(&p);
     } else if (!strcmp(command, "mux")) {
         p.xc_type = xc_mux;
+        p.format = strdup("fmp4-segment");
         return do_mux(&p, filename);
     }
 

--- a/libavpipe/include/avpipe_xc.h
+++ b/libavpipe/include/avpipe_xc.h
@@ -18,7 +18,7 @@
 #include "elv_channel.h"
 
 #define MAX_STREAMS	        64
-#define MAX_MUX_IN_STREAM   (4*4096)
+#define MAX_MUX_IN_STREAM   (4*4096)        // Up to 4*4096 ABR segments
 
 #define AVIO_OUT_BUF_SIZE   (1*1024*1024)   // avio output buffer size
 #define AVIO_IN_BUF_SIZE    (1*1024*1024)   // avio input buffer size

--- a/libavpipe/include/avpipe_xc.h
+++ b/libavpipe/include/avpipe_xc.h
@@ -18,7 +18,7 @@
 #include "elv_channel.h"
 
 #define MAX_STREAMS	        64
-#define MAX_MUX_IN_STREAM   4096
+#define MAX_MUX_IN_STREAM   (4*4096)
 
 #define AVIO_OUT_BUF_SIZE   (1*1024*1024)   // avio output buffer size
 #define AVIO_IN_BUF_SIZE    (1*1024*1024)   // avio input buffer size
@@ -112,7 +112,7 @@ typedef struct udp_packet_t {
 typedef struct mux_input_ctx_t {
     int     n_parts;                    /* Number of input parts */
     int     index;                      /* Index of current input part that should be processed */
-    char    *parts[MAX_MUX_IN_STREAM];  /* All the input parts */
+    char    **parts;                    /* All the input parts */
     int     header_size;
 } mux_input_ctx_t;
 

--- a/libavpipe/src/avpipe_mux.c
+++ b/libavpipe/src/avpipe_mux.c
@@ -508,6 +508,18 @@ avpipe_mux_fini(
         free(p_xctx->inctx_muxer[i]);
     }
 
+    /* Free avioctx of the output */
+    {
+        coderctx_t *out_muxer_ctx = &p_xctx->out_muxer_ctx;
+        if (out_muxer_ctx && out_muxer_ctx->format_context) {
+            AVIOContext *avioctx = (AVIOContext *) out_muxer_ctx->format_context->pb;
+            if (avioctx) {
+                av_freep(&avioctx->buffer);
+                av_freep(&avioctx);
+            }
+        }
+    }
+
     avformat_free_context(p_xctx->out_muxer_ctx.format_context);
 
     free(in_mux_ctx->video.parts);

--- a/libavpipe/src/avpipe_mux.c
+++ b/libavpipe/src/avpipe_mux.c
@@ -463,6 +463,12 @@ avpipe_mux(
 
     av_write_trailer(xctx->out_muxer_ctx.format_context);
 
+    if (ret == AVERROR_EOF)
+        ret = 0;
+
+    elv_log("avpipe_mux done url=%s, rc=%d, xctx->err=%d",
+        xctx->params->url, ret, xctx->err);
+
     return ret;
 }
 

--- a/libavpipe/src/avpipe_mux.c
+++ b/libavpipe/src/avpipe_mux.c
@@ -399,6 +399,7 @@ read_frame_again:
     } else {
         if (ret != AVERROR_EOF)
             elv_err("Failed to read frame index=%d, ret=%d", index, ret);
+        return ret;
     }
 
     return index;

--- a/libavpipe/src/avpipe_mux.c
+++ b/libavpipe/src/avpipe_mux.c
@@ -2,6 +2,10 @@
 #include "avpipe_utils.h"
 #include "elv_log.h"
 
+void
+log_params(
+    xcparams_t *params);
+
 int
 elv_mux_open(
     struct AVFormatContext *format_ctx,
@@ -233,6 +237,8 @@ avpipe_init_muxer(
         in_mux_ctx->audios[stream].parts = (char **) calloc(MAX_MUX_IN_STREAM, sizeof(char *));
         in_mux_ctx->captions[stream].parts = (char **) calloc(MAX_MUX_IN_STREAM, sizeof(char *));
     }
+
+    log_params(p);
 
     if ((ret = init_mux_ctx(p->mux_spec, out_filename, in_mux_ctx)) != eav_success) {
         elv_err("Initializing mux context failed, ret=%d", ret);

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -3727,7 +3727,10 @@ avpipe_xc(
                 rc = eav_success;
             } else {
                 elv_err("av_read_frame() rc=%d, url=%s", rc, params->url);
-                rc = eav_read_input;
+                if (rc == AVERROR(ETIMEDOUT))
+                    rc = eav_io_timeout;
+                else
+                    rc = eav_read_input;
             }
             break;
         }

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -4186,10 +4186,14 @@ get_xc_type_name(
         return "xc_audio_pan";
     case xc_audio_merge:
         return "xc_audio_merge";
+    case xc_mux:
+        return "xc_mux";
     case xc_extract_images:
         return "xc_extract_images";
     case xc_extract_all_images:
         return "xc_extract_all_images";
+    case xc_probe:
+        return "xc_probe";
     default:
         return "none";
     }

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -1496,11 +1496,11 @@ prepare_audio_encoder(
         }
 
         elv_dbg("encoder audio stream index=%d, bitrate=%d, sample_fmts=%s, timebase=%d, output frame_size=%d, sample_rate=%d, channel_layout=%s",
-            index, encoder_context->codec_context[output_stream_index]->bit_rate,
+            stream_index, encoder_context->codec_context[output_stream_index]->bit_rate,
             av_get_sample_fmt_name(encoder_context->codec_context[output_stream_index]->sample_fmt),
             encoder_context->codec_context[output_stream_index]->time_base.den, encoder_context->codec_context[output_stream_index]->frame_size,
             encoder_context->codec_context[output_stream_index]->sample_rate,
-    	channel_name);
+    	    channel_name);
 
         if (avcodec_parameters_from_context(
             encoder_context->stream[output_stream_index]->codecpar,

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -2257,9 +2257,11 @@ encode_frame(
 
         if (selected_decoded_audio(decoder_context, stream_index) >= 0) {
             /* Set the packet duration if it is not the first audio packet */
-            if (encoder_context->audio_pts[stream_index] != AV_NOPTS_VALUE)
+            if (encoder_context->audio_pts[stream_index] != AV_NOPTS_VALUE) {
                 output_packet->duration = output_packet->pts - encoder_context->audio_pts[stream_index];
-            else
+                if (!strcmp(params->ecodec2, "aac"))
+                    output_packet->duration = 1024;
+            } else
                 output_packet->duration = 0;
             encoder_context->audio_pts[stream_index] = output_packet->pts;
             encoder_context->audio_frames_written[stream_index]++;
@@ -3698,6 +3700,7 @@ avpipe_xc(
         encoder_context->audio_pts[j] = AV_NOPTS_VALUE;
         encoder_context->first_read_packet_pts[j] = AV_NOPTS_VALUE;
         encoder_context->audio_last_pts_sent_encode[j] = AV_NOPTS_VALUE;
+        encoder_context->audio_last_pts_encoded[j] = AV_NOPTS_VALUE;
     }
     decoder_context->first_key_frame_pts = AV_NOPTS_VALUE;
     decoder_context->is_av_synced = 0;

--- a/live/lhr_buffer.go
+++ b/live/lhr_buffer.go
@@ -195,6 +195,11 @@ func (rwb *RWBuffer) Len() int {
 	return rwb.count
 }
 
+// Seek doesn't do anything for a RWBuffer
+func (rwb *RWBuffer) Seek(offset int64, whence int) (int64, error) {
+	return 0, nil
+}
+
 // io.Closer
 func (rwb *RWBuffer) Close() error {
 	return rwb.CloseSide(RWBufferWriteClosed)

--- a/live/lhr_buffer.go
+++ b/live/lhr_buffer.go
@@ -1,6 +1,7 @@
 package live
 
 import (
+	"github.com/eluv-io/avpipe"
 	"io"
 	"sync"
 
@@ -40,7 +41,7 @@ var blog = elog.Get("/eluvio/avpipe/live/rwb")
  * An EOF is issued for reader when the writer closed the buffer and there is no data
  * in the buffer.
  */
-func NewRWBuffer(capacity int) io.ReadWriteCloser {
+func NewRWBuffer(capacity int) avpipe.SeekReadWriteCloser {
 	if capacity < 0 {
 		return nil
 	}

--- a/live/ts_recorder_test.go
+++ b/live/ts_recorder_test.go
@@ -57,7 +57,7 @@ func TestUdpToMp4(t *testing.T) {
 	tlog.Info("Transcoding UDP stream start", "params", fmt.Sprintf("%+v", *xcParams))
 	err = avpipe.Xc(xcParams)
 	tlog.Info("Transcoding UDP stream done", "err", err, "last pts", nil)
-	if err != nil {
+	if err != nil && err != avpipe.EAV_IO_TIMEOUT {
 		t.Error("Transcoding UDP stream failed", "err", err)
 	}
 

--- a/scripts/sample_mux_spec_abr15.txt
+++ b/scripts/sample_mux_spec_abr15.txt
@@ -1,33 +1,33 @@
 abr-mux
-audio,1,O/O1-aabr/ainit-stream0.m4s
-audio,1,O/O1-aabr/achunk-stream0-00001.m4s
-audio,1,O/O1-aabr/achunk-stream0-00002.m4s
-audio,1,O/O1-aabr/achunk-stream0-00003.m4s
-audio,1,O/O1-aabr/achunk-stream0-00004.m4s
-audio,1,O/O1-aabr/achunk-stream0-00005.m4s
-audio,1,O/O1-aabr/achunk-stream0-00006.m4s
-audio,1,O/O1-aabr/achunk-stream0-00007.m4s
-audio,1,O/O1-aabr/achunk-stream0-00008.m4s
-audio,1,O/O1-aabr/achunk-stream0-00009.m4s
-audio,1,O/O1-aabr/achunk-stream0-00010.m4s
-audio,1,O/O1-aabr/achunk-stream0-00011.m4s
-audio,1,O/O1-aabr/achunk-stream0-00012.m4s
-audio,1,O/O1-aabr/achunk-stream0-00013.m4s
-audio,1,O/O1-aabr/achunk-stream0-00014.m4s
-audio,1,O/O1-aabr/achunk-stream0-00015.m4s
-video,1,O/O1-vabr/vinit-stream0.m4s
-video,1,O/O1-vabr/vchunk-stream0-00001.m4s
-video,1,O/O1-vabr/vchunk-stream0-00002.m4s
-video,1,O/O1-vabr/vchunk-stream0-00003.m4s
-video,1,O/O1-vabr/vchunk-stream0-00004.m4s
-video,1,O/O1-vabr/vchunk-stream0-00005.m4s
-video,1,O/O1-vabr/vchunk-stream0-00006.m4s
-video,1,O/O1-vabr/vchunk-stream0-00007.m4s
-video,1,O/O1-vabr/vchunk-stream0-00008.m4s
-video,1,O/O1-vabr/vchunk-stream0-00009.m4s
-video,1,O/O1-vabr/vchunk-stream0-00010.m4s
-video,1,O/O1-vabr/vchunk-stream0-00011.m4s
-video,1,O/O1-vabr/vchunk-stream0-00012.m4s
-video,1,O/O1-vabr/vchunk-stream0-00013.m4s
-video,1,O/O1-vabr/vchunk-stream0-00014.m4s
-video,1,O/O1-vabr/vchunk-stream0-00015.m4s
+audio,1,O/O1-bbb-abrs g/ainit-stream0.m4s
+audio,1,O/O1-bbb-abrs g/achunk-stream0-00001.m4s
+audio,1,O/O1-bbb-abrs g/achunk-stream0-00002.m4s
+audio,1,O/O1-bbb-abrs g/achunk-stream0-00003.m4s
+audio,1,O/O1-bbb-abrs g/achunk-stream0-00004.m4s
+audio,1,O/O1-bbb-abrs g/achunk-stream0-00005.m4s
+audio,1,O/O1-bbb-abrs g/achunk-stream0-00006.m4s
+audio,1,O/O1-bbb-abrs g/achunk-stream0-00007.m4s
+audio,1,O/O1-bbb-abrs g/achunk-stream0-00008.m4s
+audio,1,O/O1-bbb-abrs g/achunk-stream0-00009.m4s
+audio,1,O/O1-bbb-abrs g/achunk-stream0-00010.m4s
+audio,1,O/O1-bbb-abrs g/achunk-stream0-00011.m4s
+audio,1,O/O1-bbb-abrs g/achunk-stream0-00012.m4s
+audio,1,O/O1-bbb-abrs g/achunk-stream0-00013.m4s
+audio,1,O/O1-bbb-abrs g/achunk-stream0-00014.m4s
+audio,1,O/O1-bbb-abrs g/achunk-stream0-00015.m4s
+video,1,O/O1-bbb-abrs g/vinit-stream0.m4s
+video,1,O/O1-bbb-abrs g/vchunk-stream0-00001.m4s
+video,1,O/O1-bbb-abrs g/vchunk-stream0-00002.m4s
+video,1,O/O1-bbb-abrs g/vchunk-stream0-00003.m4s
+video,1,O/O1-bbb-abrs g/vchunk-stream0-00004.m4s
+video,1,O/O1-bbb-abrs g/vchunk-stream0-00005.m4s
+video,1,O/O1-bbb-abrs g/vchunk-stream0-00006.m4s
+video,1,O/O1-bbb-abrs g/vchunk-stream0-00007.m4s
+video,1,O/O1-bbb-abrs g/vchunk-stream0-00008.m4s
+video,1,O/O1-bbb-abrs g/vchunk-stream0-00009.m4s
+video,1,O/O1-bbb-abrs g/vchunk-stream0-00010.m4s
+video,1,O/O1-bbb-abrs g/vchunk-stream0-00011.m4s
+video,1,O/O1-bbb-abrs g/vchunk-stream0-00012.m4s
+video,1,O/O1-bbb-abrs g/vchunk-stream0-00013.m4s
+video,1,O/O1-bbb-abrs g/vchunk-stream0-00014.m4s
+video,1,O/O1-bbb-abrs g/vchunk-stream0-00015.m4s


### PR DESCRIPTION
Solves issues: https://github.com/eluv-io/avpipe/issues/67, https://github.com/eluv-io/avpipe/issues/68
- Increase muxing capacity up to 4*4096 ABR segments (more than 8 hours).
- Add capability to mux to MP4 in addition to fMP4. This can be chosen using the format in transcoding parameters.
- During muxing adjust output PTS/DTS and start from zero.
- Better EOF detection when muxing multiple streams.
- Start muxing after the first keyframe detection.
- Some enhancements and fixes in mux output seeker interface.
- Fix a memory leak in avpipe mux when muxing is filished