### PR TITLE
basic support for PNG and ProRes 4444 overlay

### DIFF
--- a/exc/elv_xc.c
+++ b/exc/elv_xc.c
@@ -1575,6 +1575,12 @@ main(
                 }
             } else if (!strcmp(argv[i], "-wm-shadow-color")) {
                 p.watermark_shadow_color = strdup(argv[i+1]);
+            } else if (!strcmp(argv[i], "-wm-sequence-path")) {
+                // MEDIA FELIZ
+                p.png_sequence_path = strdup(argv[i + 1]);
+            } else if (!strcmp(argv[i], "-wm-overlay-mov")) {
+                // MEDIA FELIZ
+                p.mov_overlay_path = strdup(argv[i + 1]);
             } else {
                 usage(argv[0], argv[i], EXIT_FAILURE);
             }

--- a/exc/elv_xc.c
+++ b/exc/elv_xc.c
@@ -1194,6 +1194,8 @@ main(
         .watermark_overlay_len = 0,
         .watermark_overlay_type = unknown_image,
         .watermark_shadow_color = strdup("white"),  /* Default shadow color */
+        .png_sequence_path = NULL,          /* MEDIA FELIZ */
+        .mov_overlay_path = NULL,           /* MEDIA FELIZ */
         .gpu_index = -1,
         .seg_duration = NULL,
         .debug_frame_level = 0,

--- a/libavpipe/include/avpipe_xc.h
+++ b/libavpipe/include/avpipe_xc.h
@@ -449,6 +449,8 @@ typedef struct xcparams_t {
     char        *watermark_font_color;      // black
     int         watermark_shadow;           // Default 1, means shadow exist 
     char        *overlay_filename;          // Overlay file name
+    char        *mov_overlay_path;          // MEDIA FELIZ: Path to overlay ProRes 4444 with alpha
+    char        *png_sequence_path;         // MEDIA FELIZ: Path template for PNG sequence (ex. /frames/frame_%06d.png)
     char        *watermark_overlay;         // Overlay image buffer, default is NULL
     image_type  watermark_overlay_type;     // Overlay image type, default is png
     int         watermark_overlay_len;      // Length of watermark_overlay if there is any

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -3539,7 +3539,76 @@ get_filter_str(
         }
         *filter_str = (char *) calloc(strlen(local_filter_str)+1, 1);
         strcpy(*filter_str, local_filter_str);
-    } else if (params->watermark_overlay && params->watermark_overlay[0] != '\0') {
+    } else if (params->png_sequence_path && *params->png_sequence_path != '\0') {
+        // MEDIA FELIZ - PNG Sequence Overlay
+        const char *filt_template =
+            "[in] scale=%d:%d [in_scaled]; "
+            "movie='%s', setpts=N/FRAME_RATE/TB [overlay_seq]; "
+            "[in_scaled][overlay_seq] overlay=%s:%s:alpha=1.0 [out]";
+
+        if (!params->watermark_xloc || *params->watermark_xloc == '\0' ||
+            !params->watermark_yloc || *params->watermark_yloc == '\0') {
+            elv_err("PNG sequence overlay requires xloc and yloc. xloc=\"%s\" "
+                    "yloc=\"%s\" path=%s",
+                    params->watermark_xloc ? params->watermark_xloc : "NULL",
+                    params->watermark_yloc ? params->watermark_yloc : "NULL",
+                    params->png_sequence_path);
+            return eav_filter_string_init;
+        }
+
+        int filt_str_len = strlen(params->png_sequence_path) + FILTER_STRING_SZ;
+        *filter_str = (char *)calloc(filt_str_len, 1);
+
+        int ret = snprintf(
+            *filter_str, filt_str_len, filt_template,
+            encoder_context->codec_context[encoder_context->video_stream_index]->width,
+            encoder_context->codec_context[encoder_context->video_stream_index]->height,
+            params->png_sequence_path, params->watermark_xloc,
+            params->watermark_yloc);
+        if (ret < 0) {
+            free(*filter_str);
+            return eav_filter_string_init;
+        } else if (ret >= filt_str_len) {
+            free(*filter_str);
+            elv_dbg("Not enough memory for PNG sequence overlay filter");
+            return eav_filter_string_init;
+        }
+    } else if (params->mov_overlay_path && *params->mov_overlay_path != '\0') {
+        // MEDIA FELIZ
+        const char *filt_template =
+            "[in] scale=%d:%d [in_scaled]; "
+            "movie='%s', setpts=PTS [mov_overlay]; "
+            "[in_scaled][mov_overlay] overlay=%s:%s [out]";
+
+        if (!params->watermark_xloc || *params->watermark_xloc == '\0' ||
+            !params->watermark_yloc || *params->watermark_yloc == '\0') {
+            elv_err("MOV overlay requires xloc and yloc. xloc=\"%s\" "
+                    "yloc=\"%s\" path=%s",
+                    params->watermark_xloc ? params->watermark_xloc : "NULL",
+                    params->watermark_yloc ? params->watermark_yloc : "NULL",
+                    params->mov_overlay_path);
+            return eav_filter_string_init;
+        }
+
+        int filt_str_len = strlen(params->mov_overlay_path) + FILTER_STRING_SZ;
+        *filter_str = (char *)calloc(filt_str_len, 1);
+
+        int ret = snprintf(
+            *filter_str, filt_str_len, filt_template,
+            encoder_context->codec_context[encoder_context->video_stream_index]->width,
+            encoder_context->codec_context[encoder_context->video_stream_index]->height,
+            params->mov_overlay_path, params->watermark_xloc,
+            params->watermark_yloc);
+        if (ret < 0) {
+            free(*filter_str);
+            return eav_filter_string_init;
+        } else if (ret >= filt_str_len) {
+            free(*filter_str);
+            elv_dbg("Not enough memory for MOV overlay filter");
+            return eav_filter_string_init;
+        }
+    } else if (params->watermark_overlay &&
+               params->watermark_overlay[0] != '\0') {
         char *filt_buf = NULL;
         int filt_buf_size;
         int filt_str_len;


### PR DESCRIPTION

PNG sequence overlays
- frame_000001.png, frame_000002.png…
```
./bin/exc \
  -f "./media/bbb_30s.mp4" \
  -xc-type video \
  -format mp4 \
  -wm-xloc 0 \
  -wm-yloc 0 \
  -wm-sequence-path "./media/overlay_frames/frame_%06d.png"
```

ProRes 4444 MOV overlays with alpha
```
./bin/exc \
  -f "./media/bbb_30s.mp4" \
  -xc-type video \
  -format mp4 \
  -wm-xloc 0 \
  -wm-yloc 0 \
  -wm-overlay-mov "./media/overlay_prores.mov"
```
