### PR TITLE
Assorted Improvements, Stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,10 +53,6 @@ dkms.conf
 
 # VisualStudioCode
 .vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
 
 /bin/
 /include/

--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ The following repositories can be checked out in any directory, but for better o
   - `run_tests.sh` to run avpipe core functionality and transcoding tests.
   - `run_live_tests.sh`: to run avipe live-streaming functionality tests.
 
+### Run `exc` and `elvxc`
+
+`exc` and `elvxc` are standalone variants of avpipe that are generally used for testing. They are both installed when running `make` in the root.
+
+`exc` is a lightweight C-only wrapper of avpipe. A detailed usage doc can be printed out by simply running `exc`. It is primarily usable for single-shot transcoding operations.
+
+`elvxc` is a standalone go binary that invokes the avpipe library to do probing, log analysis, muxing, and transcoding.
+
 ## Design
 
 - Avpipe library has been built on top of the different libraries of ffmpeg, the most important ones are libx264, libx265, libavcodec, libavformat, libavfilter and libswresample. But in order to achieve all the features and capabilities some parts of ffmpeg library have been changed. Avpipe library is capable of transcoding or probing an input source (i.e a media file, or an UDP/RTMP stream) and producing output media or probe results. In order to start a transcoding job the transcoding parameters have to be set.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # avpipe
 
-# Introduction
+## Introduction
+
 The avpipe library is basically a C/Go library on top of FFmpeg with very simple transcoding APIs.
 This library helps third party developers to develop server programs or apps for transcoding audio/video in C or Go.
 The avpipe library has the capability to transcode audio/video input files and produce MP4 or M4S (for HLS/DASH playout) segments on the fly.
@@ -11,23 +12,27 @@ Similarly the output of avpipe library can be set by some callback functions to 
 Usually the media segments are either fragmented MP4 or TS segments.
 So far, the work on avpipe has been focused on generating fragmented MP4 segments (the TS format might be added later).
 
-# Build
+## Build
 
-## Prerequisites
+### Prerequisites
+
 The following libraries must be installed:
+
 - libx264
 - libx265
 - cuda-10.2 or cuda-11 (if you want to compile and build to support cuda/nvidia)
 
-## Clone FFmpeg and avpipe
+### Clone FFmpeg and avpipe
+
 The following repositories can be checked out in any directory, but for better organization it is recommended to be cloned in the same parent directory like _src_
 (_src_ is the workspace containing FFmpeg and avpipe).
- - elv-io/FFmpeg:
-   - `git clone git@github.com:eluv-io/FFmpeg.git`
- - eluv-io/avpipe:
-   - `git clone git@github.com:eluv-io/avpipe.git`
-    
-## Build FFmpeg and avpipe
+
+- eluv-io/FFmpeg:
+  - `git clone git@github.com:eluv-io/FFmpeg.git`
+- eluv-io/avpipe:
+  - `git clone git@github.com:eluv-io/avpipe.git`
+
+### Build FFmpeg and avpipe
 
 - Build eluv-io/FFmpeg: in FFmpeg directory `<ffmpeg-path>` run
   - `./build.sh`
@@ -39,27 +44,27 @@ The following repositories can be checked out in any directory, but for better o
 - This installs the binaries under `<avpipe-path>/bin`
 - Note: avpipe has to be built and linked with eluv-io/FFmpeg to be functional.
 
-## Test avpipe
+### Test avpipe
 
-- Download media test files from https://console.cloud.google.com/storage/browser/eluvio-test-assets into _media_ directory inside _<avpipe-path>_
+- Download media test files from https://console.cloud.google.com/storage/browser/eluvio-test-assets into `media` directory inside `<avpipe-path>`
   - `cd avpipe`
-  - `mkdir ./media`  
+  - `mkdir ./media`
   - `cd ./media`
   - `gsutil -m cp 'gs://eluvio-test-assets/*' .`
-- Inside _<avpipe-path>_ run
+- Inside `<avpipe-path>` run
   - `go test -timeout 2000s`
 - Instead of the above commands, you can run the following scripts:
   - `run_tests.sh` to run avpipe core functionality and transcoding tests.
   - `run_live_tests.sh`: to run avipe live-streaming functionality tests.
-  
-# Design
+
+## Design
+
 - Avpipe library has been built on top of the different libraries of ffmpeg, the most important ones are libx264, libx265, libavcodec, libavformat, libavfilter and libswresample. But in order to achieve all the features and capabilities some parts of ffmpeg library have been changed. Avpipe library is capable of transcoding or probing an input source (i.e a media file, or an UDP/RTMP stream) and producing output media or probe results. In order to start a transcoding job the transcoding parameters have to be set.
 - This section describes some of the capabilities and features of avpipe library and how to set the parameters to utilize those features.
 
-
 ### Parameters
 
-```
+```c
 typedef struct xcparams_t {
     char    *url;                       // URL of the input for transcoding
     int     bypass_transcoding;         // if 0 means do transcoding, otherwise bypass transcoding
@@ -125,8 +130,8 @@ typedef struct xcparams_t {
     int         stream_id;                  // Stream id to trasncode, should be >= 0
     char        *filter_descriptor;         // Filter descriptor if tx-type == audio-merge
     char        *mux_spec;
-    int64_t     extract_image_interval_ts;  // Write frames at this interval. Default: -1 
-    int64_t     *extract_images_ts;         // Write frames at these timestamps. 
+    int64_t     extract_image_interval_ts;  // Write frames at this interval. Default: -1
+    int64_t     *extract_images_ts;         // Write frames at these timestamps.
     int         extract_images_sz;          // Size of the array extract_images_ts
 
     int         video_time_base;            // New video encoder time_base (1/video_time_base)
@@ -147,12 +152,12 @@ typedef struct xcparams_t {
   - If xc_type=xc_audio_join then avpipe library creates an audio join filter graph and joins the selected input audio streams to produce a joint audio stream.
   - If xc_type=xc_audio_pan then avpipe library creates an audio pan filter graph to pan multiple channels in one input stream to one output stereo stream.
 - **Specifying decoder/encoder:** the ecodec/decodec params are used to set video encoder/decoder. Also ecodec2/decodec2 params are used to set audio encoder/decoder. For video the decoder can be one of "h264", "h264_cuvid", "jpeg2000", "hevc" and encoder can be "libx264", "libx265", "h264_nvenc", "h264_videotoolbox", or "mjpeg". For audio the decoder can be “aac” or “ac3” and the encoder can be "aac", "ac3", "mp2" or "mp3".
-- **Transcoding multiple audio:** avpipe library has the capability to transcode one or multiple audio streams at the same time. The _audio_index_ array includes the audio index of the streams that will be transcoded. The parameter _n_audio_ determines the number of audio indexes in the _audio_index_ array.
+- **Transcoding multiple audio:** avpipe library has the capability to transcode one or multiple audio streams at the same time. The `audio_index` array includes the audio index of the streams that will be transcoded. The parameter `n_audio` determines the number of audio indexes in the `audio_index` array.
 - **Using GPU:** avpipe library can utilize NVIDIA cards for transcoding. In order to utilize the NVIDIA GPU, the gpu_index must be set (the default is using GPU with index 0). To find the existing GPU indexes on a machine, nvidia-smi command can be used. In addition, the decoder and encoder should be set to "h264_cuvid" or "h264_nvenc" respectively. And finally, in order to pick the correct GPU index the following environment variable must be set “CUDA_DEVICE_ORDER=PCI_BUS_ID” before running the program.
 - **Text watermarking:** this can be done with setting watermark_text, watermark_xloc, watermark_yloc, watermark_relative_sz, and watermark_font_color while transcoding a video (xc_type=xc_video), which makes specified watermark text to appear at specified location.
 - **Image watermarking:** this can be done with setting watermark_overlay (the buffer containing overlay image), watermark_overlay_len, watermark_xloc, and watermark_yloc while transcoding a video (xc_type=xc_video).
 - **Live streaming with UDP/HLS/RTMP:** avpipe library has the capability to transcode an input live stream and generate MP4 or ABR segments. Although the parameter setting would be similar to transcoding any other input file, setting up input/output handlers would be different (this is discussed in sections 6 and 8).
-- **Extracting images:** avpipe library can extract images either using a time interval or specific timestamps. 
+- **Extracting images:** avpipe library can extract images either using a time interval or specific timestamps.
 - **HDR support:** avpipe library allows to create HDR output while transcoding with H.265 encoder. To make an HDR content two parameters max_cll and master_display have to be set.
 - **Bypass feature:** setting bypass_transcoding to 1, would avoid transcoding and copies the input packets to output. This feature is very useful (saves a lot of CPU and time) when input data matches with output and we can skip transcoding.
 - **Muxing audio/video ABR segments and creating fMP4/MP4 files:** this feature allows the creation of fMP4/MP4 files from transcoded audio/video segments. In order to do this a muxing spec has to be made to tell avpipe which ABR segments should be stitched together to produce the final fMP4/MP4. To make this feature working xc_type should be set to xc_mux and the mux_spec param should point to a buffer containing muxing spec. If the format is 'fmp4-segment' the output will be fMP4, otherwise MP4.
@@ -161,25 +166,24 @@ typedef struct xcparams_t {
   - setting xc_type = xc_audio_join would join 2 or more audio inputs and create a new audio output (for example joining two mono streams and creating one stereo).
   - setting xc_type = xc_audio_pan would pick different audio channels from input and create a new audio stream (for example picking different channels from a 5.1 channel layout and producing a stereo containing two channels).
   - setting xc_type = xc_audio_merge would merge different input audio streams and produce a new multi-channel output stream (for example, merging different input mono streams and create a new 5.1)
-- **Setting video timebase:** setting _video_time_base_ will set the timebase of generated video to 1/video_time_base (the timebase has to be bigger than 10000).
-- **Video frame duration:** the parameter _video_frame_duration_ts_ can be used to set the duration of each video frame with the specified timebase for output video. This along with video_time_base can be used to normalize the video frames and their duration. For example, for a stream with 60 fps and _video_frame_duration_ts_ equal to 256, the _video_time_base_ would be 15360. As another example, for a 59.94 fps, the _video_frame_duration_ts_ can be 1001 and _video_time_base_ would be 60000. In this case a segment of 1800 frames would be 1801800 timebase long.
+- **Setting video timebase:** setting `video_time_base` will set the timebase of generated video to 1/video_time_base (the timebase has to be bigger than 10000).
+- **Video frame duration:** the parameter `video_frame_duration_ts` can be used to set the duration of each video frame with the specified timebase for output video. This along with video*time_base can be used to normalize the video frames and their duration. For example, for a stream with 60 fps and `video_frame_duration_ts` equal to 256, the `video_time_base` would be 15360. As another example, for a 59.94 fps, the `video_frame_duration_ts` can be 1001 and `video_time_base` would be 60000. In this case a segment of 1800 frames would be 1801800 timebase long.
 - **Debugging with frames:** if the parameter debug_frame_level is on then the logs will also include very low level debug messages to trace reading/writing every piece of data.
 - **Connection timeout:** This parameter is useful when recording / transcoding RTMP or MPEGTS streams. If avpipe is listening for an RTMP stream, connection_timeout determines the time in sec to listen for an incoming RTMP stream. If avpipe is listening for incoming UDP MPEGTS packets, connection_timeout determines the time in sec to wait for the first incoming UDP packet (if no packet is received during connection_timeout, then timeout would happen and an error would be generated).
-
-
 
 ### C/Go interaction architecture
 
 Avpipe library has two main layers (components): avpipe C library and avpipe C/GO library.
 
-### Avpipe C library:
+#### Avpipe C library
+
 The first layer is the C code, mainly libavpipe directory, that has been built on top of the different libraries of ffmpeg like libx264, libx265, libavcodec, libavformat, libavfilter and libswresample.
 This is the main transcoding engine of avpipe and defines low level C transcoding API of avpipe library.
 Avpipe uses the callbacks in avio_alloc_context() to read, write, or seek into the media files.
 
 As mentioned before this layer uses the callbacks in avio_alloc_context() to read, write, or seek into the media files. These callbacks are used by FFmpeg libraries to read, and seek into the input file (or write and seek to the output file). Avpipe C library provides avpipe_io_handler_t struct to client applications for transcoding (at this moment exc and Go layer are the users of avpipe_io_handler_t); notice that three of these functions are exactly matched to read, write, seek callback functions of avio_alloc_context(), but three more functions are also added to open, close and stat the input or output:
 
-```
+```c
 typedef struct avpipe_io_handler_t {
   avpipe_opener_f avpipe_opener;
   avpipe_closer_f avpipe_closer;
@@ -190,62 +194,66 @@ typedef struct avpipe_io_handler_t {
 } avpipe_io_handler_t;
 ```
 
-- The _avpipe_opener()_ callback function opens the media file (makes a transcoding session) and initializes an ioctx_t structure.
-- The _avpipe_closer()_ callback function closes the corresponding resources that were allocated for the media file (releases the resources that were allocated with the opener).
-- The _avpipe_reader()_ callback function reads the packets/frames of the opened media file for transcoding. This callback function automatically gets called by ffmpeg during transcoding.
-- The _avpipe_writer()_ callback function writes the transcoded packets/frames to the output media file. This callback function automatically gets called by ffmpeg during transcoding.
-- The _avpipe_seeker()_ callback function seeks to a specific offset and gets called automatically by ffmpeg during transcoding.
-- The _avpipe_stater()_ callback function publishes different statistics about transcoding and gets called by the avpipe library itself.
+- The `avpipe_opener()` callback function opens the media file (makes a transcoding session) and initializes an ioctx_t structure.
+- The `avpipe_closer()` callback function closes the corresponding resources that were allocated for the media file (releases the resources that were allocated with the opener).
+- The `avpipe_reader()` callback function reads the packets/frames of the opened media file for transcoding. This callback function automatically gets called by ffmpeg during transcoding.
+- The `avpipe_writer()` callback function writes the transcoded packets/frames to the output media file. This callback function automatically gets called by ffmpeg during transcoding.
+- The `avpipe_seeker()` callback function seeks to a specific offset and gets called automatically by ffmpeg during transcoding.
+- The `avpipe_stater()` callback function publishes different statistics about transcoding and gets called by the avpipe library itself.
 
 In order to start a transcoding session with avpipe C library, the following APIs are provided:
 
-- _avpipe_init(xctx_t **xctx, avpipe_io_handler_t *in_handlers, avpipe_io_handler_t *out_handlers, txparams_t *p):_ this initialises a transcoding context with provided input handlers, output handlers, and transcoding parameters.
-- _avpipe_fini(xctx_t **xctx):_ This releases all the resources associated with the already initialized transcoding context.
-- _avpipe_xc(xctx_t *xctx, int do_instrument):_ this starts the transcoding corresponding to the transcoding context that was already initialized by avpipe_init(). If do_instrument is set it will also do some instrumentation while transcoding.
-- _avpipe_probe(avpipe_io_handler_t *in_handlers, txparams_t *p,    xcprobe_t **xcprobe, int *n_streams):_ this function probes an input media which can be accessed by in_handlers callback functions. It is recommended to set the seekable parameter to make searching and finding some meta data faster in the input stream if the input stream is not a live stream. Of course, for a live stream seekable should not be set since it is not possible to seek back and forth in live input data.
+- `avpipe_init(xctx_t **xctx, avpipe_io_handler_t *in_handlers, avpipe_io_handler_t *out_handlers, txparams_t *p):` this initialises a transcoding context with provided input handlers, output handlers, and transcoding parameters.
+- `avpipe_fini(xctx_t **xctx):` This releases all the resources associated with the already initialized transcoding context.
+- `avpipe_xc(xctx_t *xctx, int do_instrument):` this starts the transcoding corresponding to the transcoding context that was already initialized by avpipe_init(). If do_instrument is set it will also do some instrumentation while transcoding.
+- `avpipe_probe(avpipe_io_handler_t *in_handlers, txparams_t *p, xcprobe_t **xcprobe, int *n_streams):` this function probes an input media which can be accessed by in_handlers callback functions. It is recommended to set the seekable parameter to make searching and finding some meta data faster in the input stream if the input stream is not a live stream. Of course, for a live stream seekable should not be set since it is not possible to seek back and forth in live input data.
 
+#### C/Go layer
 
-
-### C/Go layer:
-The second layer is the C/GO code, mainly avpipe.go,  that provides the API for Go programs, and avpipe.c, which glues the Go layer to avpipe C library.
+The second layer is the C/GO code, mainly avpipe.go, that provides the API for Go programs, and avpipe.c, which glues the Go layer to avpipe C library.
 The handlers in avpipe.c are the callback functions that get called by ffmpeg and they call the Go layer callback functions themselves.
 
 Avpipe C/Go layer provides APIs that can be used by Go programs. The implementation of this layer is in two files avpipe.c and avpipe.go. The transcoding APIs exposed to Go client programs are designed and implemented in two categories:
 
 **1) APIs with no handle:** these APIs are very simple to use and are useful when the client application is dealing with short transcodings (i.e transcodings that would take 20-30 secs) and the application doesn’t need to cancel the transcoding
- 
-**2) Handle based APIs:** which work based on a handle and corresponding transcoding can be cancelled using the specified handle. These transcoding APIs are useful, for example, when dealing with live streams and the application wants to cancel a live stream recording. 
- 
+
+**2) Handle based APIs:** which work based on a handle and corresponding transcoding can be cancelled using the specified handle. These transcoding APIs are useful, for example, when dealing with live streams and the application wants to cancel a live stream recording.
+
 All the APIs in the C/Go library can be categories as the following:
 
-#### No handle based transcoding APIs are:
-- _Xc(params *XcParams):_ initializes a transcoding context in avpipe and starts running the corresponding transcoding job.
-- _Mux(params *XcParams):_ initializes a transcoding context in avpipe and starts running the corresponding muxing job.
-- _Probe(params *XcParams):_ starts probing the specified input in the url parameter. In order to make probing faster, it is better to set seekable in params to true when probing non-live inputs.
+##### No handle based transcoding APIs
 
-#### Handle based transcoding APIs are:
-- _XcInit(params *XcParams):_ initializes a transcoding context in avpipe and returns its corresponding 32bit handle to the client code. This handle can be used to start or cancel the transcoding job.
-- _XcRun(handle int32):_ starts the transcoding job that corresponds to the obtained handle by _XcInit()_.
-- _XcCancel(handle int32):_ cancels or stops the transcoding job corresponding to the handle.
+- `Xc(params *XcParams):` initializes a transcoding context in avpipe and starts running the corresponding transcoding job.
+- `Mux(params *XcParams):` initializes a transcoding context in avpipe and starts running the corresponding muxing job.
+- `Probe(params *XcParams):` starts probing the specified input in the url parameter. In order to make probing faster, it is better to set seekable in params to true when probing non-live inputs.
 
-#### IO handler APIs are:
-- _InitIOHandler(inputOpener InputOpener, outputOpener OutputOpener):_ This is used to set global input/output opener for avpipe transcoding. If there is no specific input or output opener for a URL the global input/output opener will be used.
-- _InitUrlIOHandler(url string, inputOpener InputOpener, outputOpener OutputOpener):_ This is used to set input/output opener specific to a URL when transcoding. The input or output opener set by this function is only valid for the specified url and will be unset after _Xc()_ or _Probe()_ is complete.
-- _InitMuxIOHandler(inputOpener InputOpener, outputOpener OutputOpener):_ Sets the global handler for muxing (similar to InitIOHandler for transcoding).
-- _InitUrlMuxIOHandler(url string, inputOpener InputOpener, outputOpener OutputOpener):_ This is used to set input/output opener specific to a URL when muxing (similar to InitUrlIOHandler for transcoding).
+##### Handle based transcoding APIs
 
-#### Miscellaneous APIs are:
-- _H264GuessProfile(bitdepth, width, height int):_ returns the profile.
-- _H264GuessLevel(profile int, bitrate int64, framerate, width, height int):_ returns the level.
+- `XcInit(params *XcParams):` initializes a transcoding context in avpipe and returns its corresponding 32bit handle to the client code. This handle can be used to start or cancel the transcoding job.
+- `XcRun(handle int32):` starts the transcoding job that corresponds to the obtained handle by `XcInit()`.
+- `XcCancel(handle int32):` cancels or stops the transcoding job corresponding to the handle.
 
+##### IO handler APIs
+
+- `InitIOHandler(inputOpener InputOpener, outputOpener OutputOpener):` This is used to set global input/output opener for avpipe transcoding. If there is no specific input or output opener for a URL the global input/output opener will be used.
+- `InitUrlIOHandler(url string, inputOpener InputOpener, outputOpener OutputOpener):` This is used to set input/output opener specific to a URL when transcoding. The input or output opener set by this function is only valid for the specified url and will be unset after `Xc()` or `Probe()` is complete.
+- `InitMuxIOHandler(inputOpener InputOpener, outputOpener OutputOpener):` Sets the global handler for muxing (similar to InitIOHandler for transcoding).
+- `InitUrlMuxIOHandler(url string, inputOpener InputOpener, outputOpener OutputOpener):` This is used to set input/output opener specific to a URL when muxing (similar to InitUrlIOHandler for transcoding).
+
+##### Miscellaneous APIs
+
+- `H264GuessProfile(bitdepth, width, height int):` returns the profile.
+- `H264GuessLevel(profile int, bitrate int64, framerate, width, height int):` returns the level.
 
 ### Setting up Go IO handlers
+
 As mentioned before the source of transcoding in avpipe library can be a file on a disk, a TCP connection like RTMP, some UDP datagrams like MPEGTS stream, or even an object on the cloud. Similarly the output of transcoding in avpipe can be a file on a disk, some memory cache, or another object on the cloud. This flexibility in avpipe is achieved by two interfaces: InputOpener and OutputOpener interface.
 
-#### InputOpener interface: 
+#### InputOpener interface
+
 This interface has only one Open() method that must be implemented. This method is called just before transcoding, probing, or muxing starts. In avpipe library every input is determined by a url and a unique fd (the same way a file is determined by an fd in your operating system) and when open() is called the fd and the url is passed to it. Then the Open() returns an implementation of the InputHandler interface. The Read() method in InputHandler interface is used to read the input, the Seek() method is used to seek to a specific position in the input, Close() is used to close the input, Size() is used to obtain info about size of input, and Stat() is used to report some statistics of input.
 
-```
+```go
 type InputOpener interface {
   // fd determines uniquely opening input.
   // url determines input string for transcoding
@@ -271,10 +279,11 @@ type InputHandler interface {
 }
 ```
 
-#### OutputOpener interface: 
+#### OutputOpener interface
+
 Similar to InputOpener this interface has only one open() method that must be implemented. This open() method is called before a new transcoding segment is generated. The new transcoding segments generated by avpipe can be HLS/DASH segments (m4s files), or fragmented MP4 files; in either case the open() method would be called before the segment is generated. This open() method has to return an implementation of the OutputHandler interface, which is used to seek, write, close and stat output segments. More specifically, in OutputHandler interface the Write() method is used to write to the output segment, the Seek() method is used to seek into the output segment, Close() method is used to close the output segment and Stat() is used to report some statistics of output.
 
-```
+```go
 type OutputOpener interface {
   // h determines uniquely opening input.
   // fd determines uniquely opening output.
@@ -298,43 +307,45 @@ type OutputHandler interface {
 
 Note that the methods in InputHandler and OutputHandler interfaces are called indirectly by ffmpeg. For some examples of the implementations of these interfaces you can refer to avpipe_test.go or elvxc directory.
 
-## Transcoding Audio/Video
+### Transcoding Audio/Video
+
 Avpipe library has the following transcoding options to transcode audio/video:
 
-- _xc_all:_ in this mode both audio and video will be decoded and encoded according to transcoding params. Usually there is no need to specify decoder and decoder is detected automatically.
-- _xc_video:_ in this mode video will be decoded and encoded according to transcoding params.
-- _xc_audio:_ in this mode audio will be decoded and encoded according to encoder param (by default it is AAC).
-- _xc_audio_pan:_ in this mode audio pan filter will be used before injecting the audio frames into the encoder.
-- _xc_audio_merge:_ in this mode audio merge filter will be used before injecting the audio frames into the encoder.
-- _xc_mux:_ in this mode avpipe would mux some audio and video ABR segments and produce an MP4 output. In this case, it is needed to provide a mux_spec which points to ABR segments to be muxed.
-- _xc_extract_images:_ in this mode avpipe will extract specific images/frames at specific times from a video.
+- `xc_all`: in this mode both audio and video will be decoded and encoded according to transcoding params. Usually there is no need to specify decoder and decoder is detected automatically.
+- `xc_video`: in this mode video will be decoded and encoded according to transcoding params.
+- `xc_audio`: in this mode audio will be decoded and encoded according to encoder param (by default it is AAC).
+- `xc_audio_pan`: in this mode audio pan filter will be used before injecting the audio frames into the encoder.
+- `xc_audio_merge`: in this mode audio merge filter will be used before injecting the audio frames into the encoder.
+- `xc_mux`: in this mode avpipe would mux some audio and video ABR segments and produce an MP4 output. In this case, it is needed to provide a mux_spec which points to ABR segments to be muxed.
+- `xc_extract_images`: in this mode avpipe will extract specific images/frames at specific times from a video.
 
-### Audio specific params
-- _channel_layout:_ In all the above cases channel_layout parameter can be set to specify the output channel layout. If the channel_layout param is not set then the input channel layout would carry to the output.
-- _audio_index:_ The audio_index param can be used to pick the specified audio (using stream index) for transcoding.
-- _audio_seg_duration_ts:_ This param determines the duration of the generated audio segment in TS.
-- _audio_bitrate:_ This param sets the audio bitrate in the output.
-- _filter_descriptor:_ The filter_descriptor param must be set when transcoding type is xc_audio_pan/xc_audio_merge.
+#### Audio specific params
 
+- `channel_layout`: In all the above cases channel_layout parameter can be set to specify the output channel layout. If the channel_layout param is not set then the input channel layout would carry to the output.
+- `audio_index`: The audio_index param can be used to pick the specified audio (using stream index) for transcoding.
+- `audio_seg_duration_ts`: This param determines the duration of the generated audio segment in TS.
+- `audio_bitrate`: This param sets the audio bitrate in the output.
+- `filter_descriptor`: The filter_descriptor param must be set when transcoding type is xc_audio_pan/xc_audio_merge.
 
-## Avpipe stat reports
+### Avpipe stat reports
+
 - Avpipe library reports some input and output stats via some events.
 - Input stats include the following events:
-  - in_stat_bytes_read: input bytes read (this is true for all inputs but not for RTMP).
-  - in_stat_audio_frame_read: input audio frames read so far.
-  - in_stat_video_frame_read: input video frames read so far.
-  - in_stat_decoding_audio_start_pts: input stream start pts for audio.
-  - in_stat_decoding_video_start_pts: input stream start pts for video.
+  - `in_stat_bytes_read`: input bytes read (this is true for all inputs but not for RTMP).
+  - `in_stat_audio_frame_read`: input audio frames read so far.
+  - `in_stat_video_frame_read`: input video frames read so far.
+  - `in_stat_decoding_audio_start_pts`: input stream start pts for audio.
+  - `in_stat_decoding_video_start_pts`: input stream start pts for video.
 - Input stats are reported via input handlers avpipe_stater() callback function.
 - A GO client of avpipe library, must implement InputHandler.Stat() method.
 - Output stats include the following events:
-  - out_stat_bytes_written: bytes written to current segment so far. Audio and video each have their own output segment.
-  - out_stat_frame_written: includes total frames written and frames written to current segment.
-  - out_stat_encoding_end_pts: end pts of generated segment. This event is generated when an output segment is complete and it is closing.
+  - `out_stat_bytes_written`: bytes written to current segment so far. Audio and video each have their own output segment.
+  - `out_stat_frame_written`: includes total frames written and frames written to current segment.
+  - `out_stat_encoding_end_pts`: end pts of generated segment. This event is generated when an output segment is complete and it is closing.
 - Output stats are reported via output handlers avpipe_stater() callback function.
 - A GO client of avpipe library, must implement OutputHandler.Stat() method.
 
-## Setting up live
+### Setting up live
 
 - Avpipe can handle HLS, UDP TS, and RTMP live streams. For each case it is needed to set parameters for live stream properly.
 - If the parameters are set correctly, then avpipe recorder would read the live data and generate live audio/video mezzanine files.
@@ -342,15 +353,14 @@ Avpipe library has the following transcoding options to transcode audio/video:
 - In order to have a good quality output, the audio and video live has to be synced.
 - If input has multiple audios, avpipe can sync the selected audio with one of the elementary video streams, specified by sync_audio_to_stream_id, based the first key frame in the video stream. In this case, sync_audio_to_stream_id would be set to the stream id of the video elementary stream.
 
-
-## Transcoding with preset
+### Transcoding with preset
 
 - Avpipe has the capability to apply preset parameter when encoding using H264 encoder.
 - The experiments show that using preset `faster` instead of `medium` would generate almost the same size output/bandwidth while keeping the picture quality high.
 - The other advantage of using preset `faster` instead of `medium` is that it would consume less CPU and encode faster.
 - To compare the following command is used to generate the mezzanines for `creed_5_min.mov`:
 
-```
+```text
 ./bin/etx -f ../media/MGM/creed_5_min.mov -tx-type all -force-keyint 48 -seg-duration 30.03 -seekable 1 -format fmp4-segment -> preset medium
 ./bin/etx -f ../media/MGM/creed_5_min.mov -tx-type all -force-keyint 48 -seg-duration 30.03 -seekable 1 -format fmp4-segment -preset faster -> preset faster
 
@@ -365,20 +375,21 @@ Avpipe library has the following transcoding options to transcode audio/video:
 +------------+-----------------------+-------------------+-----------------------------------------------------------------------------------------------------------+
 
 ```
-- Expermineting with other input files and some RTMP streams showed the same results.
 
+- Experimenting with other input files and some RTMP streams showed the same results.
 
-## h.265 Implementation Notes
+### h.265 Implementation Notes
+
 - h.265 levels for ingests follow the same behaviour as ffmpeg. Below are examples from our testing
 
-|Source Resolution|Profile|Source h.265 Level|Fabric h.265 Level|
-|-----------------|-------|------------------|------------------|
-|1080p            |Main   |4.0               |4.0               |
-|1080p            |Main 10|4.0               |4.0               |
-|1080p            |Main   |4.1               |4.0               |
-|1080p            |Main 10|4.1               |4.0               |
-|1080p            |Main   |5.0               |4.0               |
-|1080p            |Main 10|5.0               |4.0               |
-|1080p            |Main   |5.1               |4.0               |
-|4k               |Main 10|5.1               |5.0               |
-|4k               |Main 10|5.2               |5.0               |
+| Source Resolution | Profile | Source h.265 Level | Fabric h.265 Level |
+| ----------------- | ------- | ------------------ | ------------------ |
+| 1080p             | Main    | 4.0                | 4.0                |
+| 1080p             | Main 10 | 4.0                | 4.0                |
+| 1080p             | Main    | 4.1                | 4.0                |
+| 1080p             | Main 10 | 4.1                | 4.0                |
+| 1080p             | Main    | 5.0                | 4.0                |
+| 1080p             | Main 10 | 5.0                | 4.0                |
+| 1080p             | Main    | 5.1                | 4.0                |
+| 4k                | Main 10 | 5.1                | 5.0                |
+| 4k                | Main 10 | 5.2                | 5.0                |

--- a/avpipe.c
+++ b/avpipe.c
@@ -733,6 +733,12 @@ out_stat(
         else
             rc = AVPipeStatOutput(h, fd, stream_index, buftype, stat_type, &outctx->encoder_ctx->video_last_pts_sent_encode);
         break;
+    case out_stat_start_file:
+        rc = AVPipeStatOutput(h, fd, stream_index, buftype, stat_type, &outctx->seg_index);
+        break;
+    case out_stat_end_file:
+        rc = AVPipeStatOutput(h, fd, stream_index, buftype, stat_type, &outctx->seg_index);
+        break;
     case out_stat_frame_written:
         {
             encoding_frame_stats_t encoding_frame_stats = {

--- a/avpipe.go
+++ b/avpipe.go
@@ -130,6 +130,23 @@ func (a AVType) Name() string {
 	}
 }
 
+func (a AVType) AVClass() string {
+	switch a {
+	case FMP4AudioSegment, FMP4VideoSegment:
+		return "mez_creation"
+	case DASHAudioInit, DASHAudioSegment, DASHVideoInit, DASHVideoSegment:
+		return "abr"
+	case HLSAudioM3U, HLSMasterM3U, HLSVideoM3U, DASHManifest:
+		return "manifest"
+	case FrameImage:
+		return "frame_extraction"
+	case MuxSegment, MP4Segment, MP4Stream, FMP4Stream:
+		return "mux"
+	default:
+		return "unknown"
+	}
+}
+
 // This is corresponding to AV_NOPTS_VALUE
 const AvNoPtsValue = uint64(C.uint64_t(0x8000000000000000))
 

--- a/avpipe.go
+++ b/avpipe.go
@@ -91,6 +91,45 @@ const (
 	FrameImage
 )
 
+func (a AVType) Name() string {
+	switch a {
+	case DASHManifest:
+		return "DASHManifest"
+	case DASHVideoInit:
+		return "DASHVideoInit"
+	case DASHVideoSegment:
+		return "DASHVideoSegment"
+	case DASHAudioInit:
+		return "DASHAudioInit"
+	case DASHAudioSegment:
+		return "DASHAudioSegment"
+	case HLSMasterM3U:
+		return "HLSMasterM3U"
+	case HLSVideoM3U:
+		return "HLSVideoM3U"
+	case HLSAudioM3U:
+		return "HLSAudioM3U"
+	case AES128Key:
+		return "AES128Key"
+	case MP4Stream:
+		return "MP4Stream"
+	case FMP4Stream:
+		return "FMP4Stream"
+	case MP4Segment:
+		return "MP4Segment"
+	case FMP4VideoSegment:
+		return "FMP4VideoSegment"
+	case FMP4AudioSegment:
+		return "FMP4AudioSegment"
+	case MuxSegment:
+		return "MuxSegment"
+	case FrameImage:
+		return "FrameImage"
+	default:
+		return fmt.Sprintf("Unknown(%d)", a)
+	}
+}
+
 // This is corresponding to AV_NOPTS_VALUE
 const AvNoPtsValue = uint64(C.uint64_t(0x8000000000000000))
 
@@ -383,6 +422,38 @@ const (
 	AV_OUT_STAT_END_FILE                = 11
 	AV_IN_STAT_DATA_SCTE35              = 12
 )
+
+func (a AVStatType) Name() string {
+	switch a {
+	case AV_IN_STAT_BYTES_READ:
+		return "AV_IN_STAT_BYTES_READ"
+	case AV_IN_STAT_AUDIO_FRAME_READ:
+		return "AV_IN_STAT_AUDIO_FRAME_READ"
+	case AV_IN_STAT_VIDEO_FRAME_READ:
+		return "AV_IN_STAT_VIDEO_FRAME_READ"
+	case AV_IN_STAT_DECODING_AUDIO_START_PTS:
+		return "AV_IN_STAT_DECODING_AUDIO_START_PTS"
+	case AV_IN_STAT_DECODING_VIDEO_START_PTS:
+		return "AV_IN_STAT_DECODING_VIDEO_START_PTS"
+	case AV_IN_STAT_FIRST_KEYFRAME_PTS:
+		return "AV_IN_STAT_FIRST_KEYFRAME_PTS"
+	case AV_OUT_STAT_BYTES_WRITTEN:
+		return "AV_OUT_STAT_BYTES_WRITTEN"
+	case AV_OUT_STAT_FRAME_WRITTEN:
+		return "AV_OUT_STAT_FRAME_WRITTEN"
+	case AV_OUT_STAT_ENCODING_END_PTS:
+		return "AV_OUT_STAT_ENCODING_END_PTS"
+	case AV_OUT_STAT_START_FILE:
+		return "AV_OUT_STAT_START_FILE"
+	case AV_OUT_STAT_END_FILE:
+		return "AV_OUT_STAT_END_FILE"
+	case AV_IN_STAT_DATA_SCTE35:
+		return "AV_IN_STAT_DATA_SCTE35"
+	default:
+		return fmt.Sprintf("Unknown(%d)", a)
+	}
+
+}
 
 type SideDataDisplayMatrix struct {
 	Type       string  `json:"side_data_type"`

--- a/avpipe.go
+++ b/avpipe.go
@@ -372,14 +372,16 @@ type AVStatType int
 const (
 	AV_IN_STAT_BYTES_READ               = 1
 	AV_IN_STAT_AUDIO_FRAME_READ         = 2
-	AV_IN_STAT_VIDEO_FRAME_READ         = 4
-	AV_IN_STAT_DECODING_AUDIO_START_PTS = 8
-	AV_IN_STAT_DECODING_VIDEO_START_PTS = 16
-	AV_OUT_STAT_BYTES_WRITTEN           = 32
-	AV_OUT_STAT_FRAME_WRITTEN           = 64
-	AV_IN_STAT_FIRST_KEYFRAME_PTS       = 128
-	AV_OUT_STAT_ENCODING_END_PTS        = 256
-	AV_IN_STAT_DATA_SCTE35              = 512
+	AV_IN_STAT_VIDEO_FRAME_READ         = 3
+	AV_IN_STAT_DECODING_AUDIO_START_PTS = 4
+	AV_IN_STAT_DECODING_VIDEO_START_PTS = 5
+	AV_OUT_STAT_BYTES_WRITTEN           = 6
+	AV_OUT_STAT_FRAME_WRITTEN           = 7
+	AV_IN_STAT_FIRST_KEYFRAME_PTS       = 8
+	AV_OUT_STAT_ENCODING_END_PTS        = 9
+	AV_OUT_STAT_START_FILE              = 10
+	AV_OUT_STAT_END_FILE                = 11
+	AV_IN_STAT_DATA_SCTE35              = 12
 )
 
 type SideDataDisplayMatrix struct {
@@ -1181,6 +1183,12 @@ func (h *ioHandler) OutStat(fd C.int64_t,
 	case C.out_stat_encoding_end_pts:
 		statArgs := *(*uint64)(stat_args)
 		err = outHandler.Stat(streamIndex, avType, AV_OUT_STAT_ENCODING_END_PTS, &statArgs)
+	case C.out_stat_start_file:
+		statArgs := *(*int)(stat_args)
+		err = outHandler.Stat(streamIndex, avType, AV_OUT_STAT_START_FILE, &statArgs)
+	case C.out_stat_end_file:
+		statArgs := *(*int)(stat_args)
+		err = outHandler.Stat(streamIndex, avType, AV_OUT_STAT_END_FILE, &statArgs)
 	case C.out_stat_frame_written:
 		encodingFramesStats := (*C.encoding_frame_stats_t)(stat_args)
 		statArgs := &EncodingFrameStats{

--- a/avpipe_test.go
+++ b/avpipe_test.go
@@ -310,33 +310,29 @@ func (o *fileOutput) Close() error {
 }
 
 func (o fileOutput) Stat(streamIndex int, avType avpipe.AVType, statType avpipe.AVStatType, statArgs interface{}) error {
+	doLog := func(args ...interface{}) {
+		if debugFrameLevel {
+			logArgs := []interface{}{"stat", statType.Name(), "avType", avType.Name(), "streamIndex", streamIndex}
+			logArgs = append(logArgs, args...)
+			log.Debug("AVP TEST OUT STAT", logArgs...)
+		}
+	}
 	switch statType {
 	case avpipe.AV_OUT_STAT_BYTES_WRITTEN:
 		writeOffset := statArgs.(*uint64)
-		if debugFrameLevel {
-			log.Debug("AVP TEST OUT STAT", "STAT, write offset", *writeOffset, "streamIndex", streamIndex)
-		}
+		doLog("write offset", *writeOffset)
 	case avpipe.AV_OUT_STAT_ENCODING_END_PTS:
 		endPTS := statArgs.(*uint64)
-		if debugFrameLevel {
-			log.Debug("AVP TEST OUT STAT", "STAT, endPTS", *endPTS, "streamIndex", streamIndex)
-		}
+		doLog("endPTS", *endPTS)
 	case avpipe.AV_OUT_STAT_START_FILE:
 		segIdx := statArgs.(*int)
-		if debugFrameLevel {
-			log.Debug("AVP TEST OUT STAT", "STAT, start file", *segIdx, "streamIndex", streamIndex)
-		}
+		doLog("segIdx", *segIdx)
 	case avpipe.AV_OUT_STAT_END_FILE:
 		segIdx := statArgs.(*int)
-		if debugFrameLevel {
-			log.Debug("AVP TEST OUT STAT", "STAT, end file", *segIdx, "streamIndex", streamIndex)
-		}
+		doLog("segIdx", *segIdx)
 	case avpipe.AV_OUT_STAT_FRAME_WRITTEN:
 		encodingStats := statArgs.(*avpipe.EncodingFrameStats)
-		if debugFrameLevel {
-			log.Debug("AVP TEST OUT STAT", "avType", avType,
-				"encodingStats", encodingStats, "streamIndex", streamIndex)
-		}
+		doLog("encodingStats", encodingStats)
 		if avType == avpipe.FMP4AudioSegment {
 			statsInfo.encodingAudioFrameStats = *encodingStats
 		} else {

--- a/avpipe_test.go
+++ b/avpipe_test.go
@@ -321,6 +321,16 @@ func (o fileOutput) Stat(streamIndex int, avType avpipe.AVType, statType avpipe.
 		if debugFrameLevel {
 			log.Debug("AVP TEST OUT STAT", "STAT, endPTS", *endPTS, "streamIndex", streamIndex)
 		}
+	case avpipe.AV_OUT_STAT_START_FILE:
+		segIdx := statArgs.(*int)
+		if debugFrameLevel {
+			log.Debug("AVP TEST OUT STAT", "STAT, start file", *segIdx, "streamIndex", streamIndex)
+		}
+	case avpipe.AV_OUT_STAT_END_FILE:
+		segIdx := statArgs.(*int)
+		if debugFrameLevel {
+			log.Debug("AVP TEST OUT STAT", "STAT, end file", *segIdx, "streamIndex", streamIndex)
+		}
 	case avpipe.AV_OUT_STAT_FRAME_WRITTEN:
 		encodingStats := statArgs.(*avpipe.EncodingFrameStats)
 		if debugFrameLevel {

--- a/elvxc/cmd/transcode.go
+++ b/elvxc/cmd/transcode.go
@@ -198,18 +198,28 @@ func (o *elvxcOutput) Close() error {
 }
 
 func (o *elvxcOutput) Stat(streamIndex int, avType avpipe.AVType, statType avpipe.AVStatType, statArgs interface{}) error {
+	doLog := func(args ...interface{}) {
+		logArgs := []interface{}{"stat", statType.Name(), "avType", avType.Name(), "streamIndex", streamIndex}
+		logArgs = append(logArgs, args...)
+		log.Info("AVCMD Outhandler.Stat", logArgs...)
+	}
 
 	switch statType {
 	case avpipe.AV_OUT_STAT_BYTES_WRITTEN:
 		writeOffset := statArgs.(*uint64)
-		log.Info("AVCMD OutputHandler.Stat", "write offset", *writeOffset, "streamIndex", streamIndex)
+		doLog("write offset", *writeOffset)
 	case avpipe.AV_OUT_STAT_ENCODING_END_PTS:
 		endPTS := statArgs.(*uint64)
-		log.Info("AVCMD OutputHandler.Stat", "endPTS", *endPTS, "streamIndex", streamIndex)
+		doLog("endPTS", *endPTS)
+	case avpipe.AV_OUT_STAT_START_FILE:
+		segIdx := statArgs.(*int)
+		doLog("segIdx", *segIdx)
+	case avpipe.AV_OUT_STAT_END_FILE:
+		segIdx := statArgs.(*int)
+		doLog("segIdx", *segIdx)
 	case avpipe.AV_OUT_STAT_FRAME_WRITTEN:
 		encodingStats := statArgs.(*avpipe.EncodingFrameStats)
-		log.Info("AVCMD OutputHandler.Stat", "avType", avType,
-			"encodingStats", encodingStats, "streamIndex", streamIndex)
+		doLog("encodingStats", encodingStats)
 	}
 	return nil
 }

--- a/init-local.sh
+++ b/init-local.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+export FFMPEG_DIST="$HOME/.local"
+export SRT_DIST="$HOME/.local/bin"
+export PKG_CONFIG_PATH="$HOME/.local/lib/pkgconfig"
+echo FFMPEG_DIST=$FFMPEG_DIST
+echo SRT_DIST=$SRT_DIST
+echo PKG_CONFIG_PATH=$PKG_CONFIG_PATH

--- a/libavpipe/include/avpipe_xc.h
+++ b/libavpipe/include/avpipe_xc.h
@@ -100,9 +100,9 @@ typedef enum avp_stat_t {
     out_stat_bytes_written = 6,             // # of bytes written to the output stream
     out_stat_frame_written = 7,             // # of frames written to the output stream
     in_stat_first_keyframe_pts = 8,         // First keyframe in the input stream
-    out_stat_encoding_end_pts = 9,          //
-    out_stat_start_file = 10,               //
-    out_stat_end_file = 11,                 //
+    out_stat_encoding_end_pts = 9,          // The last PTS encoded. This stat is recorded when a file is closed
+    out_stat_start_file = 10,               // Sent when a new file is opened and reports the segment index
+    out_stat_end_file = 11,                 // Sent when a file is closed and reports the segment index
     in_stat_data_scte35 = 12               // SCTE data arrived
 } avp_stat_t;
 

--- a/libavpipe/include/avpipe_xc.h
+++ b/libavpipe/include/avpipe_xc.h
@@ -94,14 +94,16 @@ typedef enum avpipe_buftype_t {
 typedef enum avp_stat_t {
     in_stat_bytes_read = 1,                 // # of bytes read from input stream
     in_stat_audio_frame_read = 2,           // # of audio frames read from the input stream
-    in_stat_video_frame_read = 4,           // # of video frames read from the input stream
-    in_stat_decoding_audio_start_pts = 8,   // PTS of first audio packet went to the decoder
-    in_stat_decoding_video_start_pts = 16,  // PTS of first video packet went to the decoder
-    out_stat_bytes_written = 32,            // # of bytes written to the output stream
-    out_stat_frame_written = 64,            // # of frames written to the output stream
-    in_stat_first_keyframe_pts = 128,       // First keyframe in the input stream
-    out_stat_encoding_end_pts = 256,        // 
-    in_stat_data_scte35 = 512               // SCTE data arrived
+    in_stat_video_frame_read = 3,           // # of video frames read from the input stream
+    in_stat_decoding_audio_start_pts = 4,   // PTS of first audio packet went to the decoder
+    in_stat_decoding_video_start_pts = 5,   // PTS of first video packet went to the decoder
+    out_stat_bytes_written = 6,             // # of bytes written to the output stream
+    out_stat_frame_written = 7,             // # of frames written to the output stream
+    in_stat_first_keyframe_pts = 8,         // First keyframe in the input stream
+    out_stat_encoding_end_pts = 9,          //
+    out_stat_start_file = 10,               //
+    out_stat_end_file = 11,                 //
+    in_stat_data_scte35 = 12               // SCTE data arrived
 } avp_stat_t;
 
 struct coderctx_t;

--- a/libavpipe/include/avpipe_xc.h
+++ b/libavpipe/include/avpipe_xc.h
@@ -548,6 +548,15 @@ typedef struct xc_frame_t {
     int         stream_index;
 } xc_frame_t;
 
+/**
+ * out_tracker_t is used to keep information useful for providing stat
+ * information about a stream.
+ *
+ * It is kept within the `avpipe_opaque` field of the AVFormatContext. One
+ * out_tracker_t is created for each output stream. The `out_tracker_t`'s
+ * lifecycle is associated with the format context, and it will be freed in
+ * `avpipe_fini`.
+ */
 typedef struct out_tracker_t {
     struct avpipe_io_handler_t  *out_handlers;
     coderctx_t                  *encoder_ctx;   /* Needed to get access for stats */
@@ -559,6 +568,8 @@ typedef struct out_tracker_t {
     /** Needed to detect type of encoding frame */
     int video_stream_index;
     int audio_stream_index;
+
+    int output_stream_index;
 } out_tracker_t;
 
 typedef struct encoding_frame_stats_t {

--- a/libavpipe/src/avpipe_io.c
+++ b/libavpipe/src/avpipe_io.c
@@ -211,14 +211,11 @@ elv_io_close(
     if (out_tracker != NULL)
         out_handlers = out_tracker->out_handlers;
 
-    elv_dbg("OUT elv_io_close url=%s, stream_index=%d, seg_index=%d avioctx=%p, avioctx->opaque=%p buf=%p outtracker[0]->last_outctx=%p, outtracker[1]->last_outctx=%p",
+    elv_dbg("OUT elv_io_close url=%s, stream_index=%d, seg_index=%d avioctx=%p, avioctx->opaque=%p buf=%p outtracker[0]->last_outctx=%p, outtracker[1]->last_outctx=%p, outhandlers=%p",
         outctx != NULL ? outctx->url : "", outctx != NULL ? outctx->stream_index : -1, outctx != NULL ? outctx->seg_index : -1, pb, pb->opaque, avioctx->buffer,
-	    out_tracker != NULL ? out_tracker[0].last_outctx : 0, out_tracker != NULL ? out_tracker[1].last_outctx : 0);
+	    out_tracker != NULL ? out_tracker[0].last_outctx : 0, out_tracker != NULL ? out_tracker[1].last_outctx : 0, out_handlers);
     if (out_handlers) {
-#if 0
-        // PENDING (RM): this crashes with ffmpeg-4.4, needs to be fixed
-        out_handlers->avpipe_stater(outctx, out_stat_encoding_end_pts);
-#endif
+        out_handlers->avpipe_stater(outctx, 0, out_stat_encoding_end_pts);
         out_handlers->avpipe_closer(outctx);
     }
     if (outctx)

--- a/libavpipe/src/avpipe_io.c
+++ b/libavpipe/src/avpipe_io.c
@@ -218,6 +218,10 @@ elv_io_close(
         outctx != NULL ? outctx->url : "", outctx != NULL ? outctx->stream_index : -1, outctx != NULL ? outctx->seg_index : -1, pb, pb->opaque, avioctx->buffer,
 	    out_tracker != NULL ? out_tracker->last_outctx : 0, out_handlers);
     if (out_handlers) {
+        // TODO(Nate): Separate out this stat into something more descriptive of the particular case
+        // For now, this double-stat is fine because the 'out_stat_encoding_end_pts' is also used
+        // for muxing, which doesn't have a meaningful value of 'seg_index'. Additionally, ABR and
+        // mez should be pretty separate. But that can be done later.
         out_handlers->avpipe_stater(outctx, out_tracker->output_stream_index, out_stat_encoding_end_pts);
         out_handlers->avpipe_stater(outctx, out_tracker->output_stream_index, out_stat_end_file);
         out_handlers->avpipe_closer(outctx);

--- a/libavpipe/src/avpipe_io.c
+++ b/libavpipe/src/avpipe_io.c
@@ -217,7 +217,7 @@ elv_io_close(
         outctx != NULL ? outctx->url : "", outctx != NULL ? outctx->stream_index : -1, outctx != NULL ? outctx->seg_index : -1, pb, pb->opaque, avioctx->buffer,
 	    out_tracker != NULL ? out_tracker->last_outctx : 0, out_handlers);
     if (out_handlers) {
-        out_handlers->avpipe_stater(outctx, 0, out_stat_encoding_end_pts);
+        out_handlers->avpipe_stater(outctx, out_tracker->output_stream_index, out_stat_encoding_end_pts);
         out_handlers->avpipe_closer(outctx);
     }
     if (outctx)

--- a/libavpipe/src/avpipe_io.c
+++ b/libavpipe/src/avpipe_io.c
@@ -39,6 +39,7 @@ elv_io_open(
 
     elv_dbg("OUT elv_io_open url=%s", url);
 
+    ioctx_t *outctx = (ioctx_t *) calloc(1, sizeof(ioctx_t));
     out_tracker_t *out_tracker = (out_tracker_t *) format_ctx->avpipe_opaque;
     avpipe_io_handler_t *out_handlers = out_tracker->out_handlers;
 
@@ -46,7 +47,6 @@ elv_io_open(
         /* Regular segment */
         char *endptr;
         AVDictionaryEntry *stream_opt = av_dict_get(*options, "stream_index", 0, 0);
-        ioctx_t *outctx = (ioctx_t *) calloc(1, sizeof(ioctx_t));
 
         /* The outctx is created after writing the first frame, so set frames_written to 1. */
         //outctx->frames_written = 1;
@@ -78,7 +78,6 @@ elv_io_open(
         elv_dbg("OUT elv_io_open stream_index=%d, seg_index=%d avioctx=%p, avioctx->opaque=%p, buf=%p, outctx=%p, outtracker->last_outctx=%p, outtracker->last_outctx=%p",
             outctx->stream_index, outctx->seg_index, avioctx, avioctx->opaque, avioctx->buffer, outctx, out_tracker->last_outctx, out_tracker->last_outctx);
     } else {
-        ioctx_t *outctx = (ioctx_t *) calloc(1, sizeof(ioctx_t));
         outctx->stream_index = 0;
         outctx->encoder_ctx = out_tracker->encoder_ctx;
         outctx->inctx = out_tracker->inctx;
@@ -195,6 +194,8 @@ elv_io_open(
         (*pb) = avioctx;
     }
 
+    out_handlers->avpipe_stater(outctx, out_tracker->output_stream_index, out_stat_start_file);
+
     return ret;
 }
 
@@ -218,6 +219,7 @@ elv_io_close(
 	    out_tracker != NULL ? out_tracker->last_outctx : 0, out_handlers);
     if (out_handlers) {
         out_handlers->avpipe_stater(outctx, out_tracker->output_stream_index, out_stat_encoding_end_pts);
+        out_handlers->avpipe_stater(outctx, out_tracker->output_stream_index, out_stat_end_file);
         out_handlers->avpipe_closer(outctx);
     }
     if (outctx)

--- a/libavpipe/src/avpipe_io.c
+++ b/libavpipe/src/avpipe_io.c
@@ -54,13 +54,13 @@ elv_io_open(
         outctx->stream_index = (int) strtol(stream_opt->value, &endptr, 10);
         outctx->url = strdup(url);
         assert(outctx->stream_index == 0 || outctx->stream_index == 1);
-        if (out_tracker[outctx->stream_index].xc_type == xc_video)
+        if (out_tracker->xc_type == xc_video)
             outctx->type = avpipe_video_segment;
         else
             outctx->type = avpipe_audio_segment;
-        outctx->seg_index = out_tracker[outctx->stream_index].seg_index;
-        out_tracker[outctx->stream_index].seg_index++;
-        outctx->inctx = out_tracker[outctx->stream_index].inctx;
+        outctx->seg_index = out_tracker->seg_index;
+        out_tracker->seg_index++;
+        outctx->inctx = out_tracker->inctx;
 
         if (out_handlers->avpipe_opener(url, outctx) < 0) {
             free(outctx);
@@ -73,15 +73,15 @@ elv_io_open(
         avioctx->seekable = 0;
         avioctx->direct = 1;
         (*pb) = avioctx;
-        out_tracker[outctx->stream_index].last_outctx = outctx;
+        out_tracker->last_outctx = outctx;
 
         elv_dbg("OUT elv_io_open stream_index=%d, seg_index=%d avioctx=%p, avioctx->opaque=%p, buf=%p, outctx=%p, outtracker->last_outctx=%p, outtracker->last_outctx=%p",
-            outctx->stream_index, outctx->seg_index, avioctx, avioctx->opaque, avioctx->buffer, outctx, out_tracker[outctx->stream_index].last_outctx, out_tracker[outctx->stream_index].last_outctx);
+            outctx->stream_index, outctx->seg_index, avioctx, avioctx->opaque, avioctx->buffer, outctx, out_tracker->last_outctx, out_tracker->last_outctx);
     } else {
         ioctx_t *outctx = (ioctx_t *) calloc(1, sizeof(ioctx_t));
         outctx->stream_index = 0;
-        outctx->encoder_ctx = out_tracker[outctx->stream_index].encoder_ctx;
-        outctx->inctx = out_tracker[outctx->stream_index].inctx;
+        outctx->encoder_ctx = out_tracker->encoder_ctx;
+        outctx->inctx = out_tracker->inctx;
         outctx->seg_index = 0; // init segment has stream_index and seg_index = 0
 
         if (!url || url[0] == '\0') {
@@ -107,8 +107,8 @@ elv_io_open(
                     outctx->stream_index = url[i] - '0';
                 }
             }
-            outctx->encoder_ctx = out_tracker[outctx->stream_index].encoder_ctx;
-            outctx->inctx = out_tracker[outctx->stream_index].inctx;
+            outctx->encoder_ctx = out_tracker->encoder_ctx;
+            outctx->inctx = out_tracker->inctx;
             //elv_dbg("XXX stream_index=%d", outctx->stream_index);
             if (!strncmp(url + strlen(url) - 3, "mpd", 3)) {
                 outctx->type = avpipe_manifest;
@@ -119,14 +119,14 @@ elv_io_open(
                 outctx->seg_index = -1;     // Special index for manifest
             }
             else if (!strncmp(url, "media", 5)) {
-                if (out_tracker[outctx->stream_index].xc_type == xc_video)
+                if (out_tracker->xc_type == xc_video)
                     outctx->type = avpipe_video_m3u;
                 else
                     outctx->type = avpipe_audio_m3u;
                 outctx->seg_index = -1;     // Special index for manifest
             }
             else if (!strncmp(url, "init", 4)) {
-                if (out_tracker[outctx->stream_index].xc_type == xc_video)
+                if (out_tracker->xc_type == xc_video)
                     outctx->type = avpipe_video_init_stream;
                 else
                     outctx->type = avpipe_audio_init_stream;
@@ -147,16 +147,16 @@ elv_io_open(
                     free(outctx);
                     return -1;
                 }
-                outctx->seg_index = out_tracker[outctx->stream_index].seg_index;
-                out_tracker[outctx->stream_index].seg_index++;
-                outctx->inctx = out_tracker[outctx->stream_index].inctx;
+                outctx->seg_index = out_tracker->seg_index;
+                out_tracker->seg_index++;
+                outctx->inctx = out_tracker->inctx;
             } else if (!strncmp(url, "fmp4", 4)) {
                 outctx->type = avpipe_fmp4_stream;
             } else if (strstr(url, "segment")) {
                 outctx->type = avpipe_mp4_segment;
-                outctx->seg_index = out_tracker[outctx->stream_index].seg_index;
-                out_tracker[outctx->stream_index].seg_index++;
-                outctx->inctx = out_tracker[outctx->stream_index].inctx;
+                outctx->seg_index = out_tracker->seg_index;
+                out_tracker->seg_index++;
+                outctx->inctx = out_tracker->inctx;
             }
         }
  
@@ -166,7 +166,7 @@ elv_io_open(
             outctx->type == avpipe_video_fmp4_segment ||
             outctx->type == avpipe_audio_fmp4_segment)
             // not set for outctx->type == avpipe_image because elv_io_close will free outctx for each frame extracted
-            out_tracker[outctx->stream_index].last_outctx = outctx;
+            out_tracker->last_outctx = outctx;
         /* Manifest or init segments */
         if (out_handlers->avpipe_opener(url, outctx) < 0) {
             free(outctx);
@@ -177,7 +177,7 @@ elv_io_open(
             out_handlers->avpipe_reader, out_handlers->avpipe_writer, out_handlers->avpipe_seeker);
 
         elv_dbg("OUT elv_io_open url=%s, type=%d, stream_index=%d, seg_index=%d, last_outctx=%p, buf=%p",
-            url, outctx->type, outctx->stream_index, outctx->seg_index, out_tracker[outctx->stream_index].last_outctx, avioctx->buffer);
+            url, outctx->type, outctx->stream_index, outctx->seg_index, out_tracker->last_outctx, avioctx->buffer);
 
         /* libavformat expects seekable streams for mp4 */
         if (outctx->type == avpipe_mp4_stream || outctx->type == avpipe_mp4_segment)
@@ -208,12 +208,14 @@ elv_io_close(
     ioctx_t *outctx = (ioctx_t *)pb->opaque;
     avpipe_io_handler_t *out_handlers = NULL;
 
-    if (out_tracker != NULL)
-        out_handlers = out_tracker->out_handlers;
 
-    elv_dbg("OUT elv_io_close url=%s, stream_index=%d, seg_index=%d avioctx=%p, avioctx->opaque=%p buf=%p outtracker[0]->last_outctx=%p, outtracker[1]->last_outctx=%p, outhandlers=%p",
+    if (out_tracker != NULL) {
+        out_handlers = out_tracker->out_handlers;
+    }
+
+    elv_dbg("OUT elv_io_close url=%s, stream_index=%d, seg_index=%d avioctx=%p, avioctx->opaque=%p buf=%p outtracker->last_outctx=%p, outhandlers=%p",
         outctx != NULL ? outctx->url : "", outctx != NULL ? outctx->stream_index : -1, outctx != NULL ? outctx->seg_index : -1, pb, pb->opaque, avioctx->buffer,
-	    out_tracker != NULL ? out_tracker[0].last_outctx : 0, out_tracker != NULL ? out_tracker[1].last_outctx : 0, out_handlers);
+	    out_tracker != NULL ? out_tracker->last_outctx : 0, out_handlers);
     if (out_handlers) {
         out_handlers->avpipe_stater(outctx, 0, out_stat_encoding_end_pts);
         out_handlers->avpipe_closer(outctx);

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -1783,29 +1783,28 @@ prepare_encoder(
      * Needs to allocate up to number of streams when transcoding multiple streams at the same time.
      */
     if (params->xc_type & xc_video) {
-        out_tracker = (out_tracker_t *) calloc(MAX_STREAMS, sizeof(out_tracker_t));
-        out_tracker[0].out_handlers = out_handlers;
-        out_tracker[0].inctx = inctx;
-        out_tracker[0].video_stream_index = decoder_context->video_stream_index;
-        out_tracker[0].audio_stream_index = decoder_context->audio_stream_index[0];
-        out_tracker[0].seg_index = atoi(params->start_segment_str);
-        out_tracker[0].encoder_ctx = encoder_context;
-        out_tracker[0].xc_type = xc_video;
+        out_tracker = (out_tracker_t *) calloc(1, sizeof(out_tracker_t));
+        out_tracker->out_handlers = out_handlers;
+        out_tracker->inctx = inctx;
+        out_tracker->video_stream_index = decoder_context->video_stream_index;
+        out_tracker->audio_stream_index = decoder_context->audio_stream_index[0];
+        out_tracker->seg_index = atoi(params->start_segment_str);
+        out_tracker->encoder_ctx = encoder_context;
+        out_tracker->xc_type = xc_video;
         encoder_context->format_context->avpipe_opaque = out_tracker;
     }
 
     if (params->xc_type & xc_audio) {
         for (int j=0; j<encoder_context->n_audio_output; j++) {
-            out_tracker = (out_tracker_t *) calloc(MAX_STREAMS, sizeof(out_tracker_t));
-            for (int i=0; i<encoder_context->n_audio_output; i++) {
-                out_tracker[i].out_handlers = out_handlers;
-                out_tracker[i].inctx = inctx;
-                out_tracker[i].video_stream_index = decoder_context->video_stream_index;
-                out_tracker[i].audio_stream_index = decoder_context->audio_stream_index[i];
-                out_tracker[i].seg_index = atoi(params->start_segment_str);
-                out_tracker[i].encoder_ctx = encoder_context;
-                out_tracker[i].xc_type = xc_audio;
-            }
+            out_tracker = (out_tracker_t *) calloc(1, sizeof(out_tracker_t));
+            out_tracker->out_handlers = out_handlers;
+            out_tracker->inctx = inctx;
+            out_tracker->video_stream_index = decoder_context->video_stream_index;
+            out_tracker->audio_stream_index = decoder_context->audio_stream_index[j];
+            out_tracker->seg_index = atoi(params->start_segment_str);
+            out_tracker->encoder_ctx = encoder_context;
+            out_tracker->xc_type = xc_audio;
+            out_tracker->output_stream_index = j;
             encoder_context->format_context2[j]->avpipe_opaque = out_tracker;
         }
     }

--- a/live/lhr_tool_test.go
+++ b/live/lhr_tool_test.go
@@ -583,17 +583,27 @@ func (o *outputCtx) Close() error {
 }
 
 func (o *outputCtx) Stat(streamIndex int, avType avpipe.AVType, statType avpipe.AVStatType, statArgs interface{}) error {
+	doLog := func(args ...interface{}) {
+		if debugFrameLevel {
+			logArgs := []interface{}{"stat", statType.Name(), "avType", avType.Name(), "streamIndex", streamIndex}
+			logArgs = append(logArgs, args...)
+			log.Debug("STAT", logArgs...)
+		}
+	}
+
 	switch statType {
 	case avpipe.AV_OUT_STAT_BYTES_WRITTEN:
 		writeOffset := statArgs.(*uint64)
-		if debugFrameLevel {
-			log.Debug("STAT, write offset", *writeOffset, "streamIndex", streamIndex, "avType", avType)
-		}
+		doLog("write offset", *writeOffset)
 	case avpipe.AV_OUT_STAT_ENCODING_END_PTS:
 		endPTS := statArgs.(*uint64)
-		if debugFrameLevel {
-			log.Debug("STAT, endPTS", *endPTS, "streamIndex", streamIndex, "avType", avType)
-		}
+		doLog("endPTS", *endPTS)
+	case avpipe.AV_OUT_STAT_START_FILE:
+		segIdx := statArgs.(*int)
+		doLog("segIdx", *segIdx)
+	case avpipe.AV_OUT_STAT_END_FILE:
+		segIdx := statArgs.(*int)
+		doLog("segIdx", *segIdx)
 	}
 	return nil
 }


### PR DESCRIPTION
This PR consists of a couple of things that are pretty well separated into commits:

- Add `start_file` and `end_file` as stat events.
- Format the README and add a mention of `exc` and `elvxc`.
- Remove redundant `out_tracker_t` allocations.
- Add assorted helper methods to go enums.
- Simplify test logging

There will be an associated PR in qfab to actually make these stats visible.