### PR TITLE
Probe use duration tag if not provided by format

### DIFF
--- a/libavpipe/include/avpipe_utils.h
+++ b/libavpipe/include/avpipe_utils.h
@@ -80,3 +80,8 @@ hex_encode(
     byte *buf,
     int sz,
     char *str);
+
+int64_t
+parse_duration(
+    const char *duration_str,
+    AVRational time_base);

--- a/libavpipe/src/avpipe_utils.c
+++ b/libavpipe/src/avpipe_utils.c
@@ -332,3 +332,23 @@ hex_encode(byte *buf, int sz, char *str)
         sprintf(str + 2 * i, "%02x", buf[i]);
     }
 }
+
+// Parse a duration string of format "HH:MM:SS.SUB" into duration ts
+int64_t
+parse_duration(const char *duration_str, AVRational time_base) {
+    int hours = 0, minutes = 0;
+    double seconds = 0.0;
+
+    if (sscanf(duration_str, "%d:%d:%lf", &hours, &minutes, &seconds) != 3) {
+        elv_dbg("Failed to parse duration string: %s", duration_str);
+        return -1;
+    }
+
+    double secs = hours * 3600 + minutes * 60 + seconds;
+    int64_t usecs = (int64_t)(secs * 1000000.0);
+
+    // Rescale to timebase
+    int64_t duration_ts = av_rescale_q(usecs, AV_TIME_BASE_Q, time_base);
+
+    return duration_ts;
+}

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -4348,6 +4348,11 @@ avpipe_probe(
             }
         }
 
+        // Start time is optional - set to 0 if not explicitly specified
+        if (s->start_time == AV_NOPTS_VALUE) {
+            s->start_time = 0;
+        }
+
         stream_probes_ptr->duration_ts = s->duration;
         stream_probes_ptr->time_base = s->time_base;
         stream_probes_ptr->nb_frames = s->nb_frames;


### PR DESCRIPTION
1. Set probe result start time to 0 if not explicitly specified by the format

This is to avoid returning AV_NOPTS_VALUE since that is an internal constant in ffmpeg and there is no differentiation needed between start time not specified and start time 0 (they are treated the same way).

2. Estimate stream duration if not specified by the format
This is an enhancement for support of matroska/webm files with no duration.  There is an optional duration tag - use it if found.

Future note: we could also determine duration by reading a few starting frames, then seeking to the end and read the last frames.

Example probe result (elvxc):

```
Stream[0]
	stream_id: 0
	codec_type: video
	codec_id: 167
	codec_name: vp9
	profile: Profile 0
	level: -99
	duration_ts: 9923600
	time_base: 1/1000
	nb_frames: 0
	start_time: 0
	avg_frame_rate: 25/1
	frame_rate: 25/1
	SampleRate: 0
	channels: 0
	channel_layout: -
	ticks_per_frame: 1
	bit_rate: 0
	has_b_frames: false
	width: 1920
	height: 1080
	pix_fmt: 0
	sample_aspect_ratio: 1:1
	display_aspect_ratio: 16:9
	field_order:
	tags:
		language: eng
		DURATION: 02:45:23.600000000
		avpipe: duration estimated from tag
Stream[1]
	stream_id: 0
	codec_type: audio
	codec_id: 86076
	codec_name: opus
	profile:
	level: -99
	duration_ts: 9923628
	time_base: 1/1000
	nb_frames: 0
	start_time: 0
	avg_frame_rate: 0/1
	frame_rate: 0/1
	SampleRate: 48000
	channels: 2
	channel_layout: stereo
	ticks_per_frame: 1
	bit_rate: 0
	has_b_frames: false
	width: 0
	height: 0
	pix_fmt: -
	sample_aspect_ratio: 0:1
	display_aspect_ratio: 0:1
	field_order:
	tags:
		language: eng
		DURATION: 02:45:23.628000000
		avpipe: duration estimated from tag
Container
	format_name: matroska,webm
	duration: 9923.62793
```