### PR TITLE
Stamp PTS/DTS on muxed packets

### DIFF
--- a/avpipe.c
+++ b/avpipe.c
@@ -1116,13 +1116,13 @@ read_next_input:
                 return AVERROR_EOF;
             filepath = in_mux_ctx->video.parts[in_mux_ctx->video.index];
             in_mux_ctx->video.index++;
-        } else if (index <= in_mux_ctx->last_audio_index) {
+        } else if (index <= in_mux_ctx->audio_count) {
             if (in_mux_ctx->audios[index-1].index >= in_mux_ctx->audios[index-1].n_parts)
                 return AVERROR_EOF;
             filepath = in_mux_ctx->audios[index-1].parts[in_mux_ctx->audios[index-1].index];
             in_mux_ctx->audios[index-1].index++;
-        } else if (index <= in_mux_ctx->last_audio_index+in_mux_ctx->last_caption_index) {
-            i = index - in_mux_ctx->last_audio_index - 1;
+        } else if (index <= in_mux_ctx->audio_count+in_mux_ctx->caption_count) {
+            i = index - in_mux_ctx->audio_count - 1;
             if (in_mux_ctx->captions[i].index >= in_mux_ctx->captions[i].n_parts)
                 return AVERROR_EOF;
             filepath = in_mux_ctx->captions[i].parts[in_mux_ctx->captions[i].index];
@@ -1147,8 +1147,13 @@ read_next_input:
             in_mux_ctx->audios[index-1].header_size = read_header(fd, in_mux_ctx->mux_type);
 #endif
 
-        if (debug_frame_level)
+        if (debug_frame_level) {
             elv_dbg("IN MUX READ opened new file filepath=%s, fd=%d", filepath, fd);
+            if (strstr(filepath, "init")) {
+                // The read in which this log happens only contains data from new continuity
+                elv_dbg("IN MUX READ INIT open filepath=%s, pos=%d", filepath, c->read_bytes);
+            }
+        }
     }
 
     fd = *((int64_t *)(c->opaque));

--- a/exc/elv_mux.c
+++ b/exc/elv_mux.c
@@ -102,17 +102,17 @@ read_next_input:
                 return AVERROR_EOF;
             filepath = in_mux_ctx->video.parts[in_mux_ctx->video.index];
             in_mux_ctx->video.index++;
-        } else if (index <= in_mux_ctx->last_audio_index) {
+        } else if (index <= in_mux_ctx->audio_count) {
             if (in_mux_ctx->audios[index-1].index >= in_mux_ctx->audios[index-1].n_parts)
                 return AVERROR_EOF;
             filepath = in_mux_ctx->audios[index-1].parts[in_mux_ctx->audios[index-1].index];
             in_mux_ctx->audios[index-1].index++;
-        } else if (index <= in_mux_ctx->last_audio_index+in_mux_ctx->last_caption_index) {
-            if (in_mux_ctx->captions[index - in_mux_ctx->last_audio_index - 1].index >=
-                in_mux_ctx->captions[index - in_mux_ctx->last_audio_index - 1].n_parts)
+        } else if (index <= in_mux_ctx->audio_count+in_mux_ctx->caption_count) {
+            if (in_mux_ctx->captions[index - in_mux_ctx->audio_count - 1].index >=
+                in_mux_ctx->captions[index - in_mux_ctx->audio_count - 1].n_parts)
                 return AVERROR_EOF;
-            filepath = in_mux_ctx->captions[index - in_mux_ctx->last_audio_index - 1].parts[in_mux_ctx->captions[index - in_mux_ctx->last_audio_index - 1].index];
-            in_mux_ctx->captions[index - in_mux_ctx->last_audio_index - 1].index++;
+            filepath = in_mux_ctx->captions[index - in_mux_ctx->audio_count - 1].parts[in_mux_ctx->captions[index - in_mux_ctx->audio_count - 1].index];
+            in_mux_ctx->captions[index - in_mux_ctx->audio_count - 1].index++;
         } else {
             elv_err("in_mux_read_packet invalid mux index=%d", index);
             return -1;

--- a/goavpipe/structs.go
+++ b/goavpipe/structs.go
@@ -130,16 +130,16 @@ type XcType int
 
 const (
 	XcNone             XcType = iota
-	XcVideo                   = 1
-	XcAudio                   = 2
-	XcAll                     = 3  // XcAudio | XcVideo
-	XcAudioMerge              = 6  // XcAudio | 0x04
-	XcAudioJoin               = 10 // XcAudio | 0x08
-	XcAudioPan                = 18 // XcAudio | 0x10
-	XcMux                     = 32
-	XcExtractImages           = 65  // XcVideo | 2^6
-	XcExtractAllImages        = 129 // XcVideo | 2^7
-	Xcprobe                   = 256
+	XcVideo            XcType = 1
+	XcAudio            XcType = 2
+	XcAll              XcType = 3  // XcAudio | XcVideo
+	XcAudioMerge       XcType = 6  // XcAudio | 0x04
+	XcAudioJoin        XcType = 10 // XcAudio | 0x08
+	XcAudioPan         XcType = 18 // XcAudio | 0x10
+	XcMux              XcType = 32
+	XcExtractImages    XcType = 65  // XcVideo | 2^6
+	XcExtractAllImages XcType = 129 // XcVideo | 2^7
+	Xcprobe            XcType = 256
 )
 
 type XcProfile int

--- a/libavpipe/include/avpipe_xc.h
+++ b/libavpipe/include/avpipe_xc.h
@@ -141,15 +141,20 @@ typedef struct mux_input_ctx_t {
     int     header_size;
 } mux_input_ctx_t;
 
+/*
+io_mux_ctx_t is used for handling input streams for muxing. It assumes that all input streams, as
+ordered by the muxing spec, have the ordering video -> audio(s) -> caption(s). It stores an input
+context for each of the input streams, as well as the number of each.
+*/
 typedef struct io_mux_ctx_t {
     char            *out_filename;              /* Output filename/url for this muxing */
     char            *mux_type;                  /* "mux-mez" or "mux-abr" */
     mux_input_ctx_t video;
     int64_t         last_video_pts;
-    int             last_audio_index;
+    int             audio_count;
     mux_input_ctx_t audios[MAX_STREAMS];
     int64_t         last_audio_pts;
-    int             last_caption_index;
+    int             caption_count;
     mux_input_ctx_t captions[MAX_STREAMS];
 } io_mux_ctx_t;
 

--- a/libavpipe/src/avpipe_mux.c
+++ b/libavpipe/src/avpipe_mux.c
@@ -459,7 +459,7 @@ avpipe_mux(
             elv_dbg("avpipe_mux stream %d avg_frame_rate or time_base is 0", i);
             continue;
         }
-        set_pts_per_frame_from_streaminfo(pts_estimator, i, av_rescale_q(1, avg_frame_rate, time_base));
+        set_pts_per_frame_from_streaminfo(pts_estimator, i, av_rescale_q(1, av_inv_q(time_base), avg_frame_rate));
     }
 
     for (int i=0; i < stream_count; i++) {
@@ -672,7 +672,7 @@ static int adjust_pts(pts_estimator_t *estimator, int stream_index, AVPacket *pk
                     stream_index, pts_delta, expected_delta, pkt->pts, estimator->last_pts[stream_index]);
                 estimator->major_discrepancies_logged++;
             } else if (estimator->major_discrepancies_logged == 100) {
-                elv_warn("avpipe_mux done reporting major PTS discrepancies, too many logs");
+                elv_err("avpipe_mux done reporting major PTS discrepancies, too many logs");
                 estimator->major_discrepancies_logged++;
             }
         } else if (diff_from_expected > 0) {

--- a/libavpipe/src/avpipe_mux.c
+++ b/libavpipe/src/avpipe_mux.c
@@ -453,7 +453,7 @@ avpipe_mux(
             continue;
         }
         pts_per_frame[i] = av_rescale_q(1, av_inv_q(time_base), avg_frame_rate);
-        elv_warn("avpipe_mux stream %d avg_frame_rate %d/%d tb %d/%d, pts per frame: %d", i, avg_frame_rate.num, avg_frame_rate.den, time_base.num, time_base.den, pts_per_frame[i]);
+        elv_warn("avpipe_mux stream %d avg_frame_rate %d/%d tb %d/%d, pts per frame: "PRId64"", i, avg_frame_rate.num, avg_frame_rate.den, time_base.num, time_base.den, pts_per_frame[i]);
     }
 
     for (int i=0; i < stream_count; i++) {

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -3268,7 +3268,13 @@ skip_until_start_time_pts(
     else
         input_start_pts = decoder_context->audio_input_start_pts[input_packet->stream_index];
 
-    const int64_t packet_in_pts_offset = input_packet->pts - input_start_pts;
+    int64_t packet_in_pts_offset = input_packet->pts - input_start_pts;
+
+    // PENDING(SS) For audio ABR, the mez source has imperfect frame durations (occasional 1023)
+    // This causes probelms when skipping - we might skip over the correct frame because it is a few ts units short
+    if (selected_decoded_audio(decoder_context, input_packet->stream_index) >= 0)
+        packet_in_pts_offset += 15;
+
     /* Drop frames before the desired 'start_time' */
     if (packet_in_pts_offset < params->start_time_ts) {
         elv_dbg("PREDECODE SKIP frame early stream_index=%d, pts=%" PRId64 ", start_time_ts=%" PRId64


### PR DESCRIPTION
This partially resolves https://github.com/qluvio/content-fabric/issues/3266.

The main description here is copied from that issue.

Additionally, there are a few miscellaneous changes:

- renaming `last_foo_index` to `foo_count`, because the naming was confusing to me
- assigning muxing inctx params, because previously debug frame level was broken on them

This is intentionally as light as reasonable, and will be followed by the subsequent changes described in the issue (and that I discussed with Serban).

#### First Iteration
The first iteration is already largely completed.

The first thing to fix the glaring issues with this is to adjust the way that PTS/DTS are adjusted for incoming packets. The simple way to do this has two steps:

1. Estimate the frame duration in the incoming streams, `d_i`.
2. Stamp the `i`th frame for stream `j` with the timestamp `d_i * i` for both PTS and DTS.

The frame duration can be retrieved by looking at the stream information retrieved by ffmpeg when inspecting the stream. If present, the framerate will be stored in `avg_frame_rate` as a rational, and the PTS size of each frame can be calculated as `timescale * avg_frame_rate`. If the framerate is not estimated by ffmpeg, simply assuming the gap between the first two frames is the expected gap between all frames is generally correct as a first pass.

The frame stamping results in clearly playing video, but can potentially result in synchronization issues, especially if there are small gaps in the input or the cuts between channels are not perfect. The implementation also logs when a 'surprising' gap between frames is found, which is arbitrarily defined as more than 20% different than the expected frame duration.