### PR TITLE
Minimum required to function like exc

### DIFF
--- a/avpipe.go
+++ b/avpipe.go
@@ -86,6 +86,8 @@ const (
 	MuxSegment
 	// FrameImage 16
 	FrameImage
+	// MpegtsSegment 16
+	MpegtsSegment
 )
 
 func (a AVType) Name() string {
@@ -121,6 +123,8 @@ func (a AVType) Name() string {
 	case MuxSegment:
 		return "MuxSegment"
 	case FrameImage:
+		return "FrameImage"
+	case MpegtsSegment:
 		return "FrameImage"
 	default:
 		return fmt.Sprintf("Unknown(%d)", a)
@@ -956,6 +960,8 @@ func getAVType(av_type C.int) AVType {
 		return MuxSegment
 	case C.avpipe_image:
 		return FrameImage
+	case C.avpipe_mpegts_segment:
+		return MpegtsSegment
 	default:
 		return Unknown
 	}

--- a/avpipe.go
+++ b/avpipe.go
@@ -125,7 +125,7 @@ func (a AVType) Name() string {
 	case FrameImage:
 		return "FrameImage"
 	case MpegtsSegment:
-		return "FrameImage"
+		return "MpegtsSegment"
 	default:
 		return fmt.Sprintf("Unknown(%d)", a)
 	}


### PR DESCRIPTION
This is all that's necessary for `elvxc` to work correctly.

Also, I realized that on my computer, `elvxc` has a busted signature whenever I build it for whatever reason. Took a while to debug. Genuinely no idea what is really going on with that.

```
[nate-copy-ts-piping][~/eluvio/avpipe/elvxc]$ go install ./...
[nate-copy-ts-piping][~/eluvio/avpipe/elvxc]$ which elvxc
/Users/narmstrong/go/bin/elvxc
[nate-copy-ts-piping][~/eluvio/avpipe/elvxc]$ ls -l ~/go/bin/elvxc
-rwxr-xr-x  1 narmstrong  staff  8129192 Mar 11 19:56 /Users/narmstrong/go/bin/elvxc
[nate-copy-ts-piping][~/eluvio/avpipe/elvxc]$ codesign -vv elvxc
elvxc: invalid signature (code or signature have been modified)
In architecture: arm64
[nate-copy-ts-piping][~/eluvio/avpipe/elvxc]$ elvxc
[1]    60950 killed     elvxc
[nate-copy-ts-piping][~/eluvio/avpipe/elvxc]$ codesign -f -s
 - ~/go/bin/elvxc
/Users/narmstrong/go/bin/elvxc: replacing existing signature
[nate-copy-ts-piping][~/eluvio/avpipe/elvxc]$ elvxc
Audio Video Command

Usage:
  elvxc [command]

Available Commands:
  analyse     Analyse qfab log file
  help        Help about any command
  mux         Mux some media files based on a muxing spec
  probe       Probe a media file
  stress      Stress test the persistent cache
  transcode   Transcode a media file

Flags:
  -h, --help   help for elvxc

Use "elvxc [command] --help" for more information about a command.
```