### PR TITLE
Include xc handle in logs

### DIFF
--- a/avpipe.c
+++ b/avpipe.c
@@ -67,6 +67,8 @@ int     AVPipeCloseOutput(int64_t, int64_t);
 int     AVPipeCloseMuxOutput(int64_t);
 int     AVPipeStatOutput(int64_t, int64_t, int, avpipe_buftype_t, avp_stat_t, void *);
 int     AVPipeStatMuxOutput(int64_t, int, avp_stat_t, void *);
+int32_t GenerateAndRegisterHandle();
+int     AssociateCThreadWithHandle(int32_t);
 int     CLog(char *);
 int     CDebug(char *);
 int     CInfo(char *);
@@ -380,6 +382,7 @@ udp_in_opener(
     params->udp_channel = inctx->udp_channel;
     params->inctx = inctx;
 
+    // TODO(Nate): How to get the handle all the way into here??
     pthread_create(&inctx->utid, NULL, udp_thread_func, params);
     elv_dbg("IN OPEN UDP fd=%d, sockfd=%d, url=%s, tid=%"PRId64, fd, sockfd, url, inctx->utid);
     return 0;
@@ -1043,6 +1046,8 @@ xc(
         goto end_tx;
     }
 
+    xctx->handle = GenerateAndRegisterHandle();
+
     if ((rc = avpipe_xc(xctx, 0)) != eav_success) {
         elv_err("Transcoding failed url=%s, rc=%d", params->url, rc);
         goto end_tx;
@@ -1346,6 +1351,8 @@ mux(
         elv_err("Initializing muxer failed, url=%s", params->url);
         goto end_mux;
     }
+
+    xctx->handle = GenerateAndRegisterHandle();
 
     if ((rc = avpipe_mux(xctx)) != eav_success) {
         elv_err("Muxing failed");

--- a/avpipe.go
+++ b/avpipe.go
@@ -37,12 +37,11 @@ package avpipe
 // #include "elv_log.h"
 import "C"
 import (
-	"crypto/rand"
 	"encoding/json"
 	"fmt"
 	"io"
-	"math"
 	"math/big"
+	"math/rand"
 	"sync"
 	"unsafe"
 )
@@ -1471,12 +1470,8 @@ func getCParams(params *XcParams) (*C.xcparams_t, error) {
 }
 
 func generateI32Handle() int32 {
-	handle64, err := rand.Int(rand.Reader, big.NewInt(math.MaxInt32))
-	if err != nil {
-		log.Error("Unexpected error generating handle randomness", err)
-		return 0
-	}
-	return int32(handle64.Int64())
+	// avpipe treats negative handles as evidence of an error, so we generate a non-negative handle
+	return rand.Int31()
 }
 
 // params: transcoding parameters

--- a/avpipe.go
+++ b/avpipe.go
@@ -45,12 +45,7 @@ import (
 	"math/big"
 	"sync"
 	"unsafe"
-
-	elog "github.com/eluv-io/log-go"
-	"github.com/modern-go/gls"
 )
-
-var log = elog.Get("/eluvio/avpipe")
 
 const traceIo bool = false
 
@@ -1293,68 +1288,38 @@ func (h *ioHandler) OutStat(fd C.int64_t,
 	return err
 }
 
-// TODO(Nate): DO this
-// If multiple simultaneous XCs, can we just have a map[gid]handle and set that when we start a
-// transcode job?
-
-var gidHandleMap sync.Map = sync.Map{}
-
-func AssociateGIDWithHandle(handle int32) {
-	gidHandleMap.Store(gls.GoID(), handle)
-}
-
-func DissociateGIDWithHandle() {
-	gidHandleMap.Delete(gls.GoID())
-}
-
-func GIDHandle() (int32, bool) {
-	gid := gls.GoID()
-	handle, ok := gidHandleMap.Load(gid)
-	if !ok {
-		return 0, false
-	}
-	return handle.(int32), true
-}
-
-func LogHandleIfKnown() []interface{} {
-	if handle, ok := GIDHandle(); ok {
-		return []interface{}{"av_handle", handle}
-	}
-	return nil
-}
-
 //export CLog
 func CLog(msg *C.char) C.int {
 	m := C.GoString((*C.char)(unsafe.Pointer(msg)))
-	log.Info(m, LogHandleIfKnown()...)
+	log.Info(m)
 	return C.int(0)
 }
 
 //export CDebug
 func CDebug(msg *C.char) C.int {
 	m := C.GoString((*C.char)(unsafe.Pointer(msg)))
-	log.Debug(m, LogHandleIfKnown()...)
+	log.Debug(m)
 	return C.int(len(m))
 }
 
 //export CInfo
 func CInfo(msg *C.char) C.int {
 	m := C.GoString((*C.char)(unsafe.Pointer(msg)))
-	log.Info(m, LogHandleIfKnown()...)
+	log.Info(m)
 	return C.int(len(m))
 }
 
 //export CWarn
 func CWarn(msg *C.char) C.int {
 	m := C.GoString((*C.char)(unsafe.Pointer(msg)))
-	log.Warn(m, LogHandleIfKnown()...)
+	log.Warn(m)
 	return C.int(len(m))
 }
 
 //export CError
 func CError(msg *C.char) C.int {
 	m := C.GoString((*C.char)(unsafe.Pointer(msg)))
-	log.Error(m, LogHandleIfKnown()...)
+	log.Error(m)
 	return C.int(len(m))
 }
 

--- a/avpipe.go
+++ b/avpipe.go
@@ -1288,6 +1288,22 @@ func (h *ioHandler) OutStat(fd C.int64_t,
 	return err
 }
 
+//export GenerateAndRegisterHandle
+func GenerateAndRegisterHandle() C.int32_t {
+	handle := generateI32Handle()
+	AssociateGIDWithHandle(handle)
+	return C.int32_t(handle)
+}
+
+//export AssociateCThreadWithHandle
+func AssociateCThreadWithHandle(handle C.int32_t) C.int {
+	if int32(handle) == 0 {
+		return C.int(0)
+	}
+	AssociateGIDWithHandle(int32(handle))
+	return C.int(0)
+}
+
 //export CLog
 func CLog(msg *C.char) C.int {
 	m := C.GoString((*C.char)(unsafe.Pointer(msg)))
@@ -1477,12 +1493,7 @@ func Xc(params *XcParams) error {
 		log.Error("Transcoding failed", err, "url", params.Url)
 	}
 
-	handle := generateI32Handle()
-	log.Info("Associating handle with one shot XC", "av_handle", handle, "url", params.Url)
-	AssociateGIDWithHandle(handle)
-
 	rc := C.xc((*C.xcparams_t)(unsafe.Pointer(cparams)))
-
 	DissociateGIDWithHandle()
 
 	gMutex.Lock()
@@ -1504,10 +1515,6 @@ func Mux(params *XcParams) error {
 	if err != nil {
 		log.Error("Muxing failed", err, "url", params.Url)
 	}
-
-	handle := generateI32Handle()
-	log.Info("Associating handle with one shot mux", "av_handle", handle, "url", params.Url)
-	AssociateGIDWithHandle(handle)
 
 	rc := C.mux((*C.xcparams_t)(unsafe.Pointer(cparams)))
 

--- a/avpipe_log.go
+++ b/avpipe_log.go
@@ -1,6 +1,9 @@
 package avpipe
 
 import (
+	"bytes"
+	"encoding/binary"
+	"encoding/hex"
 	"sync"
 
 	"github.com/modern-go/gls"
@@ -44,7 +47,7 @@ func (l *logWrapper) Fatal(msg string, fields ...interface{}) {
 	l.log.Fatal(msg, fields...)
 }
 
-var log = logWrapper{log: elog.Get("/eluvio/avpipe")}
+var log = logWrapper{log: elog.Get("/avpipe")}
 
 var gidHandleMap sync.Map = sync.Map{}
 
@@ -67,7 +70,9 @@ func GIDHandle() (int32, bool) {
 
 func logHandleIfKnown() []interface{} {
 	if handle, ok := GIDHandle(); ok {
-		return []interface{}{"av_handle", handle}
+		buf := &bytes.Buffer{}
+		binary.Write(buf, binary.BigEndian, handle)
+		return []interface{}{"avp", hex.EncodeToString(buf.Bytes())}
 	}
 	return nil
 }

--- a/avpipe_log.go
+++ b/avpipe_log.go
@@ -1,0 +1,73 @@
+package avpipe
+
+import (
+	"sync"
+
+	"github.com/modern-go/gls"
+
+	elog "github.com/eluv-io/log-go"
+)
+
+// logWrapper is used to wrap the standard log-go logger to include the handle of the AVPipe job in
+// question, if it is known
+type logWrapper struct {
+	log *elog.Log
+}
+
+func (l *logWrapper) Trace(msg string, fields ...interface{}) {
+	fields = append(fields, logHandleIfKnown()...)
+	l.log.Trace(msg, fields...)
+}
+
+func (l *logWrapper) Debug(msg string, fields ...interface{}) {
+	fields = append(fields, logHandleIfKnown()...)
+	l.log.Debug(msg, fields...)
+}
+
+func (l *logWrapper) Info(msg string, fields ...interface{}) {
+	fields = append(fields, logHandleIfKnown()...)
+	l.log.Info(msg, fields...)
+}
+
+func (l *logWrapper) Warn(msg string, fields ...interface{}) {
+	fields = append(fields, logHandleIfKnown()...)
+	l.log.Warn(msg, fields...)
+}
+
+func (l *logWrapper) Error(msg string, fields ...interface{}) {
+	fields = append(fields, logHandleIfKnown()...)
+	l.log.Error(msg, fields...)
+}
+
+func (l *logWrapper) Fatal(msg string, fields ...interface{}) {
+	fields = append(fields, logHandleIfKnown()...)
+	l.log.Fatal(msg, fields...)
+}
+
+var log = logWrapper{log: elog.Get("/eluvio/avpipe")}
+
+var gidHandleMap sync.Map = sync.Map{}
+
+func AssociateGIDWithHandle(handle int32) {
+	gidHandleMap.Store(gls.GoID(), handle)
+}
+
+func DissociateGIDWithHandle() {
+	gidHandleMap.Delete(gls.GoID())
+}
+
+func GIDHandle() (int32, bool) {
+	gid := gls.GoID()
+	handle, ok := gidHandleMap.Load(gid)
+	if !ok {
+		return 0, false
+	}
+	return handle.(int32), true
+}
+
+func logHandleIfKnown() []interface{} {
+	if handle, ok := GIDHandle(); ok {
+		return []interface{}{"av_handle", handle}
+	}
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ require (
 	github.com/eluv-io/errors-go v1.0.0
 	github.com/eluv-io/log-go v1.0.1
 	github.com/grafov/m3u8 v0.11.1
+	github.com/modern-go/gls v0.0.0-20250215024828-78308f6bb19d // indirect
 	github.com/spf13/cobra v0.0.5
 	github.com/stretchr/testify v1.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -76,8 +76,9 @@ github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
-github.com/modern-go/gls v0.0.0-20220109145502-612d0167dce5 h1:uiS4zKYKJVj5F3ID+5iylfKPsEQmBEOucSD9Vgmn0i0=
 github.com/modern-go/gls v0.0.0-20220109145502-612d0167dce5/go.mod h1:I8AX+yW//L8Hshx6+a1m3bYkwXkpsVjA2795vP4f4oQ=
+github.com/modern-go/gls v0.0.0-20250215024828-78308f6bb19d h1:e3xdlObtriVu9HlrOfYB8Nmy51+DuJy5Hcgsg+x7ixg=
+github.com/modern-go/gls v0.0.0-20250215024828-78308f6bb19d/go.mod h1:I8AX+yW//L8Hshx6+a1m3bYkwXkpsVjA2795vP4f4oQ=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -2914,6 +2914,8 @@ transcode_video_func(
     xc_frame_t *xc_frame;
     int err = 0;
 
+    AssociateCThreadWithHandle(xctx->handle);
+
     AVFrame *frame = av_frame_alloc();
     AVFrame *filt_frame = av_frame_alloc();
 
@@ -2997,6 +2999,8 @@ transcode_audio_func(
     xcparams_t *params = xctx->params;
     xc_frame_t *xc_frame;
     int err = 0;
+
+    AssociateCThreadWithHandle(xctx->handle);
 
     AVFrame *frame = av_frame_alloc();
     AVFrame *filt_frame = av_frame_alloc();


### PR DESCRIPTION
This PR is an approach that I'm pretty happy with that will make logs much more parseable. As best as I can tell by manual inspection, every log that is emitted from `avpipe` will now include the `av_handle` as a parseable element of the log.

For LRO-styled jobs that use the v2 `XcInit` -> `XcRun` flow, this matches with the existing handle in the transcode context. For single-shot jobs that use `Xc` or `Mux`, this positive 32-bit int handle is generated at the start of these `c` functions after the `xctx_t` is created. This also includes the threads that are created, except for the UDP in thread, as it wasn't trivial to include the handle in that location.

This is implemented by using a `sync.Map` as a form of goroutine(thread)-local storage, and inserting that information if it is known in every log statement. This should not introduce much overhead, as the `sync.Map` is optimized for a situation where a number of goroutines are editing a disjoint set of keys, which is exactly the case here. Each goroutine will only ever edit its own entry.

I still need to test this a bit more thoroughly, but it should make AV logs significantly more `grep`-able and manually parseable.

This PR is totally separate from the other AV QoS improvements.

```
2025-03-01T01:39:33.510Z DEBUG PI IN READ read=6847 pos=9219239 total=9219239, checksum=50357 logger=/eluvio/avpipe gid=1621 av_handle=815607388
2025-03-01T01:39:33.510Z DEBUG PI VIDEO PACKET IN  pts=1040039 dts=1040039 duration=1001 pos=9210460 size=8779 stream_index=0 flags=0 data=0x35108c00 logger=/eluvio/avpipe gid=1621 av_handle=815607388
2025-03-01T01:39:33.510Z DEBUG AVPSRV IN STAT            logger=/eluvio/extapi/avtest gid=1621 streamIndex=0 video frame read=1040
2025-03-01T01:39:33.510Z DEBUG PI IN READ buf=0x34cb1600, size=2048 logger=/eluvio/avpipe gid=1621 av_handle=815607388
2025-03-01T01:39:33.510Z DEBUG PI VIDEO PACKET IN THREAD pts=1040039 dts=1040039 duration=1001 pos=9210460 size=8779 stream_index=0 flags=0 data=0x35108c00 logger=/eluvio/avpipe gid=1060 av_handle=815607388
```