### PR TITLE
Close mpegts parts

### DIFF
--- a/avpipe.c
+++ b/avpipe.c
@@ -398,7 +398,6 @@ udp_in_closer(
     int fd = *((int64_t *)inctx->opaque);
     int sockfd = *((int *)((int64_t *)inctx->opaque+1));
     elv_dbg("IN CLOSE UDP fd=%d, sockfd=%d, url=%s\n", fd, sockfd, inctx->url ? inctx->url : "bogus.mp4");
-    // free(inctx->opaque);
     close(sockfd);
     return 0;
 }

--- a/avpipe.c
+++ b/avpipe.c
@@ -398,7 +398,7 @@ udp_in_closer(
     int fd = *((int64_t *)inctx->opaque);
     int sockfd = *((int *)((int64_t *)inctx->opaque+1));
     elv_dbg("IN CLOSE UDP fd=%d, sockfd=%d, url=%s\n", fd, sockfd, inctx->url ? inctx->url : "bogus.mp4");
-    free(inctx->opaque);
+    // free(inctx->opaque);
     close(sockfd);
     return 0;
 }

--- a/libavpipe/src/avpipe_copy_mpegts.c
+++ b/libavpipe/src/avpipe_copy_mpegts.c
@@ -360,6 +360,11 @@ copy_mpegts_func(
     xc_frame_t *xc_frame;
     int err = 0;
 
+    AVFormatContext *format_context;
+    coderctx_t *encoder_context = &cp_ctx->encoder_ctx;
+
+    format_context = encoder_context->format_context;
+
     while (!xctx->stop || elv_channel_size(cp_ctx->ch) > 0) {
 
         // Retrieve MPEGTS packets from the dedicated "copy mpegts" channel
@@ -392,6 +397,7 @@ copy_mpegts_func(
             break;
         }
     }
+    av_interleaved_write_frame(format_context, NULL);
 
     if (!xctx->err)
         xctx->err = err;

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -3991,6 +3991,12 @@ xc_done:
     pthread_join(xctx->vthread_id, NULL);
     pthread_join(xctx->athread_id, NULL);
 
+    if (params->copy_mpegts) {
+        cp_ctx_t *cp_ctx = &xctx->cp_ctx;
+        elv_channel_close(cp_ctx->ch, 0);
+        pthread_join(cp_ctx->thread_id, NULL);
+    }
+
     /*
      * Flush all frames, first flush decoder buffers, then encoder buffers by passing NULL frame.
      */
@@ -4921,6 +4927,20 @@ avpipe_fini(
         }
     }
 
+    if ((*xctx)->params->copy_mpegts) {
+        cp_ctx_t *cp_ctx = &(*xctx)->cp_ctx;
+        coderctx_t *mpegts_encoder_ctx = &cp_ctx->encoder_ctx;
+        elv_warn("Freeing mpegts encoder context, closing io");
+        avio_close(mpegts_encoder_ctx->format_context->pb);
+        avformat_free_context(mpegts_encoder_ctx->format_context);
+        for (int i=0; i<MAX_STREAMS; i++) {
+            if (mpegts_encoder_ctx->codec_context[i]) {
+                /* Corresponds to avcodec_open2() */
+                avcodec_close(mpegts_encoder_ctx->codec_context[i]);
+                avcodec_free_context(&mpegts_encoder_ctx->codec_context[i]);
+            }
+        }
+    }
 #ifdef USE_RESAMPLE_AAC
     if ((*xctx)->params && !strcmp((*xctx)->params->ecodec2, "aac")) {
         av_audio_fifo_free(decoder_context->fifo);

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -4948,6 +4948,10 @@ avpipe_fini(
     }
 #endif
 
+    if ((*xctx)->in_handlers && (*xctx)->inctx && (*xctx)->inctx->opaque) {
+        // inctx->opaque is allocated by either in_opener or udp_in_opener
+        free((*xctx)->inctx->opaque);
+    }
     // PENDING(SS) These are not allocated by avpipe_init
     free((*xctx)->in_handlers);
     free((*xctx)->out_handlers);


### PR DESCRIPTION
There were two issues here:

1. The mpegts channel was not being closed, and the thread not waited on.
2. When using udp input, the input context opaque `inctx->opaque` was being freed as a result of `udp_in_closer` returning, which happened before the other output contexts were closed. As a result of that, they were reading garbage data and passing that into `AVPipeCloseOutput`, which then would fail silently because it was unable to find a matching handler, and we do not listen to the return codes of most functions in `avpipe_fini`.

This is resolved by releasing resources from the mpegts copy encoder in a similar way as the rest of the code, and freeing the inctx opaque only at the end of the fini function.

A version of `content-fabric` depending on this code passes the SRT distribution unit test.

