### PR TITLE
Make muxing timing adjustment based on dts

### DIFF
--- a/libavpipe/include/avpipe_xc.h
+++ b/libavpipe/include/avpipe_xc.h
@@ -145,10 +145,10 @@ typedef struct io_mux_ctx_t {
     char            *out_filename;              /* Output filename/url for this muxing */
     char            *mux_type;                  /* "mux-mez" or "mux-abr" */
     mux_input_ctx_t video;
-    int64_t         last_video_pts;
+    int64_t         last_video_dts;
     int             last_audio_index;
     mux_input_ctx_t audios[MAX_STREAMS];
-    int64_t         last_audio_pts;
+    int64_t         last_audio_dts;
     int             last_caption_index;
     mux_input_ctx_t captions[MAX_STREAMS];
 } io_mux_ctx_t;


### PR DESCRIPTION
The muxing timing adjustments make it so that the output from muxing starts at 0, and also doesn't end up being non-monotonic when the DTS resets. This change makes it so that this works for cases where packets are out of PTS-order, which previously would break because the PTS would briefly double, and then raise errors because it was non-monotonic.

The error can be seen from this sequence of logs, where a packet with pts ahead of dts comes in and results in the near doubling of the PTS, which later results in this error

```
2025-04-19T16:28:16.512Z DEBUG PI muxer input packet dts != pts, index=0, pts=48048 dts=46046 logger=/avpipe gid=378 avp=1e80ae71
2025-04-19T16:28:16.512Z DEBUG PI VIDEO PACKET MUX IN  pts=48048 dts=48048 duration=1001 pos=1655731 size=1307 stream_index=0 flags=0 data=0x13a00fe00 logger=/avpipe gid=378 avp=1e80ae71
2025-04-19T16:28:16.512Z DEBUG PI modifying packet sidx=0 pts=48048 dts=48048 last_video_pts=47047 last_audio_pts=95232 logger=/avpipe gid=378 avp=1e80ae71
2025-04-19T16:28:16.512Z DEBUG PI VIDEO PACKET MUX PRE-ADJUST pts=48048 dts=48048 duration=1001 pos=1655731 size=1307 stream_index=0 flags=0 data=0x13a00fe00 logger=/avpipe gid=378 avp=1e80ae71
2025-04-19T16:28:16.512Z DEBUG PI VIDEO PACKET MUX OUT  pts=46046 dts=46046 duration=1001 pos=1655731 size=1307 stream_index=0 flags=0 data=0x13a00fe00 logger=/avpipe gid=378 avp=1e80ae71
2025-04-19T16:28:16.512Z DEBUG PI modifying packet sidx=1 pts=96256 dts=96256 last_video_pts=48048 last_audio_pts=95232 logger=/avpipe gid=378 avp=1e80ae71
...
2025-04-19T16:28:16.517Z ERROR FF Application provided invalid, non monotonically increasing dts to muxer in stream 0: 47047 >= 46046 logger=/avpipe gid=378 avp=1e80ae71
```

This resolves the broken integration tests that Michael was noticing, for example this [failure](http://192.168.96.115:8080/job/content%20fabric%20integration%20unit%20tests/378/), not sure the link works as its to our internal jenkins.