### PR TITLE
Disable b-frames for ABR encoding

### DIFF
--- a/exc/elv_xc.c
+++ b/exc/elv_xc.c
@@ -947,7 +947,7 @@ get_image_type(
 
     if (strncmp(image_type_str, "jpg", 3) == 0 || strncmp(image_type_str, "JPG", 3) == 0)
         return jpg_image;
-    
+
     if (strncmp(image_type_str, "gif", 3) == 0 || strncmp(image_type_str, "GIF", 3) == 0)
         return gif_image;
 
@@ -1305,8 +1305,11 @@ main(
                     usage(argv[0], argv[i], EXIT_FAILURE);
                 }
             } else if (!strcmp(argv[i], "-deinterlace")) {
-                if (sscanf(argv[i+1], "%d", &p.deinterlace) != 1) {
+                int deinterlace;
+                if (sscanf(argv[i+1], "%d", &deinterlace) != 1) {
                     usage(argv[0], argv[i], EXIT_FAILURE);
+                } else {
+                    p.deinterlace = deinterlace;
                 }
             }
             else if (strlen(argv[i]) > 2) {

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -1223,7 +1223,9 @@ prepare_video_encoder(
         av_opt_set(encoder_codec_context->priv_data, "preset", params->preset, AV_OPT_FLAG_ENCODING_PARAM | AV_OPT_SEARCH_CHILDREN);
     }
 
-    if (!strcmp(params->format, "fmp4-segment") || !strcmp(params->format, "fmp4")) {
+    // TODO: Add a parameter for b-frames instead of using format
+    if (!strcmp(params->format, "fmp4-segment") || !strcmp(params->format, "fmp4") ||
+        !strcmp(params->format, "dash") || !strcmp(params->format, "hls")) {
         encoder_codec_context->max_b_frames = 0;
     }
 

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -898,6 +898,8 @@ set_h264_params(
                                                 encoder_codec_context->width,
                                                 encoder_codec_context->height);
     }
+
+    av_opt_set(encoder_codec_context->priv_data, "x264-params", "stitchable=1", 0);
 }
 
 static void

--- a/rules.make
+++ b/rules.make
@@ -2,7 +2,6 @@
 # rules.make
 # contains all the common parts of the build system
 #
-# delete xcoder to build on Mac
 
 BINDIR=bin
 LIBDIR=lib
@@ -12,8 +11,8 @@ OSNAME := $(shell uname -s)
 LDFLAGS := \
 		-lavpipe \
 		-lutils \
-		$(shell pkg-config --libs libavfilter libavcodec libavformat libavdevice libswresample libavresample libswscale libavutil libpostproc xcoder srt)
-CFLAGS := $(shell pkg-config --cflags libavfilter libavcodec libavformat libavdevice libswresample libavresample libswscale libavutil libpostproc xcoder srt)
+		$(shell pkg-config --libs libavfilter libavcodec libavformat libavdevice libswresample libavresample libswscale libavutil libpostproc srt)
+CFLAGS := $(shell pkg-config --cflags libavfilter libavcodec libavformat libavdevice libswresample libavresample libswscale libavutil libpostproc srt)
 
 ifeq ($(OSNAME), Darwin)
 	LDFLAGS := ${LDFLAGS} \
@@ -38,5 +37,6 @@ ifeq ($(OSNAME), Linux)
 		-lva-drm \
 		-lva-x11 \
 		-lpthread \
-		-lsrt
+		$(shell pkg-config --libs xcoder)
+	CFLAGS := ${CFLAGS} $(shell pkg-config --cflags xcoder)
 endif


### PR DESCRIPTION
This resolves some (hopefully all) differences in SPS/PPS between mezzanine and ABR encodings (`fmp4-segment` and `dash` formats respectively).

No differences in SPS/PPS observed in simple test using exc.

Note that our ABR segments don't seem to have b-frames even without setting `max_b_frames` to 0. Maybe this is due to another encoder setting related to frame buffers or something.

A future improvement, as noted in the TODO comment, is to add a parameter for b-frames to the API.

Also removed xcoder when building on Mac.

Issues:

- https://github.com/eluv-io/avpipe/issues/95
- https://github.com/qluvio/content-fabric/issues/3007
- https://github.com/qluvio/content-fabric/issues/3274
- https://github.com/qluvio/archive-avpipe/issues/292