### PR TITLE
Intercept WARN/ERROR logs

### DIFF
--- a/avpipe.go
+++ b/avpipe.go
@@ -1494,7 +1494,7 @@ func generateI32Handle() int32 {
 
 // params: transcoding parameters
 func Xc(params *XcParams) error {
-
+	defer XCEnded()
 	if params == nil {
 		log.Error("Failed transcoding, params are not set.")
 		return EAV_PARAM
@@ -1507,7 +1507,6 @@ func Xc(params *XcParams) error {
 	}
 
 	rc := C.xc((*C.xcparams_t)(unsafe.Pointer(cparams)))
-	XCEnded()
 
 	gMutex.Lock()
 	defer gMutex.Unlock()
@@ -1518,6 +1517,7 @@ func Xc(params *XcParams) error {
 }
 
 func Mux(params *XcParams) error {
+	defer XCEnded()
 	if params == nil {
 		log.Error("Failed muxing, params are not set")
 		return EAV_PARAM
@@ -1530,8 +1530,6 @@ func Mux(params *XcParams) error {
 	}
 
 	rc := C.mux((*C.xcparams_t)(unsafe.Pointer(cparams)))
-
-	XCEnded()
 
 	gMutex.Lock()
 	defer gMutex.Unlock()
@@ -1710,12 +1708,12 @@ func XcInit(params *XcParams) (int32, error) {
 }
 
 func XcRun(handle int32) error {
+	defer XCEnded()
 	if handle < 0 {
 		return EAV_BAD_HANDLE
 	}
 	AssociateGIDWithHandle(handle)
 	rc := C.xc_run(C.int32_t(handle))
-	XCEnded()
 	if rc == 0 {
 		return nil
 	}

--- a/avpipe.go
+++ b/avpipe.go
@@ -127,20 +127,38 @@ func (a AVType) Name() string {
 	}
 }
 
-func (a AVType) AVClass() string {
+type AVClass = string
+
+var AVClassE = struct {
+	Mez      AVClass
+	Abr      AVClass
+	Manifest AVClass
+	Mux      AVClass
+	Frame    AVClass
+	Unknown  AVClass
+}{
+	Mez:      "mez",
+	Abr:      "abr",
+	Manifest: "manifest",
+	Mux:      "mux",
+	Frame:    "frame",
+	Unknown:  "unknown",
+}
+
+func (a AVType) AVClass() AVClass {
 	switch a {
-	case FMP4AudioSegment, FMP4VideoSegment:
-		return "mez_creation"
+	case FMP4AudioSegment, FMP4VideoSegment, MP4Segment:
+		return AVClassE.Mez
 	case DASHAudioInit, DASHAudioSegment, DASHVideoInit, DASHVideoSegment:
-		return "abr"
+		return AVClassE.Abr
 	case HLSAudioM3U, HLSMasterM3U, HLSVideoM3U, DASHManifest:
-		return "manifest"
+		return AVClassE.Manifest
 	case FrameImage:
-		return "frame_extraction"
-	case MuxSegment, MP4Segment, MP4Stream, FMP4Stream:
-		return "mux"
+		return AVClassE.Frame
+	case MuxSegment, MP4Stream, FMP4Stream:
+		return AVClassE.Mux
 	default:
-		return "unknown"
+		return AVClassE.Unknown
 	}
 }
 

--- a/avpipe.go
+++ b/avpipe.go
@@ -1507,7 +1507,7 @@ func Xc(params *XcParams) error {
 	}
 
 	rc := C.xc((*C.xcparams_t)(unsafe.Pointer(cparams)))
-	DissociateGIDWithHandle()
+	XCEnded()
 
 	gMutex.Lock()
 	defer gMutex.Unlock()
@@ -1531,7 +1531,7 @@ func Mux(params *XcParams) error {
 
 	rc := C.mux((*C.xcparams_t)(unsafe.Pointer(cparams)))
 
-	DissociateGIDWithHandle()
+	XCEnded()
 
 	gMutex.Lock()
 	defer gMutex.Unlock()
@@ -1715,7 +1715,7 @@ func XcRun(handle int32) error {
 	}
 	AssociateGIDWithHandle(handle)
 	rc := C.xc_run(C.int32_t(handle))
-	DissociateGIDWithHandle()
+	XCEnded()
 	if rc == 0 {
 		return nil
 	}

--- a/avpipe_log.go
+++ b/avpipe_log.go
@@ -69,8 +69,16 @@ func AssociateGIDWithHandle(handle int32) {
 	}
 }
 
-func DissociateGIDWithHandle() {
-	gidHandleMap.Delete(gls.GoID())
+// XCEnded releases resources associated with the handle
+func XCEnded() {
+	handleUntyped, ok := gidHandleMap.LoadAndDelete(gls.GoID())
+	if !ok {
+		return
+	}
+	handle := handleUntyped.(int32)
+	handleChanMapMu.Lock()
+	delete(handleChanMap, handle)
+	handleChanMapMu.Unlock()
 }
 
 // RegisterWarnErrChanForHandle registers a channel to send error logs to for a given handle.

--- a/avpipe_log.go
+++ b/avpipe_log.go
@@ -65,7 +65,9 @@ var gidChanMap sync.Map = sync.Map{}
 var handleChanMap map[int32]chan string = make(map[int32]chan string)
 var handleChanMapMu sync.Mutex
 
-func AllMapsAreEmpty() bool {
+// AllLogMapsEmpty returns true if all log maps are empty
+// It should be used for testing purposes only
+func AllLogMapsEmpty() bool {
 	gidHandleMapLen := 0
 	gidHandleMap.Range(func(_, _ interface{}) bool {
 		gidHandleMapLen++

--- a/avpipe_log.go
+++ b/avpipe_log.go
@@ -90,6 +90,8 @@ func RegisterWarnErrChanForHandle(handle *int32, errChan chan string) {
 		return
 	}
 
+	gid := gls.GoID()
+	gidHandleMap.Store(gid, *handle)
 	handleChanMapMu.Lock()
 	if _, ok := handleChanMap[*handle]; ok {
 		log.Warn("RegisterErrorChanForHandle: handle already registered with channel", "handle", *handle)

--- a/avpipe_log.go
+++ b/avpipe_log.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/hex"
+	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/modern-go/gls"
@@ -33,11 +35,13 @@ func (l *logWrapper) Info(msg string, fields ...interface{}) {
 }
 
 func (l *logWrapper) Warn(msg string, fields ...interface{}) {
+	dispatchToChannelIfPresent("WARN", msg, fields...)
 	fields = append(fields, logHandleIfKnown()...)
 	l.log.Warn(msg, fields...)
 }
 
 func (l *logWrapper) Error(msg string, fields ...interface{}) {
+	dispatchToChannelIfPresent("ERROR", msg, fields...)
 	fields = append(fields, logHandleIfKnown()...)
 	l.log.Error(msg, fields...)
 }
@@ -50,13 +54,40 @@ func (l *logWrapper) Fatal(msg string, fields ...interface{}) {
 var log = logWrapper{log: elog.Get("/avpipe")}
 
 var gidHandleMap sync.Map = sync.Map{}
+var gidChanMap sync.Map = sync.Map{}
+
+var handleChanMap map[int32]chan string = make(map[int32]chan string)
+var handleChanMapMu sync.Mutex
 
 func AssociateGIDWithHandle(handle int32) {
-	gidHandleMap.Store(gls.GoID(), handle)
+	gid := gls.GoID()
+	gidHandleMap.Store(gid, handle)
+	if ch, ok := gidChanMap.LoadAndDelete(gid); ok {
+		handleChanMapMu.Lock()
+		handleChanMap[handle] = ch.(chan string)
+		handleChanMapMu.Unlock()
+	}
 }
 
 func DissociateGIDWithHandle() {
 	gidHandleMap.Delete(gls.GoID())
+}
+
+// RegisterWarnErrChanForHandle registers a channel to send error logs to for a given handle.
+// If handle is nil, then channel will be registered with a handle that is created on this
+// goroutine.
+func RegisterWarnErrChanForHandle(handle *int32, errChan chan string) {
+	if handle == nil {
+		gidChanMap.Store(gls.GoID(), errChan)
+		return
+	}
+
+	handleChanMapMu.Lock()
+	if _, ok := handleChanMap[*handle]; ok {
+		log.Warn("RegisterErrorChanForHandle: handle already registered with channel", "handle", *handle)
+	}
+	handleChanMap[*handle] = errChan
+	handleChanMapMu.Unlock()
 }
 
 func GIDHandle() (int32, bool) {
@@ -75,4 +106,20 @@ func logHandleIfKnown() []interface{} {
 		return []interface{}{"avp", hex.EncodeToString(buf.Bytes())}
 	}
 	return nil
+}
+
+func dispatchToChannelIfPresent(level string, msg string, fields ...interface{}) {
+	if handle, ok := GIDHandle(); ok {
+		if ch, ok := handleChanMap[handle]; ok {
+			//space-combine fields
+			strs := []string{level, msg}
+			for _, field := range fields {
+				strs = append(strs, fmt.Sprint(field))
+			}
+			select {
+			case ch <- strings.Join(strs, " "):
+			default:
+			}
+		}
+	}
 }

--- a/avpipe_log_test.go
+++ b/avpipe_log_test.go
@@ -13,7 +13,7 @@ import (
 func TestGIDAssociation(t *testing.T) {
 	wg := sync.WaitGroup{}
 
-	for i := 0; i < 100; i++ {
+	for i := 1; i < 100; i++ {
 		handle := int32(i)
 		wg.Add(1)
 		go func() {
@@ -30,8 +30,8 @@ func TestGIDAssociation(t *testing.T) {
 	wg.Wait()
 }
 
-// TestErrorCapturingTwoStep tests the error capturing mechanism when handle is known via XcInit
-func TestErrorCapturingTwoStep(t *testing.T) {
+// TestErrorCapturing tests the error capturing mechanism
+func TestErrorCapturing(t *testing.T) {
 	doOperation := func(handle int32, oneShot bool) {
 		errChan := make(chan string, 5)
 		// Oneshot API does not know the handle at this point
@@ -74,7 +74,7 @@ func TestErrorCapturingTwoStep(t *testing.T) {
 
 	// Test oneshot APIs
 	wg := sync.WaitGroup{}
-	for i := 0; i < 100; i++ {
+	for i := 1; i < 100; i++ {
 		handle := int32(i)
 		wg.Add(1)
 		go func() {
@@ -95,6 +95,8 @@ func TestErrorCapturingTwoStep(t *testing.T) {
 		}()
 	}
 	wg2.Wait()
+
+	require.True(t, AllMapsAreEmpty())
 }
 
 func TestCorrectChanClosure(t *testing.T) {
@@ -104,7 +106,7 @@ func TestCorrectChanClosure(t *testing.T) {
 		errCh := make(chan string, 5)
 		RegisterWarnErrChanForHandle(nil, errCh)
 
-		// Pretend an error happened, and we never get the assocaiteGIDWithHandle
+		// Pretend an error happened, and we never get the AssociateGIDWithHandle
 		XCEnded()
 
 		// Check that the channel is closed
@@ -115,4 +117,5 @@ func TestCorrectChanClosure(t *testing.T) {
 	}()
 
 	wg.Wait()
+	require.True(t, AllMapsAreEmpty())
 }

--- a/avpipe_log_test.go
+++ b/avpipe_log_test.go
@@ -96,7 +96,7 @@ func TestErrorCapturing(t *testing.T) {
 	}
 	wg2.Wait()
 
-	require.True(t, AllMapsAreEmpty())
+	require.True(t, AllLogMapsEmpty())
 }
 
 func TestCorrectChanClosure(t *testing.T) {
@@ -117,5 +117,5 @@ func TestCorrectChanClosure(t *testing.T) {
 	}()
 
 	wg.Wait()
-	require.True(t, AllMapsAreEmpty())
+	require.True(t, AllLogMapsEmpty())
 }

--- a/avpipe_log_test.go
+++ b/avpipe_log_test.go
@@ -1,0 +1,96 @@
+package avpipe
+
+import (
+	"fmt"
+	"math/rand/v2"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGIDAssociation(t *testing.T) {
+	wg := sync.WaitGroup{}
+
+	for i := 0; i < 100; i++ {
+		handle := int32(i)
+		wg.Add(1)
+		go func() {
+			AssociateGIDWithHandle(handle)
+			// Randomize scheduling a bit
+			time.Sleep(time.Millisecond*20 + time.Millisecond*time.Duration(rand.IntN(10)))
+			rHandle, ok := GIDHandle()
+			require.True(t, ok)
+			require.Equal(t, handle, rHandle)
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+}
+
+// TestErrorCapturingTwoStep tests the error capturing mechanism when handle is known via XcInit
+func TestErrorCapturingTwoStep(t *testing.T) {
+	doOperation := func(handle int32, oneShot bool) {
+		errChan := make(chan string, 5)
+		// Oneshot API does not know the handle at this point
+		var handlePtr *int32
+		if !oneShot {
+			handlePtr = &handle
+		}
+		RegisterWarnErrChanForHandle(handlePtr, errChan)
+
+		errUniq1 := rand.IntN(100)
+		errUniq2 := rand.IntN(100)
+		warnUniq1 := rand.IntN(100)
+		warnUniq2 := rand.IntN(100)
+		// Randomize scheduling a bit
+		time.Sleep(time.Millisecond*20 + time.Millisecond*time.Duration(rand.IntN(10)))
+
+		///// ENTER C CODE /////
+		if oneShot {
+			AssociateGIDWithHandle(handle)
+		}
+
+		log.Error(fmt.Sprintf("Error %d", errUniq1))
+		log.Error(fmt.Sprintf("Error %d", errUniq2))
+		log.Warn(fmt.Sprintf("Warn %d", warnUniq1))
+		log.Warn(fmt.Sprintf("Warn %d", warnUniq2))
+		///// EXIT C CODE /////
+
+		XCEnded()
+
+		// Check that all logs are captured
+		require.Len(t, errChan, 4)
+		require.Equal(t, fmt.Sprintf("ERROR Error %d", errUniq1), <-errChan)
+		require.Equal(t, fmt.Sprintf("ERROR Error %d", errUniq2), <-errChan)
+		require.Equal(t, fmt.Sprintf("WARN Warn %d", warnUniq1), <-errChan)
+		require.Equal(t, fmt.Sprintf("WARN Warn %d", warnUniq2), <-errChan)
+		require.Len(t, errChan, 0)
+	}
+
+	// Test oneshot APIs
+	wg := sync.WaitGroup{}
+	for i := 0; i < 100; i++ {
+		handle := int32(i)
+		wg.Add(1)
+		go func() {
+			doOperation(handle, true)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+
+	// Test two-step APIs
+	wg2 := sync.WaitGroup{}
+	for i := 0; i < 100; i++ {
+		handle := int32(i)
+		wg2.Add(1)
+		go func() {
+			doOperation(handle, false)
+			wg2.Done()
+		}()
+	}
+	wg2.Wait()
+}

--- a/go.mod
+++ b/go.mod
@@ -5,12 +5,13 @@ require (
 	github.com/eluv-io/errors-go v1.0.0
 	github.com/eluv-io/log-go v1.0.1
 	github.com/grafov/m3u8 v0.11.1
-	github.com/modern-go/gls v0.0.0-20250215024828-78308f6bb19d // indirect
+	github.com/modern-go/gls v0.0.0-20250215024828-78308f6bb19d
 	github.com/spf13/cobra v0.0.5
 	github.com/stretchr/testify v1.7.0
 )
 
 replace (
+	github.com/modern-go/gls => github.com/eluv-io/gls v1.0.0-elv1
 	github.com/prometheus/prometheus => github.com/prometheus/prometheus v1.7.1-0.20170814170113-3101606756c5
 	gopkg.in/urfave/cli.v1 => github.com/urfave/cli v1.22.0
 )

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/eluv-io/apexlog-go v1.9.1-elv3/go.mod h1:pZhIuRbWTsOm5WEOxke9B2dczjQu
 github.com/eluv-io/errors-go v0.0.0-20220118153923-f9ef09c8c7f2/go.mod h1:bSd8y2sXPla5W9piijQn/RT00T2bC0Dce5ofvQ8vWws=
 github.com/eluv-io/errors-go v1.0.0 h1:CsGhBoMWyXY1j4a4v4JiOPQrbNA7x/mm8PZCIyJJ40M=
 github.com/eluv-io/errors-go v1.0.0/go.mod h1:bSd8y2sXPla5W9piijQn/RT00T2bC0Dce5ofvQ8vWws=
+github.com/eluv-io/gls v1.0.0-elv1 h1:fV9z/aLSs5KH8wWMkamoS/Xxl8wmXF76WMx8/N5XEr8=
+github.com/eluv-io/gls v1.0.0-elv1/go.mod h1:4rPCrom1ZvL5sqFMGiNbCr/QfDq3oljqXEBdstdge0o=
 github.com/eluv-io/log-go v1.0.1 h1:j+/vNR7IwPxzgiwOWOKffWevEGeMhTXZVK7448FUuQg=
 github.com/eluv-io/log-go v1.0.1/go.mod h1:zXLeleJ9LQRHdEOvm7xh1dBQ/t5MJurj7vgfdUmL4jc=
 github.com/eluv-io/stack v1.8.2 h1:yocCvAcPy9vW5iBdNnig5Tem8LgOTT8JrOLvDcacnEQ=
@@ -76,9 +78,6 @@ github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
-github.com/modern-go/gls v0.0.0-20220109145502-612d0167dce5/go.mod h1:I8AX+yW//L8Hshx6+a1m3bYkwXkpsVjA2795vP4f4oQ=
-github.com/modern-go/gls v0.0.0-20250215024828-78308f6bb19d h1:e3xdlObtriVu9HlrOfYB8Nmy51+DuJy5Hcgsg+x7ixg=
-github.com/modern-go/gls v0.0.0-20250215024828-78308f6bb19d/go.mod h1:I8AX+yW//L8Hshx6+a1m3bYkwXkpsVjA2795vP4f4oQ=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=


### PR DESCRIPTION
This is an accompaniment to the content-fabric [PR](https://github.com/qluvio/content-fabric/pull/3176).

The primary thing this PR does is add some more utility to the `AVType` type, as well as intercept error and warn logs and send them to a channel. In order to reduce blocking, this just skips that if the channel is free.