### PR TITLE
Preserve continuity counts in MPEGTS output

### DIFF
--- a/doc/dev.md
+++ b/doc/dev.md
@@ -34,6 +34,12 @@ ffmpeg -re -i test.mp4 -map 0 -c copy -f mpegts udp://127.0.0.1:9000
 ./bin/exc -f udp://127.0.0.1:9000 -xc-type all -format fmp4-segment -seg-duration 30
 ```
 
+A more complex example - as called by the content fabric (source 50 fps):
+
+```
+./bin/exc -f udp://127.0.0.1:9000 -xc-type all -format fmp4-segment -video-bitrate 9500000 -audio-bitrate 192000 -sample-rate 48000  -video-seg-duration-ts 2700000  -audio-seg-duration-ts 1428480   -force-keyint 100 -enc-height 1080 -enc-width 1920 -sync-audio-to-stream-id 512   -audio-index 1,2  -copy-mpegts 1
+```
+
 #### SRT
 
 ```

--- a/libavpipe/src/avpipe_copy_mpegts.c
+++ b/libavpipe/src/avpipe_copy_mpegts.c
@@ -45,7 +45,7 @@ copy_mpegts_set_encoder_options(
     av_opt_set_int(encoder_context->format_context->priv_data, "segment_duration_ts", seg_duration_ts, 0);
 
     // For MPEGTS we want the continuity count to not reset at beginning of each segment (https://trac.ffmpeg.org/ticket/2828)
-    av_opt_set_int(encoder_context->format_context->priv_data, "individual_header_trailer", seg_duration_ts, 0);
+    av_opt_set_int(encoder_context->format_context->priv_data, "individual_header_trailer", 0, 0);
 
     int64_t stream_start_time = decoder_context->stream[stream_index]->start_time;
     cp_ctx->stream_start_pts = stream_start_time;

--- a/libavpipe/src/avpipe_copy_mpegts.c
+++ b/libavpipe/src/avpipe_copy_mpegts.c
@@ -43,7 +43,10 @@ copy_mpegts_set_encoder_options(
         seg_duration_ts = params->video_seg_duration_ts;
 
     av_opt_set_int(encoder_context->format_context->priv_data, "segment_duration_ts", seg_duration_ts, 0);
-    
+
+    // For MPEGTS we want the continuity count to not reset at beginning of each segment (https://trac.ffmpeg.org/ticket/2828)
+    av_opt_set_int(encoder_context->format_context->priv_data, "individual_header_trailer", seg_duration_ts, 0);
+
     int64_t stream_start_time = decoder_context->stream[stream_index]->start_time;
     cp_ctx->stream_start_pts = stream_start_time;
     if (stream_start_time != AV_NOPTS_VALUE) {


### PR DESCRIPTION


## TESTING WITH EXC

```
./bin/exc -f udp://127.0.0.1:9000 -xc-type all -format fmp4-segment -video-bitrate 9500000 -audio-bitrate 192000 -sample-rate 48000  -video-seg-duration-ts 2700000  -audio-seg-duration-ts 1428480   -force-keyint 100  -copy-mpegts 0 -enc-height 1080 -enc-width 1920 -sync-audio-to-stream-id 512   -audio-index 1,2  -copy-mpegts 1`
```

Using `tstools` to check output parts:

- for mac: `git@github.com:sepkooo/tstools-for-macos`
- for linux: `https://github.com/kynesim/tstools`

Print the continuity counts for a file - first and last:
```
tsreport -cnt 0100 ts-segment-00003.ts  | grep CC
```


### Before

Each file starts with 0:

```
tsreport -cnt 1 ts-segment-00001.ts  | grep CC
  CC: first: 0, last: 14; duplicate packets: 0
  CC: first: 5, last: 4; duplicate packets: 0
  CC: first: 10, last: 9; duplicate packets: 0
  CC: first: 10, last: 9; duplicate packets: 0
  CC: first: 10, last: 9; duplicate packets: 0
```
```
tsreport -cnt 1 ts-segment-00002.ts  | grep CC
  CC: first: 0, last: 8; duplicate packets: 0
  CC: first: 0, last: 10; duplicate packets: 0
  CC: first: 0, last: 0; duplicate packets: 0
  CC: first: 0, last: 0; duplicate packets: 0
  CC: first: 0, last: 0; duplicate packets: 0
```
```
tsreport -cnt 1 ts-segment-00003.ts  | grep CC
  CC: first: 0, last: 9; duplicate packets: 0
  CC: first: 0, last: 1; duplicate packets: 0
  CC: first: 0, last: 5; duplicate packets: 0
  CC: first: 0, last: 5; duplicate packets: 0
  CC: first: 0, last: 5; duplicate packets: 0
```
```
tsreport -cnt 1 ts-segment-00004.ts  | grep CC
  CC: first: 0, last: 14; duplicate packets: 0
  CC: first: 0, last: 0; duplicate packets: 0
  CC: first: 0, last: 2; duplicate packets: 0
  CC: first: 0, last: 13; duplicate packets: 0
  CC: first: 0, last: 13; duplicate packets: 0
```


### After

```
tsreport -cnt 1 ts-segment-00001.ts  | grep CC
  CC: first: 0, last: 4; duplicate packets: 0
  CC: first: 0, last: 12; duplicate packets: 0
  CC: first: 0, last: 6; duplicate packets: 0
  CC: first: 8, last: 3; duplicate packets: 0
  CC: first: 8, last: 3; duplicate packets: 0
```
```
tsreport -cnt 1 ts-segment-00002.ts  | grep CC
  CC: first: 5, last: 9; duplicate packets: 0
  CC: first: 13, last: 5; duplicate packets: 0
  CC: first: 7, last: 1; duplicate packets: 0
  CC: first: 4, last: 14; duplicate packets: 0
  CC: first: 4, last: 14; duplicate packets: 0
```
```
tsreport -cnt 1 ts-segment-00003.ts  | grep CC
  CC: first: 10, last: 10; duplicate packets: 0
  CC: first: 6, last: 9; duplicate packets: 0
  CC: first: 2, last: 8; duplicate packets: 0
  CC: first: 15, last: 5; duplicate packets: 0
  CC: first: 15, last: 5; duplicate packets: 0
```
```
tsreport -cnt 1 ts-segment-00004.ts  | grep CC
  CC: first: 1, last: 0; duplicate packets: 0
  CC: first: 10, last: 4; duplicate packets: 0
  CC: first: 9, last: 14; duplicate packets: 0
  CC: first: 6, last: 11; duplicate packets: 0
  CC: first: 6, last: 11; duplicate packets: 0
```
```
tsreport -cnt 1 ts-segment-00005.ts  | grep CC
  CC: first: 1, last: 8; duplicate packets: 0
  CC: first: 5, last: 6; duplicate packets: 0
  CC: first: 15, last: 4; duplicate packets: 0
  CC: first: 12, last: 1; duplicate packets: 0
  CC: first: 12, last: 1; duplicate packets: 0
```


