### PR TITLE
Move XcParams,structs to new package

### DIFF
--- a/avpipe.go
+++ b/avpipe.go
@@ -37,162 +37,17 @@ package avpipe
 // #include "elv_log.h"
 import "C"
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"math/big"
 	"math/rand"
 	"sync"
 	"unsafe"
+
+	"github.com/eluv-io/avpipe/goavpipe"
 )
 
 const traceIo bool = false
-
-// AVType ...
-type AVType int
-
-const (
-	// Unknown 0
-	Unknown AVType = iota
-	// DASHManifest 1
-	DASHManifest
-	// DASHVideoInit 2
-	DASHVideoInit
-	// DASHVideoSegment 3
-	DASHVideoSegment
-	// DASHAudioInit 4
-	DASHAudioInit
-	// DASHAudioSegment 5
-	DASHAudioSegment
-	// HLSMasterM3U 6
-	HLSMasterM3U
-	// HLSVideoM3U 7
-	HLSVideoM3U
-	// HLSAudioM3U 8
-	HLSAudioM3U
-	// AES128Key 9
-	AES128Key
-	// MP4Stream 10
-	MP4Stream
-	// FMP4Stream 11 (Fragmented MP4)
-	FMP4Stream
-	// MP4Segment 12
-	MP4Segment
-	// FMP4VideoSegment 13
-	FMP4VideoSegment
-	// FMP4AudioSegment 14
-	FMP4AudioSegment
-	// MuxSegment 15
-	MuxSegment
-	// FrameImage 16
-	FrameImage
-	// MpegtsSegment 17
-	MpegtsSegment
-)
-
-func (a AVType) Name() string {
-	switch a {
-	case DASHManifest:
-		return "DASHManifest"
-	case DASHVideoInit:
-		return "DASHVideoInit"
-	case DASHVideoSegment:
-		return "DASHVideoSegment"
-	case DASHAudioInit:
-		return "DASHAudioInit"
-	case DASHAudioSegment:
-		return "DASHAudioSegment"
-	case HLSMasterM3U:
-		return "HLSMasterM3U"
-	case HLSVideoM3U:
-		return "HLSVideoM3U"
-	case HLSAudioM3U:
-		return "HLSAudioM3U"
-	case AES128Key:
-		return "AES128Key"
-	case MP4Stream:
-		return "MP4Stream"
-	case FMP4Stream:
-		return "FMP4Stream"
-	case MP4Segment:
-		return "MP4Segment"
-	case FMP4VideoSegment:
-		return "FMP4VideoSegment"
-	case FMP4AudioSegment:
-		return "FMP4AudioSegment"
-	case MuxSegment:
-		return "MuxSegment"
-	case FrameImage:
-		return "FrameImage"
-	case MpegtsSegment:
-		return "MpegtsSegment"
-	default:
-		return fmt.Sprintf("Unknown(%d)", a)
-	}
-}
-
-type AVClass = string
-
-var AVClassE = struct {
-	Mez      AVClass
-	Abr      AVClass
-	Manifest AVClass
-	Mux      AVClass
-	Frame    AVClass
-	Unknown  AVClass
-}{
-	Mez:      "mez",
-	Abr:      "abr",
-	Manifest: "manifest",
-	Mux:      "mux",
-	Frame:    "frame",
-	Unknown:  "unknown",
-}
-
-func (a AVType) AVClass() AVClass {
-	switch a {
-	case FMP4AudioSegment, FMP4VideoSegment, MP4Segment:
-		return AVClassE.Mez
-	case DASHAudioInit, DASHAudioSegment, DASHVideoInit, DASHVideoSegment:
-		return AVClassE.Abr
-	case HLSAudioM3U, HLSMasterM3U, HLSVideoM3U, DASHManifest:
-		return AVClassE.Manifest
-	case FrameImage:
-		return AVClassE.Frame
-	case MuxSegment, MP4Stream, FMP4Stream:
-		return AVClassE.Mux
-	default:
-		return AVClassE.Unknown
-	}
-}
-
-// This is corresponding to AV_NOPTS_VALUE
-const AvNoPtsValue = uint64(C.uint64_t(0x8000000000000000))
-
-type XcType int
-
-const (
-	XcNone             XcType = iota
-	XcVideo                   = 1
-	XcAudio                   = 2
-	XcAll                     = 3  // XcAudio | XcVideo
-	XcAudioMerge              = 6  // XcAudio | 0x04
-	XcAudioJoin               = 10 // XcAudio | 0x08
-	XcAudioPan                = 18 // XcAudio | 0x10
-	XcMux                     = 32
-	XcExtractImages           = 65  // XcVideo | 2^6
-	XcExtractAllImages        = 129 // XcVideo | 2^7
-	Xcprobe                   = 256
-)
-
-type XcProfile int
-
-const (
-	XcProfileNone         XcProfile = iota
-	XcProfileH264BaseLine           = C.FF_PROFILE_H264_BASELINE // 66
-	XcProfileH264Heigh              = C.FF_PROFILE_H264_HIGH     // 100
-	XcProfileH264Heigh10            = C.FF_PROFILE_H264_HIGH_10  // 110
-)
 
 type SeekReadWriteCloser interface {
 	io.Seeker
@@ -201,248 +56,7 @@ type SeekReadWriteCloser interface {
 	io.Closer
 }
 
-func XcTypeFromString(xcTypeStr string) XcType {
-	var xcType XcType
-	switch xcTypeStr {
-	case "all":
-		xcType = XcAll
-	case "video":
-		xcType = XcVideo
-	case "audio":
-		xcType = XcAudio
-	case "audio-join":
-		xcType = XcAudioJoin
-	case "audio-merge":
-		xcType = XcAudioMerge
-	case "audio-pan":
-		xcType = XcAudioPan
-	case "mux":
-		xcType = XcMux
-	case "extract-images":
-		xcType = XcExtractImages
-	case "extract-all-images":
-		xcType = XcExtractAllImages
-	default:
-		xcType = XcNone
-	}
-
-	return xcType
-}
-
-type ImageType int
-
-const (
-	UnknownImage = iota
-	PngImage
-	JpgImage
-	GifImage
-)
-
-// CryptScheme is the content encryption scheme
-type CryptScheme int
-
-const (
-	// CryptNone - clear
-	CryptNone CryptScheme = iota
-	// CryptAES128 - AES-128
-	CryptAES128
-	// CryptCENC - CENC AES-CTR
-	CryptCENC
-	// CryptCBC1 - CENC AES-CBC
-	CryptCBC1
-	// CryptCENS - CENC AES-CTR Pattern
-	CryptCENS
-	// CryptCBCS - CENC AES-CBC Pattern
-	CryptCBCS
-)
-
 const MaxAudioMux = C.MAX_STREAMS
-
-// XcParams should match with txparams_t in avpipe_xc.h
-type XcParams struct {
-	Url                    string      `json:"url"`
-	BypassTranscoding      bool        `json:"bypass,omitempty"`
-	Format                 string      `json:"format,omitempty"`
-	StartTimeTs            int64       `json:"start_time_ts,omitempty"`
-	StartPts               int64       `json:"start_pts,omitempty"` // Start PTS for output
-	DurationTs             int64       `json:"duration_ts,omitempty"`
-	StartSegmentStr        string      `json:"start_segment_str,omitempty"`
-	VideoBitrate           int32       `json:"video_bitrate,omitempty"`
-	AudioBitrate           int32       `json:"audio_bitrate,omitempty"`
-	SampleRate             int32       `json:"sample_rate,omitempty"` // Audio sampling rate
-	RcMaxRate              int32       `json:"rc_max_rate,omitempty"`
-	RcBufferSize           int32       `json:"rc_buffer_size,omitempty"`
-	CrfStr                 string      `json:"crf_str,omitempty"`
-	Preset                 string      `json:"preset,omitempty"`
-	AudioSegDurationTs     int64       `json:"audio_seg_duration_ts,omitempty"`
-	VideoSegDurationTs     int64       `json:"video_seg_duration_ts,omitempty"`
-	SegDuration            string      `json:"seg_duration,omitempty"`
-	StartFragmentIndex     int32       `json:"start_fragment_index,omitempty"`
-	ForceKeyInt            int32       `json:"force_keyint,omitempty"`
-	Ecodec                 string      `json:"ecodec,omitempty"`    // Video encoder
-	Ecodec2                string      `json:"ecodec2,omitempty"`   // Audio encoder
-	Dcodec                 string      `json:"dcodec,omitempty"`    // Video decoder
-	Dcodec2                string      `json:"dcodec2,omitempty"`   // Audio decoder
-	GPUIndex               int32       `json:"gpu_index,omitempty"` // GPU index if encoder/decoder is GPU (nvidia)
-	EncHeight              int32       `json:"enc_height,omitempty"`
-	EncWidth               int32       `json:"enc_width,omitempty"`
-	CryptIV                string      `json:"crypt_iv,omitempty"`
-	CryptKey               string      `json:"crypt_key,omitempty"`
-	CryptKID               string      `json:"crypt_kid,omitempty"`
-	CryptKeyURL            string      `json:"crypt_key_url,omitempty"`
-	CryptScheme            CryptScheme `json:"crypt_scheme,omitempty"`
-	XcType                 XcType      `json:"xc_type,omitempty"`
-	CopyMpegts             bool        `json:"copy_mpegts,omitempty"`
-	Seekable               bool        `json:"seekable,omitempty"`
-	WatermarkText          string      `json:"watermark_text,omitempty"`
-	WatermarkTimecode      string      `json:"watermark_timecode,omitempty"`
-	WatermarkTimecodeRate  float32     `json:"watermark_timecode_rate,omitempty"`
-	WatermarkXLoc          string      `json:"watermark_xloc,omitempty"`
-	WatermarkYLoc          string      `json:"watermark_yloc,omitempty"`
-	WatermarkRelativeSize  float32     `json:"watermark_relative_size,omitempty"`
-	WatermarkFontColor     string      `json:"watermark_font_color,omitempty"`
-	WatermarkShadow        bool        `json:"watermark_shadow,omitempty"`
-	WatermarkShadowColor   string      `json:"watermark_shadow_color,omitempty"`
-	WatermarkOverlay       string      `json:"watermark_overlay,omitempty"`      // Buffer containing overlay image
-	WatermarkOverlayLen    int         `json:"watermark_overlay_len,omitempty"`  // Length of overlay image
-	WatermarkOverlayType   ImageType   `json:"watermark_overlay_type,omitempty"` // Type of overlay image (i.e PngImage, ...)
-	StreamId               int32       `json:"stream_id"`                        // Specify stream by ID (instead of index)
-	AudioIndex             []int32     `json:"audio_index"`                      // the length of this is equal to the number of audios
-	ChannelLayout          int         `json:"channel_layout"`                   // Audio channel layout
-	MaxCLL                 string      `json:"max_cll,omitempty"`
-	MasterDisplay          string      `json:"master_display,omitempty"`
-	BitDepth               int32       `json:"bitdepth,omitempty"`
-	SyncAudioToStreamId    int         `json:"sync_audio_to_stream_id"`
-	ForceEqualFDuration    bool        `json:"force_equal_frame_duration,omitempty"`
-	MuxingSpec             string      `json:"muxing_spec,omitempty"`
-	Listen                 bool        `json:"listen"`
-	ConnectionTimeout      int         `json:"connection_timeout"`
-	FilterDescriptor       string      `json:"filter_descriptor"`
-	SkipDecoding           bool        `json:"skip_decoding"`
-	DebugFrameLevel        bool        `json:"debug_frame_level"`
-	ExtractImageIntervalTs int64       `json:"extract_image_interval_ts,omitempty"`
-	ExtractImagesTs        []int64     `json:"extract_images_ts,omitempty"`
-	VideoTimeBase          int         `json:"video_time_base,omitempty"`
-	VideoFrameDurationTs   int         `json:"video_frame_duration_ts,omitempty"`
-	Rotate                 int         `json:"rotate,omitempty"`
-	Profile                string      `json:"profile,omitempty"`
-	Level                  int         `json:"level,omitempty"`
-	Deinterlace            int         `json:"deinterlace,omitempty"`
-}
-
-// NewXcParams initializes a XcParams struct with unset/default values
-func NewXcParams() *XcParams {
-	return &XcParams{
-		AudioBitrate:           128000,
-		AudioSegDurationTs:     -1,
-		BitDepth:               8,
-		CrfStr:                 "23",
-		DurationTs:             -1,
-		Ecodec:                 "libx264",
-		Ecodec2:                "aac",
-		EncHeight:              -1,
-		EncWidth:               -1,
-		ExtractImageIntervalTs: -1,
-		GPUIndex:               -1,
-		SampleRate:             -1,
-		SegDuration:            "30",
-		StartFragmentIndex:     1,
-		StartSegmentStr:        "1",
-		StreamId:               -1,
-		SyncAudioToStreamId:    -1,
-		VideoBitrate:           -1,
-		VideoSegDurationTs:     -1,
-		WatermarkFontColor:     "white",
-		WatermarkOverlayType:   JpgImage,
-		WatermarkRelativeSize:  0.05,
-		WatermarkShadow:        false,
-		WatermarkShadowColor:   "black",
-		WatermarkTimecodeRate:  -1,
-		WatermarkXLoc:          "W*0.05",
-		WatermarkYLoc:          "H*0.9",
-	}
-}
-
-// Custom unmarshalJSON for XcParams to make things backwards compatible with prior serialization
-//
-// Explanations of backwards compatible serializations:
-//  1. NEW: The number of audios is specified by the length of the `AudioIndex` slice.
-//     OLD: The number of audios was specified by a larger `AudioIndex` array and a `n_audio` field specifying the number.
-//     CONVERSION: If a `n_audio` field exists, the `AudioIndex` slice is shortened to be that length.
-func (p *XcParams) UnmarshalJSON(data []byte) error {
-	// The alias does not have the problematic unmarshal JSON that makes embedding XcParams into xcParamsDecoder bad
-	type xcpAlias XcParams
-
-	type xcParamsDecoder struct {
-		xcpAlias
-		NumAudio int32 `json:"n_audio"`
-	}
-
-	var xcpd xcParamsDecoder
-	xcpd.xcpAlias = xcpAlias(*p)
-	if err := json.Unmarshal(data, &xcpd); err != nil {
-		return err
-	}
-
-	*p = XcParams(xcpd.xcpAlias)
-
-	if xcpd.NumAudio != 0 && len(p.AudioIndex) > int(xcpd.NumAudio) {
-		p.AudioIndex = p.AudioIndex[:xcpd.NumAudio]
-	}
-
-	return nil
-}
-
-func (p *XcParams) UnmarshalMap(m map[string]interface{}) error {
-	// Pass through JSON unmarshalling for centralization of unmarshalling
-	b, err := json.Marshal(m)
-	if err != nil {
-		return err
-	}
-	return p.UnmarshalJSON(b)
-}
-
-type AVMediaType int
-
-const (
-	AVMEDIA_TYPE_UNKNOWN    = -1
-	AVMEDIA_TYPE_VIDEO      = 0
-	AVMEDIA_TYPE_AUDIO      = 1
-	AVMEDIA_TYPE_DATA       = 2 ///< Opaque data information usually continuous
-	AVMEDIA_TYPE_SUBTITLE   = 3
-	AVMEDIA_TYPE_ATTACHMENT = 4 ///< Opaque data information usually sparse
-	AVMEDIA_TYPE_NB         = 5
-)
-
-var AVMediaTypeNames = map[AVMediaType]string{
-	AVMEDIA_TYPE_UNKNOWN:    "unknown",
-	AVMEDIA_TYPE_VIDEO:      "video",
-	AVMEDIA_TYPE_AUDIO:      "audio",
-	AVMEDIA_TYPE_DATA:       "data",
-	AVMEDIA_TYPE_SUBTITLE:   "subtitle",
-	AVMEDIA_TYPE_ATTACHMENT: "attachment",
-	AVMEDIA_TYPE_NB:         "nb",
-}
-
-type AVFieldOrder int
-
-const (
-	AV_FIELD_UNKNOWN     = 0
-	AV_FIELD_PROGRESSIVE = 1
-	AV_FIELD_TT          = 2 //< Top coded_first, top displayed first
-	AV_FIELD_BB          = 3 //< Bottom coded first, bottom displayed first
-	AV_FIELD_TB          = 4 //< Top coded first, bottom displayed first
-	AV_FIELD_BT          = 5 //< Bottom coded first, top displayed first
-)
-
-var AVFieldOrderNames = map[AVFieldOrder]string{
-	AV_FIELD_UNKNOWN:     "",
-	AV_FIELD_PROGRESSIVE: "progressive",
-	AV_FIELD_TT:          "tt",
-	AV_FIELD_BB:          "bb",
-	AV_FIELD_TB:          "tb",
-	AV_FIELD_BT:          "bt",
-}
 
 type AVStatType int
 
@@ -579,12 +193,12 @@ type InputHandler interface {
 type OutputOpener interface {
 	// h determines uniquely opening input.
 	// fd determines uniquely opening output.
-	Open(h, fd int64, stream_index, seg_index int, pts int64, out_type AVType) (OutputHandler, error)
+	Open(h, fd int64, stream_index, seg_index int, pts int64, out_type goavpipe.AVType) (OutputHandler, error)
 }
 
 type MuxOutputOpener interface {
 	// url and fd determines uniquely opening output.
-	Open(url string, fd int64, out_type AVType) (OutputHandler, error)
+	Open(url string, fd int64, out_type goavpipe.AVType) (OutputHandler, error)
 }
 
 type OutputHandler interface {
@@ -598,7 +212,7 @@ type OutputHandler interface {
 	Close() error
 
 	// Reports some stats
-	Stat(streamIndex int, avType AVType, statType AVStatType, statArgs interface{}) error
+	Stat(streamIndex int, avType goavpipe.AVType, statType AVStatType, statArgs interface{}) error
 }
 
 // Implement IOHandler
@@ -945,44 +559,44 @@ func (h *ioHandler) getOutTable(fd int64) OutputHandler {
 	return h.outTable[fd]
 }
 
-func getAVType(av_type C.int) AVType {
+func getAVType(av_type C.int) goavpipe.AVType {
 	switch av_type {
 	case C.avpipe_video_init_stream:
-		return DASHVideoInit
+		return goavpipe.DASHVideoInit
 	case C.avpipe_audio_init_stream:
-		return DASHAudioInit
+		return goavpipe.DASHAudioInit
 	case C.avpipe_manifest:
-		return DASHManifest
+		return goavpipe.DASHManifest
 	case C.avpipe_video_segment:
-		return DASHVideoSegment
+		return goavpipe.DASHVideoSegment
 	case C.avpipe_audio_segment:
-		return DASHAudioSegment
+		return goavpipe.DASHAudioSegment
 	case C.avpipe_master_m3u:
-		return HLSMasterM3U
+		return goavpipe.HLSMasterM3U
 	case C.avpipe_video_m3u:
-		return HLSVideoM3U
+		return goavpipe.HLSVideoM3U
 	case C.avpipe_audio_m3u:
-		return HLSAudioM3U
+		return goavpipe.HLSAudioM3U
 	case C.avpipe_aes_128_key:
-		return AES128Key
+		return goavpipe.AES128Key
 	case C.avpipe_mp4_stream:
-		return MP4Stream
+		return goavpipe.MP4Stream
 	case C.avpipe_fmp4_stream:
-		return FMP4Stream
+		return goavpipe.FMP4Stream
 	case C.avpipe_mp4_segment:
-		return MP4Segment
+		return goavpipe.MP4Segment
 	case C.avpipe_video_fmp4_segment:
-		return FMP4VideoSegment
+		return goavpipe.FMP4VideoSegment
 	case C.avpipe_audio_fmp4_segment:
-		return FMP4AudioSegment
+		return goavpipe.FMP4AudioSegment
 	case C.avpipe_mux_segment:
-		return MuxSegment
+		return goavpipe.MuxSegment
 	case C.avpipe_image:
-		return FrameImage
+		return goavpipe.FrameImage
 	case C.avpipe_mpegts_segment:
-		return MpegtsSegment
+		return goavpipe.MpegtsSegment
 	default:
-		return Unknown
+		return goavpipe.Unknown
 	}
 }
 
@@ -999,7 +613,7 @@ func AVPipeOpenOutput(handler C.int64_t, stream_index, seg_index C.int, pts C.in
 	fd := gFd
 	gMutex.Unlock()
 	out_type := getAVType(stream_type)
-	if out_type == Unknown {
+	if out_type == goavpipe.Unknown {
 		log.Error("AVPipeOpenOutput()", "invalid stream type", stream_type)
 		return C.int64_t(-1)
 	}
@@ -1023,7 +637,7 @@ func AVPipeOpenOutput(handler C.int64_t, stream_index, seg_index C.int, pts C.in
 
 //export AVPipeOpenMuxOutput
 func AVPipeOpenMuxOutput(url *C.char, stream_type C.int) C.int64_t {
-	var out_type AVType
+	var out_type goavpipe.AVType
 
 	gMutex.Lock()
 	gFd++
@@ -1031,11 +645,11 @@ func AVPipeOpenMuxOutput(url *C.char, stream_type C.int) C.int64_t {
 	gMutex.Unlock()
 	switch stream_type {
 	case C.avpipe_mp4_segment:
-		out_type = MP4Segment
+		out_type = goavpipe.MP4Segment
 	case C.avpipe_video_fmp4_segment:
-		out_type = FMP4VideoSegment
+		out_type = goavpipe.FMP4VideoSegment
 	case C.avpipe_audio_fmp4_segment:
-		out_type = FMP4AudioSegment
+		out_type = goavpipe.FMP4AudioSegment
 	default:
 		log.Error("AVPipeOpenOutput()", "invalid stream type", stream_type)
 		return C.int64_t(-1)
@@ -1255,10 +869,10 @@ func AVPipeStatMuxOutput(fd C.int64_t, stream_index C.int, avp_stat C.avp_stat_t
 	switch avp_stat {
 	case C.out_stat_bytes_written:
 		statArgs := *(*uint64)(stat_args)
-		err = outHandler.Stat(streamIndex, MuxSegment, AV_OUT_STAT_BYTES_WRITTEN, &statArgs)
+		err = outHandler.Stat(streamIndex, goavpipe.MuxSegment, AV_OUT_STAT_BYTES_WRITTEN, &statArgs)
 	case C.out_stat_encoding_end_pts:
 		statArgs := *(*uint64)(stat_args)
-		err = outHandler.Stat(streamIndex, MuxSegment, AV_OUT_STAT_ENCODING_END_PTS, &statArgs)
+		err = outHandler.Stat(streamIndex, goavpipe.MuxSegment, AV_OUT_STAT_ENCODING_END_PTS, &statArgs)
 	}
 
 	if err != nil {
@@ -1372,7 +986,7 @@ func Version() string {
 	return C.GoString((*C.char)(unsafe.Pointer(C.avpipe_version())))
 }
 
-func getCParams(params *XcParams) (*C.xcparams_t, error) {
+func getCParams(params *goavpipe.XcParams) (*C.xcparams_t, error) {
 	extractImagesSize := len(params.ExtractImagesTs)
 
 	// same field order as avpipe_xc.h
@@ -1504,7 +1118,7 @@ func generateI32Handle() int32 {
 }
 
 // params: transcoding parameters
-func Xc(params *XcParams) error {
+func Xc(params *goavpipe.XcParams) error {
 	defer XCEnded()
 	if params == nil {
 		log.Error("Failed transcoding, params are not set.")
@@ -1527,14 +1141,14 @@ func Xc(params *XcParams) error {
 	return avpipeError(rc)
 }
 
-func Mux(params *XcParams) error {
+func Mux(params *goavpipe.XcParams) error {
 	defer XCEnded()
 	if params == nil {
 		log.Error("Failed muxing, params are not set")
 		return EAV_PARAM
 	}
 
-	params.XcType = XcMux
+	params.XcType = goavpipe.XcMux
 	cparams, err := getCParams(params)
 	if err != nil {
 		log.Error("Muxing failed", err, "url", params.Url)
@@ -1586,7 +1200,7 @@ func GetProfileName(codecId int, profile int) string {
 	return ""
 }
 
-func Probe(params *XcParams) (*ProbeInfo, error) {
+func Probe(params *goavpipe.XcParams) (*ProbeInfo, error) {
 	var cprobe *C.xcprobe_t
 	var n_streams C.int
 
@@ -1611,7 +1225,7 @@ func Probe(params *XcParams) (*ProbeInfo, error) {
 	for i := 0; i < int(n_streams); i++ {
 		probeInfo.StreamInfo[i].StreamIndex = int(probeArray[i].stream_index)
 		probeInfo.StreamInfo[i].StreamId = int32(probeArray[i].stream_id)
-		probeInfo.StreamInfo[i].CodecType = AVMediaTypeNames[AVMediaType(probeArray[i].codec_type)]
+		probeInfo.StreamInfo[i].CodecType = goavpipe.AVMediaTypeNames[goavpipe.AVMediaType(probeArray[i].codec_type)]
 		probeInfo.StreamInfo[i].CodecID = int(probeArray[i].codec_id)
 		probeInfo.StreamInfo[i].CodecName = C.GoString((*C.char)(unsafe.Pointer(&probeArray[i].codec_name)))
 		probeInfo.StreamInfo[i].DurationTs = int64(probeArray[i].duration_ts)
@@ -1651,7 +1265,7 @@ func Probe(params *XcParams) (*ProbeInfo, error) {
 		} else {
 			probeInfo.StreamInfo[i].DisplayAspectRatio = big.NewRat(int64(probeArray[i].display_aspect_ratio.num), int64(1))
 		}
-		probeInfo.StreamInfo[i].FieldOrder = AVFieldOrderNames[AVFieldOrder(probeArray[i].field_order)]
+		probeInfo.StreamInfo[i].FieldOrder = goavpipe.AVFieldOrderNames[goavpipe.AVFieldOrder(probeArray[i].field_order)]
 		probeInfo.StreamInfo[i].Profile = int(probeArray[i].profile)
 		probeInfo.StreamInfo[i].Level = int(probeArray[i].level)
 
@@ -1697,7 +1311,7 @@ func Probe(params *XcParams) (*ProbeInfo, error) {
 
 // Returns a handle and error (if there is any error)
 // In case of error the handle would be zero
-func XcInit(params *XcParams) (int32, error) {
+func XcInit(params *goavpipe.XcParams) (int32, error) {
 	// Convert XcParams to C.txparams_t
 	if params == nil {
 		log.Error("Failed transcoding, params are not set.")
@@ -1753,7 +1367,7 @@ func StreamInfoAsArray(s []StreamInfo) []StreamInfo {
 	a := make([]StreamInfo, maxIdx+1)
 	for i := range a {
 		a[i].StreamIndex = i
-		a[i].CodecType = AVMediaTypeNames[AVMediaType(AVMEDIA_TYPE_UNKNOWN)]
+		a[i].CodecType = goavpipe.AVMediaTypeNames[goavpipe.AVMediaType(goavpipe.AVMEDIA_TYPE_UNKNOWN)]
 	}
 	for _, v := range s {
 		a[v.StreamIndex] = v

--- a/avpipe_test.go
+++ b/avpipe_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/eluv-io/avpipe"
 	"github.com/eluv-io/avpipe/elvxc/cmd"
+	"github.com/eluv-io/avpipe/goavpipe"
 	"github.com/eluv-io/log-go"
 	"github.com/stretchr/testify/assert"
 )
@@ -173,36 +174,36 @@ type fileOutputOpener struct {
 }
 
 func (oo *fileOutputOpener) Open(_, _ int64, streamIndex, segIndex int,
-	pts int64, outType avpipe.AVType) (avpipe.OutputHandler, error) {
+	pts int64, outType goavpipe.AVType) (avpipe.OutputHandler, error) {
 
 	var filename string
 
 	switch outType {
-	case avpipe.DASHVideoInit:
+	case goavpipe.DASHVideoInit:
 		filename = fmt.Sprintf("./%s/vinit-stream%d.m4s", oo.dir, streamIndex)
-	case avpipe.DASHAudioInit:
+	case goavpipe.DASHAudioInit:
 		filename = fmt.Sprintf("./%s/ainit-stream%d.m4s", oo.dir, streamIndex)
-	case avpipe.DASHManifest:
+	case goavpipe.DASHManifest:
 		filename = fmt.Sprintf("./%s/dash.mpd", oo.dir)
-	case avpipe.DASHVideoSegment:
+	case goavpipe.DASHVideoSegment:
 		filename = fmt.Sprintf("./%s/vchunk-stream%d-%05d.m4s", oo.dir, streamIndex, segIndex)
-	case avpipe.DASHAudioSegment:
+	case goavpipe.DASHAudioSegment:
 		filename = fmt.Sprintf("./%s/achunk-stream%d-%05d.m4s", oo.dir, streamIndex, segIndex)
-	case avpipe.HLSMasterM3U:
+	case goavpipe.HLSMasterM3U:
 		filename = fmt.Sprintf("./%s/master.m3u8", oo.dir)
-	case avpipe.HLSVideoM3U:
+	case goavpipe.HLSVideoM3U:
 		fallthrough
-	case avpipe.HLSAudioM3U:
+	case goavpipe.HLSAudioM3U:
 		filename = fmt.Sprintf("./%s/media_%d.m3u8", oo.dir, streamIndex)
-	case avpipe.AES128Key:
+	case goavpipe.AES128Key:
 		filename = fmt.Sprintf("./%s/key.bin", oo.dir)
-	case avpipe.MP4Segment:
+	case goavpipe.MP4Segment:
 		filename = fmt.Sprintf("./%s/segment-%d.mp4", oo.dir, segIndex)
-	case avpipe.FMP4VideoSegment:
+	case goavpipe.FMP4VideoSegment:
 		filename = fmt.Sprintf("./%s/vsegment-%d.mp4", oo.dir, segIndex)
-	case avpipe.FMP4AudioSegment:
+	case goavpipe.FMP4AudioSegment:
 		filename = fmt.Sprintf("./%s/asegment%d-%d.mp4", oo.dir, streamIndex, segIndex)
-	case avpipe.FrameImage:
+	case goavpipe.FrameImage:
 		filename = fmt.Sprintf("./%s/%d.jpeg", oo.dir, pts)
 	}
 
@@ -228,7 +229,7 @@ type concurrentOutputOpener struct {
 }
 
 func (coo *concurrentOutputOpener) Open(h, _ int64, streamIndex, segIndex int,
-	pts int64, outType avpipe.AVType) (oh avpipe.OutputHandler, err error) {
+	pts int64, outType goavpipe.AVType) (oh avpipe.OutputHandler, err error) {
 
 	var filename string
 	dir := fmt.Sprintf("%s/O%d", coo.dir, h)
@@ -239,25 +240,25 @@ func (coo *concurrentOutputOpener) Open(h, _ int64, streamIndex, segIndex int,
 	assert.NoError(coo.t, err)
 
 	switch outType {
-	case avpipe.DASHVideoInit:
+	case goavpipe.DASHVideoInit:
 		filename = fmt.Sprintf("./%s/vinit-stream%d.m4s", dir, streamIndex)
-	case avpipe.DASHAudioInit:
+	case goavpipe.DASHAudioInit:
 		filename = fmt.Sprintf("./%s/ainit-stream%d.m4s", dir, streamIndex)
-	case avpipe.DASHManifest:
+	case goavpipe.DASHManifest:
 		filename = fmt.Sprintf("./%s/dash.mpd", dir)
-	case avpipe.DASHVideoSegment:
+	case goavpipe.DASHVideoSegment:
 		filename = fmt.Sprintf("./%s/vchunk-stream%d-%05d.m4s", dir, streamIndex, segIndex)
-	case avpipe.DASHAudioSegment:
+	case goavpipe.DASHAudioSegment:
 		filename = fmt.Sprintf("./%s/achunk-stream%d-%05d.m4s", dir, streamIndex, segIndex)
-	case avpipe.HLSMasterM3U:
+	case goavpipe.HLSMasterM3U:
 		filename = fmt.Sprintf("./%s/master.m3u8", dir)
-	case avpipe.HLSVideoM3U:
+	case goavpipe.HLSVideoM3U:
 		fallthrough
-	case avpipe.HLSAudioM3U:
+	case goavpipe.HLSAudioM3U:
 		filename = fmt.Sprintf("./%s/media_%d.m3u8", dir, streamIndex)
-	case avpipe.AES128Key:
+	case goavpipe.AES128Key:
 		filename = fmt.Sprintf("./%s/key.bin", dir)
-	case avpipe.FrameImage:
+	case goavpipe.FrameImage:
 		filename = fmt.Sprintf("./%s/%d.jpeg", dir, pts)
 	}
 
@@ -309,7 +310,7 @@ func (o *fileOutput) Close() error {
 	return err
 }
 
-func (o fileOutput) Stat(streamIndex int, avType avpipe.AVType, statType avpipe.AVStatType, statArgs interface{}) error {
+func (o *fileOutput) Stat(streamIndex int, avType goavpipe.AVType, statType avpipe.AVStatType, statArgs interface{}) error {
 	doLog := func(args ...interface{}) {
 		if debugFrameLevel {
 			logArgs := []interface{}{"stat", statType.Name(), "avType", avType.Name(), "streamIndex", streamIndex}
@@ -333,7 +334,7 @@ func (o fileOutput) Stat(streamIndex int, avType avpipe.AVType, statType avpipe.
 	case avpipe.AV_OUT_STAT_FRAME_WRITTEN:
 		encodingStats := statArgs.(*avpipe.EncodingFrameStats)
 		doLog("encodingStats", encodingStats)
-		if avType == avpipe.FMP4AudioSegment {
+		if avType == goavpipe.FMP4AudioSegment {
 			statsInfo.encodingAudioFrameStats = *encodingStats
 		} else {
 			statsInfo.encodingVideoFrameStats = *encodingStats
@@ -350,7 +351,7 @@ func TestAudioSeg(t *testing.T) {
 	}
 
 	outputDir := path.Join(baseOutPath, fn())
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		BypassTranscoding:      false,
 		Format:                 "fmp4-segment",
 		AudioBitrate:           128000,
@@ -371,7 +372,7 @@ func TestAudioSeg(t *testing.T) {
 		SyncAudioToStreamId:    -1,
 		VideoBitrate:           -1,
 		VideoSegDurationTs:     -1,
-		XcType:                 avpipe.XcAudio,
+		XcType:                 goavpipe.XcAudio,
 		Url:                    url,
 		DebugFrameLevel:        debugFrameLevel,
 	}
@@ -385,7 +386,7 @@ func TestVideoSeg(t *testing.T) {
 	}
 
 	outputDir := path.Join(baseOutPath, fn())
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		BypassTranscoding:      false,
 		Format:                 "fmp4-segment",
 		AudioBitrate:           128000,
@@ -407,7 +408,7 @@ func TestVideoSeg(t *testing.T) {
 		VideoBitrate:           -1,
 		VideoSegDurationTs:     -1,
 		ForceKeyInt:            60,
-		XcType:                 avpipe.XcVideo,
+		XcType:                 goavpipe.XcVideo,
 		Url:                    url,
 		DebugFrameLevel:        debugFrameLevel,
 	}
@@ -423,7 +424,7 @@ func TestVideoSegWithRotate(t *testing.T) {
 	}
 
 	outputDir := path.Join(baseOutPath, fn())
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		BypassTranscoding:      false,
 		Format:                 "fmp4-segment",
 		AudioBitrate:           128000,
@@ -444,7 +445,7 @@ func TestVideoSegWithRotate(t *testing.T) {
 		VideoBitrate:           -1,
 		VideoSegDurationTs:     900000,
 		ForceKeyInt:            60,
-		XcType:                 avpipe.XcVideo,
+		XcType:                 goavpipe.XcVideo,
 		Url:                    url,
 		DebugFrameLevel:        debugFrameLevel,
 		Rotate:                 90,
@@ -456,7 +457,7 @@ func TestVideoSegWithRotate(t *testing.T) {
 func TestVideoSegDoubleTS(t *testing.T) {
 	url := videoBigBuckBunnyPath
 	outputDir := path.Join(baseOutPath, fn())
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		BypassTranscoding:      false,
 		Format:                 "fmp4-segment",
 		AudioBitrate:           128000,
@@ -478,7 +479,7 @@ func TestVideoSegDoubleTS(t *testing.T) {
 		VideoBitrate:           -1,
 		VideoSegDurationTs:     -1,
 		ForceKeyInt:            60,
-		XcType:                 avpipe.XcVideo,
+		XcType:                 goavpipe.XcVideo,
 		Url:                    url,
 		DebugFrameLevel:        debugFrameLevel,
 		VideoTimeBase:          60000,
@@ -496,7 +497,7 @@ func TestSingleABRTranscode(t *testing.T) {
 
 	outputDir := path.Join(baseOutPath, fn())
 
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		BypassTranscoding:  false,
 		Format:             "hls",
 		StartTimeTs:        0,
@@ -511,7 +512,7 @@ func TestSingleABRTranscode(t *testing.T) {
 		Ecodec2:            "aac",
 		EncHeight:          720,
 		EncWidth:           1280,
-		XcType:             avpipe.XcVideo,
+		XcType:             goavpipe.XcVideo,
 		StreamId:           -1,
 		Url:                url,
 		DebugFrameLevel:    debugFrameLevel,
@@ -519,7 +520,7 @@ func TestSingleABRTranscode(t *testing.T) {
 	setFastEncodeParams(params, false)
 	xcTest(t, outputDir, params, nil, true)
 
-	params.XcType = avpipe.XcAudio
+	params.XcType = goavpipe.XcAudio
 	params.Ecodec2 = "aac"
 	xcTest(t, outputDir, params, nil, false)
 }
@@ -532,7 +533,7 @@ func TestSingleABRTranscodeByStreamId(t *testing.T) {
 
 	outputDir := path.Join(baseOutPath, fn())
 
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		BypassTranscoding:  false,
 		Format:             "hls",
 		StartTimeTs:        0,
@@ -566,7 +567,7 @@ func TestSingleABRTranscodeWithWatermark(t *testing.T) {
 
 	outputDir := path.Join(baseOutPath, fn())
 
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		BypassTranscoding:     false,
 		Format:                "hls",
 		StartTimeTs:           0,
@@ -579,7 +580,7 @@ func TestSingleABRTranscodeWithWatermark(t *testing.T) {
 		Ecodec:                h264Codec,
 		EncHeight:             720,
 		EncWidth:              1280,
-		XcType:                avpipe.XcVideo,
+		XcType:                goavpipe.XcVideo,
 		WatermarkText:         "This is avpipe text watermarking",
 		WatermarkYLoc:         "H*0.5",
 		WatermarkXLoc:         "W/2",
@@ -606,7 +607,7 @@ func TestSingleABRTranscodeWithOverlayWatermark(t *testing.T) {
 	overlayImage, err := ioutil.ReadFile("./media/avpipe.png")
 	failNowOnError(t, err)
 
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		BypassTranscoding:    false,
 		Format:               "hls",
 		StartTimeTs:          0,
@@ -619,12 +620,12 @@ func TestSingleABRTranscodeWithOverlayWatermark(t *testing.T) {
 		Ecodec:               h264Codec,
 		EncHeight:            720,
 		EncWidth:             1280,
-		XcType:               avpipe.XcVideo,
+		XcType:               goavpipe.XcVideo,
 		WatermarkYLoc:        "main_h*0.7",
 		WatermarkXLoc:        "main_w/2-overlay_w/2",
 		WatermarkOverlay:     string(overlayImage),
 		WatermarkOverlayLen:  len(overlayImage),
-		WatermarkOverlayType: avpipe.PngImage,
+		WatermarkOverlayType: goavpipe.PngImage,
 		StreamId:             -1,
 		Url:                  url,
 		DebugFrameLevel:      debugFrameLevel,
@@ -641,7 +642,7 @@ func TestV2SingleABRTranscode(t *testing.T) {
 
 	outputDir := path.Join(baseOutPath, fn())
 
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		BypassTranscoding:  false,
 		Format:             "hls",
 		StartTimeTs:        0,
@@ -655,7 +656,7 @@ func TestV2SingleABRTranscode(t *testing.T) {
 		Ecodec:             h264Codec,
 		EncHeight:          720,
 		EncWidth:           1280,
-		XcType:             avpipe.XcVideo,
+		XcType:             goavpipe.XcVideo,
 		StreamId:           -1,
 		Url:                url,
 		DebugFrameLevel:    debugFrameLevel,
@@ -663,7 +664,7 @@ func TestV2SingleABRTranscode(t *testing.T) {
 	setFastEncodeParams(params, false)
 	xcTest(t, outputDir, params, nil, true)
 
-	params.XcType = avpipe.XcAudio
+	params.XcType = goavpipe.XcAudio
 	params.Ecodec2 = "aac"
 	params.AudioIndex = []int32{1}
 	xcTest(t, outputDir, params, nil, false)
@@ -677,7 +678,7 @@ func TestV2SingleABRTranscodeIOHandler(t *testing.T) {
 
 	outputDir := path.Join(baseOutPath, fn())
 
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		BypassTranscoding:  false,
 		Format:             "hls",
 		StartTimeTs:        0,
@@ -691,7 +692,7 @@ func TestV2SingleABRTranscodeIOHandler(t *testing.T) {
 		Ecodec:             h264Codec,
 		EncHeight:          720,
 		EncWidth:           1280,
-		XcType:             avpipe.XcVideo,
+		XcType:             goavpipe.XcVideo,
 		StreamId:           -1,
 		Url:                url,
 		DebugFrameLevel:    debugFrameLevel,
@@ -699,7 +700,7 @@ func TestV2SingleABRTranscodeIOHandler(t *testing.T) {
 	setFastEncodeParams(params, false)
 	xcTest(t, outputDir, params, nil, true)
 
-	params.XcType = avpipe.XcAudio
+	params.XcType = goavpipe.XcAudio
 	params.Ecodec2 = "aac"
 	params.AudioIndex = []int32{1}
 	xcTest(t, outputDir, params, nil, false)
@@ -714,7 +715,7 @@ func TestV2SingleABRTranscodeCancelling(t *testing.T) {
 	outputDir := path.Join(baseOutPath, fn())
 	boilerplate(t, outputDir, url)
 
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		BypassTranscoding:  false,
 		Format:             "hls",
 		StartTimeTs:        0,
@@ -728,7 +729,7 @@ func TestV2SingleABRTranscodeCancelling(t *testing.T) {
 		Ecodec:             h264Codec,
 		EncHeight:          720,
 		EncWidth:           1280,
-		XcType:             avpipe.XcVideo,
+		XcType:             goavpipe.XcVideo,
 		StreamId:           -1,
 		Url:                url,
 		DebugFrameLevel:    debugFrameLevel,
@@ -749,7 +750,7 @@ func TestV2SingleABRTranscodeCancelling(t *testing.T) {
 	err2 := avpipe.XcRun(handle)
 	assert.Error(t, err2)
 
-	params.XcType = avpipe.XcAudio
+	params.XcType = goavpipe.XcAudio
 	params.Ecodec2 = "aac"
 	params.AudioIndex = []int32{1}
 	handleA, err := avpipe.XcInit(params)
@@ -762,7 +763,7 @@ func TestV2SingleABRTranscodeCancelling(t *testing.T) {
 }
 
 func doTranscode(t *testing.T,
-	p *avpipe.XcParams,
+	p *goavpipe.XcParams,
 	nThreads int,
 	outputDir, filename string) {
 
@@ -771,7 +772,7 @@ func doTranscode(t *testing.T,
 
 	done := make(chan struct{})
 	for i := 0; i < nThreads; i++ {
-		go func(params *avpipe.XcParams) {
+		go func(params *goavpipe.XcParams) {
 			err := avpipe.Xc(params)
 			done <- struct{}{} // Signal the main goroutine
 			if err != nil {
@@ -800,7 +801,7 @@ func TestNvidiaABRTranscode(t *testing.T) {
 
 	nThreads := 2
 
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		Format:             "hls",
 		StartTimeTs:        0,
 		DurationTs:         -1,
@@ -813,7 +814,7 @@ func TestNvidiaABRTranscode(t *testing.T) {
 		Ecodec:             "h264_nvenc",
 		EncHeight:          720,
 		EncWidth:           1280,
-		XcType:             avpipe.XcVideo,
+		XcType:             goavpipe.XcVideo,
 		StreamId:           -1,
 		Url:                url,
 	}
@@ -834,7 +835,7 @@ func TestNvidiaFmp4SegmentAspectRatio(t *testing.T) {
 		return
 	}
 
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		Format:          "fmp4-segment",
 		StartTimeTs:     0,
 		DurationTs:      -1,
@@ -846,7 +847,7 @@ func TestNvidiaFmp4SegmentAspectRatio(t *testing.T) {
 		Ecodec:          "h264_nvenc",
 		EncHeight:       642,
 		EncWidth:        1532,
-		XcType:          avpipe.XcVideo,
+		XcType:          goavpipe.XcVideo,
 		StreamId:        -1,
 		Url:             url,
 		DebugFrameLevel: debugFrameLevel,
@@ -871,7 +872,7 @@ func TestConcurrentABRTranscode(t *testing.T) {
 
 	nThreads := 10
 
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		Format:             "hls",
 		StartTimeTs:        0,
 		DurationTs:         -1,
@@ -884,7 +885,7 @@ func TestConcurrentABRTranscode(t *testing.T) {
 		Ecodec:             h264Codec,
 		EncHeight:          720,
 		EncWidth:           1280,
-		XcType:             avpipe.XcVideo,
+		XcType:             goavpipe.XcVideo,
 		StreamId:           -1,
 		Url:                url,
 		DebugFrameLevel:    debugFrameLevel,
@@ -901,7 +902,7 @@ func TestSettingProfileLevel(t *testing.T) {
 		return
 	}
 
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		Format:             "fmp4-segment",
 		StartTimeTs:        0,
 		DurationTs:         -1,
@@ -913,7 +914,7 @@ func TestSettingProfileLevel(t *testing.T) {
 		Ecodec:             h264Codec,
 		EncHeight:          480,
 		EncWidth:           720,
-		XcType:             avpipe.XcVideo,
+		XcType:             goavpipe.XcVideo,
 		StreamId:           -1,
 		Url:                url,
 		DebugFrameLevel:    debugFrameLevel,
@@ -940,7 +941,7 @@ func TestStartTimeTsWithSkipDecoding(t *testing.T) {
 	outputDir := path.Join(baseOutPath, fn())
 	boilerplate(t, outputDir, "")
 
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		BypassTranscoding:   false,
 		Format:              "dash",
 		StartTimeTs:         180000,
@@ -955,7 +956,7 @@ func TestStartTimeTsWithSkipDecoding(t *testing.T) {
 		Ecodec:              h264Codec,
 		EncHeight:           -1,
 		EncWidth:            -1,
-		XcType:              avpipe.XcVideo,
+		XcType:              goavpipe.XcVideo,
 		StreamId:            -1,
 		SyncAudioToStreamId: -1,
 		Url:                 url,
@@ -988,7 +989,7 @@ func TestStartTimeTsWithoutSkipDecoding(t *testing.T) {
 	outputDir := path.Join(baseOutPath, fn())
 	boilerplate(t, outputDir, "")
 
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		BypassTranscoding:   false,
 		Format:              "dash",
 		StartTimeTs:         180000,
@@ -1003,7 +1004,7 @@ func TestStartTimeTsWithoutSkipDecoding(t *testing.T) {
 		Ecodec:              h264Codec,
 		EncHeight:           -1,
 		EncWidth:            -1,
-		XcType:              avpipe.XcVideo,
+		XcType:              goavpipe.XcVideo,
 		StreamId:            -1,
 		SyncAudioToStreamId: -1,
 		Url:                 url,
@@ -1035,7 +1036,7 @@ func TestAudioAAC2AACMezMaker(t *testing.T) {
 
 	outputDir := path.Join(baseOutPath, fn())
 
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		BypassTranscoding:   false,
 		Format:              "fmp4-segment",
 		StartTimeTs:         0,
@@ -1048,7 +1049,7 @@ func TestAudioAAC2AACMezMaker(t *testing.T) {
 		SampleRate:          48000,
 		EncHeight:           -1,
 		EncWidth:            -1,
-		XcType:              avpipe.XcAudio,
+		XcType:              goavpipe.XcAudio,
 		StreamId:            -1,
 		SyncAudioToStreamId: -1,
 		Url:                 url,
@@ -1071,7 +1072,7 @@ func TestAudioAC3Ts2AC3MezMaker(t *testing.T) {
 
 	outputDir := path.Join(baseOutPath, fn())
 
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		BypassTranscoding:   false,
 		Format:              "fmp4-segment",
 		StartTimeTs:         0,
@@ -1084,7 +1085,7 @@ func TestAudioAC3Ts2AC3MezMaker(t *testing.T) {
 		SampleRate:          48000,
 		EncHeight:           -1,
 		EncWidth:            -1,
-		XcType:              avpipe.XcAudio,
+		XcType:              goavpipe.XcAudio,
 		StreamId:            -1,
 		SyncAudioToStreamId: -1,
 		Url:                 url,
@@ -1108,7 +1109,7 @@ func TestAudioAC3Ts2AACMezMaker(t *testing.T) {
 
 	outputDir := path.Join(baseOutPath, fn())
 
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		BypassTranscoding:   false,
 		Format:              "fmp4-segment",
 		StartTimeTs:         0,
@@ -1121,7 +1122,7 @@ func TestAudioAC3Ts2AACMezMaker(t *testing.T) {
 		SampleRate:          48000,
 		EncHeight:           -1,
 		EncWidth:            -1,
-		XcType:              avpipe.XcAudio,
+		XcType:              goavpipe.XcAudio,
 		StreamId:            -1,
 		SyncAudioToStreamId: -1,
 		Url:                 url,
@@ -1146,7 +1147,7 @@ func TestAudioMP3Ts2AACMezMaker(t *testing.T) {
 
 	outputDir := path.Join(baseOutPath, fn())
 
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		BypassTranscoding:   false,
 		Format:              "fmp4-segment",
 		StartTimeTs:         0,
@@ -1159,7 +1160,7 @@ func TestAudioMP3Ts2AACMezMaker(t *testing.T) {
 		SampleRate:          48000,
 		EncHeight:           -1,
 		EncWidth:            -1,
-		XcType:              avpipe.XcAudio,
+		XcType:              goavpipe.XcAudio,
 		StreamId:            -1,
 		SyncAudioToStreamId: -1,
 		Url:                 url,
@@ -1184,7 +1185,7 @@ func TestAudioDownmix2AACMezMaker(t *testing.T) {
 
 	outputDir := path.Join(baseOutPath, fn())
 
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		BypassTranscoding:   false,
 		Format:              "fmp4-segment",
 		StartTimeTs:         0,
@@ -1197,7 +1198,7 @@ func TestAudioDownmix2AACMezMaker(t *testing.T) {
 		SampleRate:          48000,
 		EncHeight:           -1,
 		EncWidth:            -1,
-		XcType:              avpipe.XcAudio,
+		XcType:              goavpipe.XcAudio,
 		ChannelLayout:       avpipe.ChannelLayout("stereo"),
 		StreamId:            -1,
 		SyncAudioToStreamId: -1,
@@ -1224,7 +1225,7 @@ func TestAudio2MonoTo1Stereo(t *testing.T) {
 
 	outputDir := path.Join(baseOutPath, fn())
 
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		BypassTranscoding:   false,
 		Format:              "fmp4-segment",
 		StartTimeTs:         0,
@@ -1233,7 +1234,7 @@ func TestAudio2MonoTo1Stereo(t *testing.T) {
 		SegDuration:         "30",
 		Ecodec2:             "aac",
 		Dcodec2:             "",
-		XcType:              avpipe.XcAudioJoin,
+		XcType:              goavpipe.XcAudioJoin,
 		ChannelLayout:       avpipe.ChannelLayout("stereo"),
 		StreamId:            -1,
 		SyncAudioToStreamId: -1,
@@ -1262,7 +1263,7 @@ func TestAudio5_1To5_1(t *testing.T) {
 
 	outputDir := path.Join(baseOutPath, fn())
 
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		BypassTranscoding:   false,
 		Format:              "fmp4-segment",
 		StartTimeTs:         0,
@@ -1271,7 +1272,7 @@ func TestAudio5_1To5_1(t *testing.T) {
 		SegDuration:         "30",
 		Ecodec2:             "aac",
 		Dcodec2:             "",
-		XcType:              avpipe.XcAudio,
+		XcType:              goavpipe.XcAudio,
 		StreamId:            -1,
 		SyncAudioToStreamId: -1,
 		Url:                 url,
@@ -1298,7 +1299,7 @@ func TestAudio5_1ToStereo(t *testing.T) {
 
 	outputDir := path.Join(baseOutPath, fn())
 
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		BypassTranscoding:   false,
 		Format:              "fmp4-segment",
 		StartTimeTs:         0,
@@ -1307,7 +1308,7 @@ func TestAudio5_1ToStereo(t *testing.T) {
 		SegDuration:         "30",
 		Ecodec2:             "aac",
 		Dcodec2:             "",
-		XcType:              avpipe.XcAudioPan,
+		XcType:              goavpipe.XcAudioPan,
 		FilterDescriptor:    "[0:1]pan=stereo|c0<c0+c4+0.707*c2|c1<c1+c5+0.707*c2[aout]",
 		ChannelLayout:       avpipe.ChannelLayout("stereo"),
 		StreamId:            -1,
@@ -1336,7 +1337,7 @@ func TestAudioMonoToMono(t *testing.T) {
 
 	outputDir := path.Join(baseOutPath, fn())
 
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		BypassTranscoding:   false,
 		Format:              "fmp4-segment",
 		StartTimeTs:         0,
@@ -1345,7 +1346,7 @@ func TestAudioMonoToMono(t *testing.T) {
 		SegDuration:         "30",
 		Ecodec2:             "aac",
 		Dcodec2:             "",
-		XcType:              avpipe.XcAudio,
+		XcType:              goavpipe.XcAudio,
 		ChannelLayout:       avpipe.ChannelLayout("mono"),
 		StreamId:            -1,
 		SyncAudioToStreamId: -1,
@@ -1374,7 +1375,7 @@ func TestAudioQuadToQuad(t *testing.T) {
 
 	outputDir := path.Join(baseOutPath, fn())
 
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		BypassTranscoding:   false,
 		Format:              "fmp4-segment",
 		StartTimeTs:         0,
@@ -1383,7 +1384,7 @@ func TestAudioQuadToQuad(t *testing.T) {
 		SegDuration:         "30",
 		Ecodec2:             "aac",
 		Dcodec2:             "",
-		XcType:              avpipe.XcAudio,
+		XcType:              goavpipe.XcAudio,
 		ChannelLayout:       avpipe.ChannelLayout("quad"),
 		StreamId:            -1,
 		SyncAudioToStreamId: -1,
@@ -1412,7 +1413,7 @@ func TestAudio6MonoTo5_1(t *testing.T) {
 
 	outputDir := path.Join(baseOutPath, fn())
 
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		BypassTranscoding:   false,
 		Format:              "fmp4-segment",
 		StartTimeTs:         0,
@@ -1421,7 +1422,7 @@ func TestAudio6MonoTo5_1(t *testing.T) {
 		SegDuration:         "30",
 		Ecodec2:             "aac",
 		Dcodec2:             "",
-		XcType:              avpipe.XcAudioMerge,
+		XcType:              goavpipe.XcAudioMerge,
 		ChannelLayout:       avpipe.ChannelLayout("5.1"),
 		FilterDescriptor:    "[0:3][0:4][0:5][0:6][0:7][0:8]amerge=inputs=6,pan=5.1|c0=c0|c1=c1|c2=c2| c3=c3|c4=c4|c5=c5[aout]",
 		StreamId:            -1,
@@ -1451,7 +1452,7 @@ func TestAudio6MonoUnequalChannelLayoutsTo5_1(t *testing.T) {
 
 	outputDir := path.Join(baseOutPath, fn())
 
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		BypassTranscoding:   false,
 		Format:              "fmp4-segment",
 		StartTimeTs:         0,
@@ -1460,7 +1461,7 @@ func TestAudio6MonoUnequalChannelLayoutsTo5_1(t *testing.T) {
 		SegDuration:         "30",
 		Ecodec2:             "aac",
 		Dcodec2:             "",
-		XcType:              avpipe.XcAudioMerge,
+		XcType:              goavpipe.XcAudioMerge,
 		ChannelLayout:       avpipe.ChannelLayout("5.1"),
 		FilterDescriptor:    "[0:0][0:1][0:2][0:3][0:4][0:5]amerge=inputs=6,pan=5.1|c0=c0|c1=c1|c2=c2|c3=c3|c4=c4|c5=c5[aout]",
 		StreamId:            -1,
@@ -1490,7 +1491,7 @@ func TestAudio10Channel_s16To6Channel_5_1(t *testing.T) {
 
 	outputDir := path.Join(baseOutPath, fn())
 
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		BypassTranscoding:   false,
 		Format:              "fmp4-segment",
 		StartTimeTs:         0,
@@ -1499,7 +1500,7 @@ func TestAudio10Channel_s16To6Channel_5_1(t *testing.T) {
 		SegDuration:         "30",
 		Ecodec2:             "aac",
 		Dcodec2:             "",
-		XcType:              avpipe.XcAudioPan,
+		XcType:              goavpipe.XcAudioPan,
 		ChannelLayout:       avpipe.ChannelLayout("5.1"),
 		FilterDescriptor:    "[0:1]pan=5.1|c0=c3|c1=c4|c2=c5|c3=c6|c4=c7|c5=c8[aout]",
 		StreamId:            -1,
@@ -1529,7 +1530,7 @@ func TestAudio2Channel1Stereo(t *testing.T) {
 
 	outputDir := path.Join(baseOutPath, fn())
 
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		BypassTranscoding:   false,
 		Format:              "fmp4-segment",
 		StartTimeTs:         0,
@@ -1538,7 +1539,7 @@ func TestAudio2Channel1Stereo(t *testing.T) {
 		SegDuration:         "30",
 		Ecodec2:             "aac",
 		Dcodec2:             "",
-		XcType:              avpipe.XcAudioPan,
+		XcType:              goavpipe.XcAudioPan,
 		ChannelLayout:       avpipe.ChannelLayout("stereo"),
 		StreamId:            -1,
 		SyncAudioToStreamId: -1,
@@ -1571,7 +1572,7 @@ func TestAudioPan2Channel1Stereo_pcm_60000(t *testing.T) {
 
 	outputDir := path.Join(baseOutPath, fn())
 
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		BypassTranscoding:   false,
 		Format:              "fmp4-segment",
 		StartTimeTs:         0,
@@ -1580,7 +1581,7 @@ func TestAudioPan2Channel1Stereo_pcm_60000(t *testing.T) {
 		SegDuration:         "30",
 		Ecodec2:             "aac",
 		Dcodec2:             "",
-		XcType:              avpipe.XcAudioPan,
+		XcType:              goavpipe.XcAudioPan,
 		ChannelLayout:       avpipe.ChannelLayout("stereo"),
 		StreamId:            -1,
 		SyncAudioToStreamId: -1,
@@ -1613,7 +1614,7 @@ func TestAudioMonoToStereo_pcm_60000(t *testing.T) {
 
 	outputDir := path.Join(baseOutPath, fn())
 
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		BypassTranscoding:   false,
 		Format:              "fmp4-segment",
 		StartTimeTs:         0,
@@ -1622,7 +1623,7 @@ func TestAudioMonoToStereo_pcm_60000(t *testing.T) {
 		SegDuration:         "30",
 		Ecodec2:             "aac",
 		Dcodec2:             "",
-		XcType:              avpipe.XcAudio,
+		XcType:              goavpipe.XcAudio,
 		ChannelLayout:       avpipe.ChannelLayout("stereo"),
 		StreamId:            -1,
 		SyncAudioToStreamId: -1,
@@ -1653,7 +1654,7 @@ func TestMultiAudioXc(t *testing.T) {
 
 	outputDir := path.Join(baseOutPath, fn())
 
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		BypassTranscoding:   false,
 		Format:              "fmp4-segment",
 		StartTimeTs:         0,
@@ -1666,7 +1667,7 @@ func TestMultiAudioXc(t *testing.T) {
 		Ecodec2:             "aac",
 		EncHeight:           720,
 		EncWidth:            1280,
-		XcType:              avpipe.XcAll,
+		XcType:              goavpipe.XcAll,
 		StreamId:            -1,
 		SyncAudioToStreamId: -1,
 		ForceKeyInt:         60,
@@ -1697,7 +1698,7 @@ func TestIrregularTsMezMaker_1001_60000(t *testing.T) {
 
 	outputDir := path.Join(baseOutPath, fn())
 
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		BypassTranscoding:   false,
 		Format:              "fmp4-segment",
 		StartTimeTs:         0,
@@ -1708,7 +1709,7 @@ func TestIrregularTsMezMaker_1001_60000(t *testing.T) {
 		Dcodec:              "",
 		EncHeight:           720,
 		EncWidth:            1280,
-		XcType:              avpipe.XcVideo,
+		XcType:              goavpipe.XcVideo,
 		StreamId:            -1,
 		SyncAudioToStreamId: -1,
 		ForceKeyInt:         120,
@@ -1737,7 +1738,7 @@ func TestIrregularTsMezMaker_1_24(t *testing.T) {
 
 	outputDir := path.Join(baseOutPath, fn())
 
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		BypassTranscoding:   false,
 		Format:              "fmp4-segment",
 		StartTimeTs:         0,
@@ -1748,7 +1749,7 @@ func TestIrregularTsMezMaker_1_24(t *testing.T) {
 		Dcodec:              "",
 		EncHeight:           720,
 		EncWidth:            1280,
-		XcType:              avpipe.XcVideo,
+		XcType:              goavpipe.XcVideo,
 		StreamId:            -1,
 		SyncAudioToStreamId: -1,
 		ForceKeyInt:         48,
@@ -1782,7 +1783,7 @@ func TestIrregularTsMezMaker_1_10000(t *testing.T) {
 
 	outputDir := path.Join(baseOutPath, fn())
 
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		BypassTranscoding:   false,
 		Format:              "fmp4-segment",
 		StartTimeTs:         0,
@@ -1793,7 +1794,7 @@ func TestIrregularTsMezMaker_1_10000(t *testing.T) {
 		Dcodec:              "",
 		EncHeight:           720,
 		EncWidth:            1280,
-		XcType:              avpipe.XcVideo,
+		XcType:              goavpipe.XcVideo,
 		StreamId:            -1,
 		SyncAudioToStreamId: -1,
 		ForceKeyInt:         48,
@@ -1831,7 +1832,7 @@ func TestMXF_H265MezMaker(t *testing.T) {
 
 	outputDir := path.Join(baseOutPath, f)
 
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		BypassTranscoding: false,
 		Format:            "fmp4-segment",
 		StartTimeTs:       0,
@@ -1842,7 +1843,7 @@ func TestMXF_H265MezMaker(t *testing.T) {
 		Dcodec:            "jpeg2000",
 		EncHeight:         -1,
 		EncWidth:          -1,
-		XcType:            avpipe.XcVideo,
+		XcType:            goavpipe.XcVideo,
 		StreamId:          -1,
 		Url:               url,
 		DebugFrameLevel:   debugFrameLevel,
@@ -1867,7 +1868,7 @@ func TestHEVC_H264MezMaker(t *testing.T) {
 
 	outputDir := path.Join(baseOutPath, fn())
 
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		BypassTranscoding: false,
 		Format:            "fmp4-segment",
 		StartTimeTs:       0,
@@ -1878,7 +1879,7 @@ func TestHEVC_H264MezMaker(t *testing.T) {
 		Dcodec:            "hevc",
 		EncHeight:         -1,
 		EncWidth:          -1,
-		XcType:            avpipe.XcVideo,
+		XcType:            goavpipe.XcVideo,
 		StreamId:          -1,
 		Url:               url,
 		DebugFrameLevel:   debugFrameLevel,
@@ -1908,7 +1909,7 @@ func TestMezMakerWithOpenInputError(t *testing.T) {
 
 	outputDir := path.Join(baseOutPath, fn())
 
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		BypassTranscoding: false,
 		Format:            "fmp4-segment",
 		StartTimeTs:       0,
@@ -1919,7 +1920,7 @@ func TestMezMakerWithOpenInputError(t *testing.T) {
 		Dcodec:            "hevc",
 		EncHeight:         -1,
 		EncWidth:          -1,
-		XcType:            avpipe.XcVideo,
+		XcType:            goavpipe.XcVideo,
 		StreamId:          -1,
 		Url:               url,
 		DebugFrameLevel:   debugFrameLevel,
@@ -1953,7 +1954,7 @@ func TestMezMakerWithReadInputError(t *testing.T) {
 
 	outputDir := path.Join(baseOutPath, fn())
 
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		BypassTranscoding: false,
 		Format:            "fmp4-segment",
 		StartTimeTs:       0,
@@ -1964,7 +1965,7 @@ func TestMezMakerWithReadInputError(t *testing.T) {
 		Dcodec:            "hevc",
 		EncHeight:         -1,
 		EncWidth:          -1,
-		XcType:            avpipe.XcVideo,
+		XcType:            goavpipe.XcVideo,
 		StreamId:          -1,
 		Url:               url,
 		DebugFrameLevel:   debugFrameLevel,
@@ -2004,7 +2005,7 @@ func TestProbeWithReadInputError(t *testing.T) {
 	foo := &fileOutputOpener{t: t, dir: outputDir}
 	avpipe.InitIOHandler(fio, foo)
 
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		Url:      url,
 		Seekable: true,
 	}
@@ -2028,7 +2029,7 @@ func TestHEVC_H265ABRTranscode(t *testing.T) {
 	videoMezDir := path.Join(baseOutPath, f, "VideoMez4H265")
 	videoABRDir := path.Join(baseOutPath, f, "VideoABR4H265")
 
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		BypassTranscoding: false,
 		Format:            "fmp4-segment",
 		StartTimeTs:       0,
@@ -2039,7 +2040,7 @@ func TestHEVC_H265ABRTranscode(t *testing.T) {
 		Dcodec:            "hevc",
 		EncHeight:         -1,
 		EncWidth:          -1,
-		XcType:            avpipe.XcVideo,
+		XcType:            goavpipe.XcVideo,
 		StreamId:          -1,
 		Url:               url,
 		DebugFrameLevel:   debugFrameLevel,
@@ -2051,7 +2052,7 @@ func TestHEVC_H265ABRTranscode(t *testing.T) {
 	setupOutDir(t, videoABRDir)
 	url = videoMezDir + "/vsegment-1.mp4"
 	log.Debug("STARTING video ABR for", "file", url)
-	params.XcType = avpipe.XcVideo
+	params.XcType = goavpipe.XcVideo
 	params.Format = "dash"
 	params.VideoSegDurationTs = 48000
 	params.Url = url
@@ -2068,7 +2069,7 @@ func TestAVPipeStats(t *testing.T) {
 
 	outputDir := path.Join(baseOutPath, fn())
 
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		BypassTranscoding:   false,
 		Format:              "fmp4-segment",
 		StartTimeTs:         0,
@@ -2080,7 +2081,7 @@ func TestAVPipeStats(t *testing.T) {
 		Ecodec2:             "aac",
 		EncHeight:           720,
 		EncWidth:            1280,
-		XcType:              avpipe.XcAll,
+		XcType:              goavpipe.XcAll,
 		StreamId:            -1,
 		SyncAudioToStreamId: -1,
 		ForceKeyInt:         48,
@@ -2133,7 +2134,7 @@ func TestABRMuxing(t *testing.T) {
 
 	// Create video mez files
 	setupOutDir(t, videoMezDir)
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		BypassTranscoding:  false,
 		Format:             "fmp4-segment",
 		StartTimeTs:        0,
@@ -2147,7 +2148,7 @@ func TestABRMuxing(t *testing.T) {
 		Ecodec:             h264Codec,
 		EncHeight:          720,
 		EncWidth:           1280,
-		XcType:             avpipe.XcVideo,
+		XcType:             goavpipe.XcVideo,
 		StreamId:           -1,
 		Url:                url,
 		DebugFrameLevel:    debugFrameLevel,
@@ -2160,7 +2161,7 @@ func TestABRMuxing(t *testing.T) {
 	log.Debug("STARTING audio mez for muxing", "file", url)
 	// Create audio mez files
 	setupOutDir(t, audioMezDir)
-	params.XcType = avpipe.XcAudio
+	params.XcType = goavpipe.XcAudio
 	params.Ecodec2 = "aac"
 	params.ChannelLayout = avpipe.ChannelLayout("stereo")
 	avpipe.InitUrlIOHandler(url, &fileInputOpener{url: url}, &fileOutputOpener{dir: audioMezDir})
@@ -2170,7 +2171,7 @@ func TestABRMuxing(t *testing.T) {
 	setupOutDir(t, videoABRDir)
 	url = videoMezDir + "/vsegment-1.mp4"
 	log.Debug("STARTING video ABR for muxing (first segment)", "file", url)
-	params.XcType = avpipe.XcVideo
+	params.XcType = goavpipe.XcVideo
 	params.Format = "dash"
 	params.VideoSegDurationTs = 48000
 	params.Url = url
@@ -2181,7 +2182,7 @@ func TestABRMuxing(t *testing.T) {
 	setupOutDir(t, videoABRDir2)
 	url = videoMezDir + "/vsegment-2.mp4"
 	log.Debug("STARTING video ABR for muxing (second segment)", "file", url)
-	params.XcType = avpipe.XcVideo
+	params.XcType = goavpipe.XcVideo
 	params.Format = "dash"
 	params.VideoSegDurationTs = 48000
 	params.Url = url
@@ -2194,7 +2195,7 @@ func TestABRMuxing(t *testing.T) {
 	setupOutDir(t, audioABRDir)
 	url = audioMezDir + "/asegment0-1.mp4"
 	log.Debug("STARTING audio ABR for muxing", "file", url)
-	params.XcType = avpipe.XcAudio
+	params.XcType = goavpipe.XcAudio
 	params.Format = "dash"
 	params.Ecodec2 = "aac"
 	params.AudioSegDurationTs = 96000
@@ -2208,7 +2209,7 @@ func TestABRMuxing(t *testing.T) {
 	setupOutDir(t, audioABRDir2)
 	url = audioMezDir + "/asegment0-2.mp4"
 	log.Debug("STARTING audio ABR for muxing (first segment)", "file", url)
-	params.XcType = avpipe.XcAudio
+	params.XcType = goavpipe.XcAudio
 	params.Format = "dash"
 	params.Ecodec2 = "aac"
 	params.AudioSegDurationTs = 96000
@@ -2282,12 +2283,12 @@ func TestABRMuxing(t *testing.T) {
 }
 
 func TestMarshalParams(t *testing.T) {
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		VideoBitrate:       8000000,
 		VideoSegDurationTs: 180000,
 		EncHeight:          720,
 		EncWidth:           1280,
-		XcType:             avpipe.XcVideo,
+		XcType:             goavpipe.XcVideo,
 	}
 	bytes, err := json.Marshal(params)
 	assert.NoError(t, err)
@@ -2296,16 +2297,16 @@ func TestMarshalParams(t *testing.T) {
 }
 
 func TestUnmarshalParams(t *testing.T) {
-	var params avpipe.XcParams
+	var params goavpipe.XcParams
 	bytes := []byte(`{"video_bitrate":8000000,"seg_duration_ts":180000,"seg_duration_fr":50,"enc_height":720,"enc_width":1280,"xc_type":1}`)
 	err := json.Unmarshal(bytes, &params)
 	assert.NoError(t, err)
-	assert.Equal(t, avpipe.XcVideo, int(params.XcType))
+	assert.Equal(t, goavpipe.XcVideo, int(params.XcType))
 	// TODO: More checks
 }
 
 func TestUnmarshalParamsNumAudioBackwardsCompat(t *testing.T) {
-	var params avpipe.XcParams
+	var params goavpipe.XcParams
 	bytesWithNAudio := []byte(`{"video_bitrate":8000000,"seg_duration_ts":180000,"seg_duration_fr":50,"enc_height":720,"enc_width":1280,"xc_type":1,"audio_index":[0,0,0,0,0,0,0,0],"n_audio":1}`)
 	err := json.Unmarshal(bytesWithNAudio, &params)
 	assert.NoError(t, err)
@@ -2324,7 +2325,7 @@ func TestProbe(t *testing.T) {
 	}
 
 	avpipe.InitIOHandler(&fileInputOpener{url: url}, &concurrentOutputOpener{dir: "O"})
-	xcparams := &avpipe.XcParams{
+	xcparams := &goavpipe.XcParams{
 		Url:      url,
 		Seekable: true,
 	}
@@ -2381,7 +2382,7 @@ func TestProbeWithData(t *testing.T) {
 	}
 
 	avpipe.InitIOHandler(&fileInputOpener{url: url}, &concurrentOutputOpener{dir: "O"})
-	xcparams := &avpipe.XcParams{
+	xcparams := &goavpipe.XcParams{
 		Url:      url,
 		Seekable: true,
 	}
@@ -2447,7 +2448,7 @@ func TestExtractImagesInterval(t *testing.T) {
 	}
 
 	outPath := path.Join(baseOutPath, fn())
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		Format:                 "image2",
 		AudioBitrate:           128000,
 		AudioSegDurationTs:     -1,
@@ -2468,7 +2469,7 @@ func TestExtractImagesInterval(t *testing.T) {
 		SyncAudioToStreamId:    -1,
 		VideoBitrate:           -1,
 		VideoSegDurationTs:     -1,
-		XcType:                 avpipe.XcExtractImages,
+		XcType:                 goavpipe.XcExtractImages,
 		Url:                    url,
 		DebugFrameLevel:        debugFrameLevel,
 	}
@@ -2495,7 +2496,7 @@ func TestExtractImagesList(t *testing.T) {
 	}
 
 	outPath := path.Join(baseOutPath, fn())
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		Format:                 "image2",
 		AudioBitrate:           128000,
 		AudioSegDurationTs:     -1,
@@ -2516,7 +2517,7 @@ func TestExtractImagesList(t *testing.T) {
 		SyncAudioToStreamId:    -1,
 		VideoBitrate:           -1,
 		VideoSegDurationTs:     -1,
-		XcType:                 avpipe.XcExtractImages,
+		XcType:                 goavpipe.XcExtractImages,
 		Url:                    url,
 		DebugFrameLevel:        debugFrameLevel,
 	}
@@ -2546,7 +2547,7 @@ func TestExtractImagesListFast(t *testing.T) {
 
 	outPath := path.Join(baseOutPath, fn())
 
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		Format:                 "image2",
 		AudioBitrate:           128000,
 		AudioSegDurationTs:     -1,
@@ -2567,7 +2568,7 @@ func TestExtractImagesListFast(t *testing.T) {
 		SyncAudioToStreamId:    -1,
 		VideoBitrate:           -1,
 		VideoSegDurationTs:     -1,
-		XcType:                 avpipe.XcExtractImages,
+		XcType:                 goavpipe.XcExtractImages,
 		Url:                    url,
 		DebugFrameLevel:        debugFrameLevel,
 	}
@@ -2592,7 +2593,7 @@ func TestExtractAllImages(t *testing.T) {
 
 	outPath := path.Join(baseOutPath, fn())
 
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		Format:                 "image2",
 		AudioBitrate:           128000,
 		AudioSegDurationTs:     -1,
@@ -2612,7 +2613,7 @@ func TestExtractAllImages(t *testing.T) {
 		SyncAudioToStreamId:    -1,
 		VideoBitrate:           -1,
 		VideoSegDurationTs:     -1,
-		XcType:                 avpipe.XcExtractAllImages,
+		XcType:                 goavpipe.XcExtractAllImages,
 		Url:                    url,
 		DebugFrameLevel:        debugFrameLevel,
 	}
@@ -2666,11 +2667,11 @@ type ProfileParams struct {
 
 func TestProfile(t *testing.T) {
 	profileParams := []ProfileParams{
-		{8, 320, 540, avpipe.XcProfileH264BaseLine},
-		{8, 1280, 720, avpipe.XcProfileH264Heigh},
-		{8, 1920, 1080, avpipe.XcProfileH264Heigh},
-		{8, 3840, 2169, avpipe.XcProfileH264Heigh},
-		{10, 3840, 2169, avpipe.XcProfileH264Heigh10},
+		{8, 320, 540, goavpipe.XcProfileH264BaseLine},
+		{8, 1280, 720, goavpipe.XcProfileH264Heigh},
+		{8, 1920, 1080, goavpipe.XcProfileH264Heigh},
+		{8, 3840, 2169, goavpipe.XcProfileH264Heigh},
+		{10, 3840, 2169, goavpipe.XcProfileH264Heigh10},
 	}
 
 	for i := 0; i < len(profileParams); i++ {
@@ -2685,7 +2686,7 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func xcTest(t *testing.T, outputDir string, params *avpipe.XcParams, xcTestResult *XcTestResult, isNewTest bool) {
+func xcTest(t *testing.T, outputDir string, params *goavpipe.XcParams, xcTestResult *XcTestResult, isNewTest bool) {
 	if isNewTest {
 		boilerplate(t, outputDir, params.Url)
 	}
@@ -2711,7 +2712,7 @@ func boilerProbe(t *testing.T, result *XcTestResult) (probeInfoArray []*avpipe.P
 	}
 
 	for _, mezFile := range result.mezFile {
-		xcparams := &avpipe.XcParams{
+		xcparams := &goavpipe.XcParams{
 			Url:      mezFile,
 			Seekable: true,
 		}
@@ -2747,12 +2748,12 @@ func boilerProbe(t *testing.T, result *XcTestResult) (probeInfoArray []*avpipe.P
 	return
 }
 
-func boilerXc(t *testing.T, params *avpipe.XcParams) {
+func boilerXc(t *testing.T, params *goavpipe.XcParams) {
 	err := avpipe.Xc(params)
 	failNowOnError(t, err)
 }
 
-func xcTest2(t *testing.T, outputDir string, params *avpipe.XcParams, xcTestResult *XcTestResult) {
+func xcTest2(t *testing.T, outputDir string, params *goavpipe.XcParams, xcTestResult *XcTestResult) {
 	boilerplate(t, outputDir, params.Url)
 	boilerXc2(t, params)
 	boilerProbe(t, xcTestResult)
@@ -2764,7 +2765,7 @@ func xcTest2(t *testing.T, outputDir string, params *avpipe.XcParams, xcTestResu
 //
 // - to run the tx session
 //   - XcRun()
-func boilerXc2(t *testing.T, params *avpipe.XcParams) {
+func boilerXc2(t *testing.T, params *goavpipe.XcParams) {
 	handle, err := avpipe.XcInit(params)
 	failNowOnError(t, err)
 	assert.Greater(t, handle, int32(0))
@@ -2772,7 +2773,7 @@ func boilerXc2(t *testing.T, params *avpipe.XcParams) {
 	failNowOnError(t, err)
 }
 
-func setFastEncodeParams(p *avpipe.XcParams, force bool) bool {
+func setFastEncodeParams(p *goavpipe.XcParams, force bool) bool {
 	if !force && !testing.Short() {
 		return false
 	}

--- a/elvxc/cmd/mux.go
+++ b/elvxc/cmd/mux.go
@@ -3,12 +3,14 @@ package cmd
 import "C"
 import (
 	"fmt"
-	"github.com/eluv-io/avpipe"
-	"github.com/spf13/cobra"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
+
+	"github.com/eluv-io/avpipe"
+	"github.com/eluv-io/avpipe/goavpipe"
+	"github.com/spf13/cobra"
 )
 
 type AVCmdMuxInputOpener struct {
@@ -121,11 +123,11 @@ func (muxInput *elvxcMuxInput) Stat(streamIndex int, statType avpipe.AVStatType,
 type AVCmdMuxOutputOpener struct {
 }
 
-func (outputOpener *AVCmdMuxOutputOpener) Open(filename string, fd int64, outType avpipe.AVType) (avpipe.OutputHandler, error) {
+func (outputOpener *AVCmdMuxOutputOpener) Open(filename string, fd int64, outType goavpipe.AVType) (avpipe.OutputHandler, error) {
 
-	if outType != avpipe.MP4Segment &&
-		outType != avpipe.FMP4AudioSegment &&
-		outType != avpipe.FMP4VideoSegment {
+	if outType != goavpipe.MP4Segment &&
+		outType != goavpipe.FMP4AudioSegment &&
+		outType != goavpipe.FMP4VideoSegment {
 		return nil, fmt.Errorf("Invalid outType=%d", outType)
 	}
 
@@ -165,7 +167,7 @@ func (muxOutput *elvxcMuxOutput) Close() error {
 	return err
 }
 
-func (muxOutput *elvxcMuxOutput) Stat(streamIndex int, avType avpipe.AVType, statType avpipe.AVStatType, statArgs interface{}) error {
+func (muxOutput *elvxcMuxOutput) Stat(streamIndex int, avType goavpipe.AVType, statType avpipe.AVStatType, statArgs interface{}) error {
 	switch statType {
 	case avpipe.AV_OUT_STAT_BYTES_WRITTEN:
 		writeOffset := statArgs.(*uint64)
@@ -219,7 +221,7 @@ func doMux(cmd *cobra.Command, args []string) error {
 	}
 	log.Debug("doMux", "mux_spec", string(muxSpec))
 
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		MuxingSpec:      string(muxSpec),
 		Url:             filename,
 		DebugFrameLevel: true,

--- a/elvxc/cmd/probe.go
+++ b/elvxc/cmd/probe.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/eluv-io/avpipe"
+	"github.com/eluv-io/avpipe/goavpipe"
 	"github.com/spf13/cobra"
 )
 
@@ -47,7 +48,7 @@ func doProbe(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Invalid listen flag")
 	}
 
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		Url:               filename,
 		Seekable:          seekable,
 		Listen:            listen,
@@ -74,7 +75,7 @@ func doProbe(cmd *cobra.Command, args []string) error {
 		fmt.Printf("\tcodec_name: %s\n", info.CodecName)
 		fmt.Printf("\tprofile: %s\n", avpipe.GetProfileName(info.CodecID, info.Profile))
 		fmt.Printf("\tlevel: %d\n", info.Level)
-		if uint64(info.DurationTs) != avpipe.AvNoPtsValue {
+		if uint64(info.DurationTs) != goavpipe.AvNoPtsValue {
 			fmt.Printf("\tduration_ts: %d\n", info.DurationTs)
 		}
 		fmt.Printf("\ttime_base: %d/%d\n", info.TimeBase.Num(), info.TimeBase.Denom())

--- a/elvxc/cmd/transcode.go
+++ b/elvxc/cmd/transcode.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/eluv-io/avpipe"
+	"github.com/eluv-io/avpipe/goavpipe"
 	"github.com/spf13/cobra"
 )
 
@@ -142,7 +143,7 @@ type elvxcOutputOpener struct {
 }
 
 func (oo *elvxcOutputOpener) Open(h, fd int64, stream_index, seg_index int,
-	pts int64, out_type avpipe.AVType) (avpipe.OutputHandler, error) {
+	pts int64, out_type goavpipe.AVType) (avpipe.OutputHandler, error) {
 
 	log.Debug("AVCMD OutputOpener.Open", "h", h, "fd", fd,
 		"stream_index", stream_index, "seg_index", seg_index, "pts", pts, "out_type", out_type)
@@ -157,37 +158,37 @@ func (oo *elvxcOutputOpener) Open(h, fd int64, stream_index, seg_index int,
 	}
 
 	switch out_type {
-	case avpipe.DASHVideoInit:
+	case goavpipe.DASHVideoInit:
 		fallthrough
-	case avpipe.DASHAudioInit:
+	case goavpipe.DASHAudioInit:
 		filename = fmt.Sprintf("./%s/init-stream%d.m4s", dir, stream_index)
-	case avpipe.DASHManifest:
+	case goavpipe.DASHManifest:
 		filename = fmt.Sprintf("./%s/dash.mpd", dir)
-	case avpipe.DASHVideoSegment:
+	case goavpipe.DASHVideoSegment:
 		fallthrough
-	case avpipe.DASHAudioSegment:
+	case goavpipe.DASHAudioSegment:
 		filename = fmt.Sprintf("./%s/chunk-stream%d-%05d.m4s", dir, stream_index, seg_index)
-	case avpipe.HLSMasterM3U:
+	case goavpipe.HLSMasterM3U:
 		filename = fmt.Sprintf("./%s/master.m3u8", dir)
-	case avpipe.HLSVideoM3U:
+	case goavpipe.HLSVideoM3U:
 		fallthrough
-	case avpipe.HLSAudioM3U:
+	case goavpipe.HLSAudioM3U:
 		filename = fmt.Sprintf("./%s/media_%d.m3u8", dir, stream_index)
-	case avpipe.AES128Key:
+	case goavpipe.AES128Key:
 		filename = fmt.Sprintf("./%s/key.bin", dir)
-	case avpipe.MP4Stream:
+	case goavpipe.MP4Stream:
 		filename = fmt.Sprintf("%s/mp4-stream.mp4", dir)
-	case avpipe.FMP4Stream:
+	case goavpipe.FMP4Stream:
 		filename = fmt.Sprintf("%s/fmp4-stream.mp4", dir)
-	case avpipe.MP4Segment:
+	case goavpipe.MP4Segment:
 		filename = fmt.Sprintf("%s/segment%d-%05d.mp4", dir, stream_index, seg_index)
-	case avpipe.FMP4VideoSegment:
+	case goavpipe.FMP4VideoSegment:
 		filename = fmt.Sprintf("%s/fmp4-vsegment%d-%05d.mp4", dir, stream_index, seg_index)
-	case avpipe.FMP4AudioSegment:
+	case goavpipe.FMP4AudioSegment:
 		filename = fmt.Sprintf("%s/fmp4-asegment%d-%05d.mp4", dir, stream_index, seg_index)
-	case avpipe.FrameImage:
+	case goavpipe.FrameImage:
 		filename = fmt.Sprintf("%s/%d.jpeg", dir, pts)
-	case avpipe.MpegtsSegment:
+	case goavpipe.MpegtsSegment:
 		filename = fmt.Sprintf("%s/ts-segment-%05d.ts", dir, seg_index)
 	}
 
@@ -228,7 +229,7 @@ func (o *elvxcOutput) Close() error {
 	return err
 }
 
-func (o *elvxcOutput) Stat(streamIndex int, avType avpipe.AVType, statType avpipe.AVStatType, statArgs interface{}) error {
+func (o *elvxcOutput) Stat(streamIndex int, avType goavpipe.AVType, statType avpipe.AVStatType, statArgs interface{}) error {
 	doLog := func(args ...interface{}) {
 		logArgs := []interface{}{"stat", statType.Name(), "avType", avType.Name(), "streamIndex", streamIndex}
 		logArgs = append(logArgs, args...)
@@ -255,7 +256,7 @@ func (o *elvxcOutput) Stat(streamIndex int, avType avpipe.AVType, statType avpip
 	return nil
 }
 
-func getAudioIndexes(params *avpipe.XcParams, audioIndexes string) (err error) {
+func getAudioIndexes(params *goavpipe.XcParams, audioIndexes string) (err error) {
 	if len(audioIndexes) == 0 {
 		return
 	}
@@ -273,8 +274,8 @@ func getAudioIndexes(params *avpipe.XcParams, audioIndexes string) (err error) {
 }
 
 // parseExtractImagesTs converts the extract-images-ts string parameter, e.g.
-// "0,64000,128000,1152000", to an int64 array in avpipe.XcParams
-func parseExtractImagesTs(params *avpipe.XcParams, s string) (err error) {
+// "0,64000,128000,1152000", to an int64 array in goavpipe.XcParams
+func parseExtractImagesTs(params *goavpipe.XcParams, s string) (err error) {
 	if len(s) == 0 {
 		return
 	}
@@ -475,25 +476,25 @@ func doTranscode(cmd *cobra.Command, args []string) error {
 	watermarkShadowColor := cmd.Flag("wm-shadow-color").Value.String()
 	watermarkOverlay := cmd.Flag("wm-overlay").Value.String()
 
-	var watermarkOverlayType avpipe.ImageType
+	var watermarkOverlayType goavpipe.ImageType
 	watermarkOverlayTypeStr := cmd.Flag("wm-overlay-type").Value.String()
 	switch watermarkOverlayTypeStr {
 	case "png":
 		fallthrough
 	case "PNG":
-		watermarkOverlayType = avpipe.PngImage
+		watermarkOverlayType = goavpipe.PngImage
 	case "jpg":
 		fallthrough
 	case "JPG":
-		watermarkOverlayType = avpipe.JpgImage
+		watermarkOverlayType = goavpipe.JpgImage
 	case "gif":
 		fallthrough
 	case "GIF":
-		watermarkOverlayType = avpipe.GifImage
+		watermarkOverlayType = goavpipe.GifImage
 	default:
-		watermarkOverlayType = avpipe.UnknownImage
+		watermarkOverlayType = goavpipe.UnknownImage
 	}
-	if len(watermarkOverlay) > 0 && watermarkOverlayType == avpipe.UnknownImage {
+	if len(watermarkOverlay) > 0 && watermarkOverlayType == goavpipe.UnknownImage {
 		return fmt.Errorf("Watermark overlay type is not valid, can be 'png', 'jpg', 'gif'")
 	}
 
@@ -521,8 +522,8 @@ func doTranscode(cmd *cobra.Command, args []string) error {
 		xcTypeStr != "extract-all-images" {
 		return fmt.Errorf("Transcoding type is not valid, with no stream-id can be 'all', 'video', 'audio', 'audio-join', 'audio-pan', 'audio-merge', or 'extract-images'")
 	}
-	xcType := avpipe.XcTypeFromString(xcTypeStr)
-	if xcType == avpipe.XcAudio && len(encoder) == 0 {
+	xcType := goavpipe.XcTypeFromString(xcTypeStr)
+	if xcType == goavpipe.XcAudio && len(encoder) == 0 {
 		encoder = "aac"
 	}
 
@@ -623,14 +624,14 @@ func doTranscode(cmd *cobra.Command, args []string) error {
 	if err != nil ||
 		(format != "segment" && format != "fmp4-segment" &&
 			audioSegDurationTs == 0 &&
-			(xcType == avpipe.XcAll || xcType == avpipe.XcAudio ||
-				xcType == avpipe.XcAudioJoin || xcType == avpipe.XcAudioMerge)) {
+			(xcType == goavpipe.XcAll || xcType == goavpipe.XcAudio ||
+				xcType == goavpipe.XcAudioJoin || xcType == goavpipe.XcAudioMerge)) {
 		return fmt.Errorf("Audio seg duration ts is not valid")
 	}
 
 	videoSegDurationTs, err := cmd.Flags().GetInt64("video-seg-duration-ts")
 	if err != nil || (format != "segment" && format != "fmp4-segment" && format != "mp4" &&
-		videoSegDurationTs == 0 && (xcType == avpipe.XcAll || xcType == avpipe.XcVideo)) {
+		videoSegDurationTs == 0 && (xcType == goavpipe.XcAll || xcType == goavpipe.XcVideo)) {
 		return fmt.Errorf("Video seg duration ts is not valid")
 	}
 
@@ -664,20 +665,20 @@ func doTranscode(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Invalid copy-mpegts value")
 	}
 
-	cryptScheme := avpipe.CryptNone
+	cryptScheme := goavpipe.CryptNone
 	val := cmd.Flag("crypt-scheme").Value.String()
 	if len(val) > 0 {
 		switch val {
 		case "aes-128":
-			cryptScheme = avpipe.CryptAES128
+			cryptScheme = goavpipe.CryptAES128
 		case "cenc":
-			cryptScheme = avpipe.CryptCENC
+			cryptScheme = goavpipe.CryptCENC
 		case "cbc1":
-			cryptScheme = avpipe.CryptCBC1
+			cryptScheme = goavpipe.CryptCBC1
 		case "cens":
-			cryptScheme = avpipe.CryptCENS
+			cryptScheme = goavpipe.CryptCENS
 		case "cbcs":
-			cryptScheme = avpipe.CryptCBCS
+			cryptScheme = goavpipe.CryptCBCS
 		case "none":
 			break
 		default:
@@ -699,7 +700,7 @@ func doTranscode(cmd *cobra.Command, args []string) error {
 		os.Mkdir(dir, 0755)
 	}
 
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		Url:                    filename,
 		BypassTranscoding:      bypass,
 		Format:                 format,
@@ -783,7 +784,7 @@ func doTranscode(cmd *cobra.Command, args []string) error {
 	done := make(chan interface{})
 
 	for i := 0; i < int(nThreads); i++ {
-		go func(params *avpipe.XcParams, filename string) {
+		go func(params *goavpipe.XcParams, filename string) {
 
 			err := avpipe.Xc(params)
 			if err != nil {

--- a/goavpipe/goavpipe.go
+++ b/goavpipe/goavpipe.go
@@ -1,0 +1,4 @@
+// Package goavpipe contains the parts of the avpipe library that may be used by other go packages
+// without relying on the actual libavpipe that does the transcoding. In particular, packages that
+// process the transcode parameters may rely on this to avoid needing a more complex toolchain.
+package goavpipe

--- a/goavpipe/structs.go
+++ b/goavpipe/structs.go
@@ -1,0 +1,393 @@
+package goavpipe
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// AVType ...
+type AVType int
+
+const (
+	// Unknown 0
+	Unknown AVType = iota
+	// DASHManifest 1
+	DASHManifest
+	// DASHVideoInit 2
+	DASHVideoInit
+	// DASHVideoSegment 3
+	DASHVideoSegment
+	// DASHAudioInit 4
+	DASHAudioInit
+	// DASHAudioSegment 5
+	DASHAudioSegment
+	// HLSMasterM3U 6
+	HLSMasterM3U
+	// HLSVideoM3U 7
+	HLSVideoM3U
+	// HLSAudioM3U 8
+	HLSAudioM3U
+	// AES128Key 9
+	AES128Key
+	// MP4Stream 10
+	MP4Stream
+	// FMP4Stream 11 (Fragmented MP4)
+	FMP4Stream
+	// MP4Segment 12
+	MP4Segment
+	// FMP4VideoSegment 13
+	FMP4VideoSegment
+	// FMP4AudioSegment 14
+	FMP4AudioSegment
+	// MuxSegment 15
+	MuxSegment
+	// FrameImage 16
+	FrameImage
+	// MpegtsSegment 17
+	MpegtsSegment
+)
+
+func (a AVType) Name() string {
+	switch a {
+	case DASHManifest:
+		return "DASHManifest"
+	case DASHVideoInit:
+		return "DASHVideoInit"
+	case DASHVideoSegment:
+		return "DASHVideoSegment"
+	case DASHAudioInit:
+		return "DASHAudioInit"
+	case DASHAudioSegment:
+		return "DASHAudioSegment"
+	case HLSMasterM3U:
+		return "HLSMasterM3U"
+	case HLSVideoM3U:
+		return "HLSVideoM3U"
+	case HLSAudioM3U:
+		return "HLSAudioM3U"
+	case AES128Key:
+		return "AES128Key"
+	case MP4Stream:
+		return "MP4Stream"
+	case FMP4Stream:
+		return "FMP4Stream"
+	case MP4Segment:
+		return "MP4Segment"
+	case FMP4VideoSegment:
+		return "FMP4VideoSegment"
+	case FMP4AudioSegment:
+		return "FMP4AudioSegment"
+	case MuxSegment:
+		return "MuxSegment"
+	case FrameImage:
+		return "FrameImage"
+	case MpegtsSegment:
+		return "MpegtsSegment"
+	default:
+		return fmt.Sprintf("Unknown(%d)", a)
+	}
+}
+
+type AVClass = string
+
+var AVClassE = struct {
+	Mez      AVClass
+	Abr      AVClass
+	Manifest AVClass
+	Mux      AVClass
+	Frame    AVClass
+	Unknown  AVClass
+}{
+	Mez:      "mez",
+	Abr:      "abr",
+	Manifest: "manifest",
+	Mux:      "mux",
+	Frame:    "frame",
+	Unknown:  "unknown",
+}
+
+func (a AVType) AVClass() AVClass {
+	switch a {
+	case FMP4AudioSegment, FMP4VideoSegment, MP4Segment:
+		return AVClassE.Mez
+	case DASHAudioInit, DASHAudioSegment, DASHVideoInit, DASHVideoSegment:
+		return AVClassE.Abr
+	case HLSAudioM3U, HLSMasterM3U, HLSVideoM3U, DASHManifest:
+		return AVClassE.Manifest
+	case FrameImage:
+		return AVClassE.Frame
+	case MuxSegment, MP4Stream, FMP4Stream:
+		return AVClassE.Mux
+	default:
+		return AVClassE.Unknown
+	}
+}
+
+// This is corresponding to AV_NOPTS_VALUE
+const AvNoPtsValue = uint64(0x8000000000000000)
+
+type XcType int
+
+const (
+	XcNone             XcType = iota
+	XcVideo                   = 1
+	XcAudio                   = 2
+	XcAll                     = 3  // XcAudio | XcVideo
+	XcAudioMerge              = 6  // XcAudio | 0x04
+	XcAudioJoin               = 10 // XcAudio | 0x08
+	XcAudioPan                = 18 // XcAudio | 0x10
+	XcMux                     = 32
+	XcExtractImages           = 65  // XcVideo | 2^6
+	XcExtractAllImages        = 129 // XcVideo | 2^7
+	Xcprobe                   = 256
+)
+
+type XcProfile int
+
+const (
+	XcProfileNone         XcProfile = iota
+	XcProfileH264BaseLine           = 66  // C.FF_PROFILE_H264_BASELINE
+	XcProfileH264Heigh              = 100 // C.FF_PROFILE_H264_HIGH
+	XcProfileH264Heigh10            = 110 // C.FF_PROFILE_H264_HIGH_10
+)
+
+func XcTypeFromString(xcTypeStr string) XcType {
+	var xcType XcType
+	switch xcTypeStr {
+	case "all":
+		xcType = XcAll
+	case "video":
+		xcType = XcVideo
+	case "audio":
+		xcType = XcAudio
+	case "audio-join":
+		xcType = XcAudioJoin
+	case "audio-merge":
+		xcType = XcAudioMerge
+	case "audio-pan":
+		xcType = XcAudioPan
+	case "mux":
+		xcType = XcMux
+	case "extract-images":
+		xcType = XcExtractImages
+	case "extract-all-images":
+		xcType = XcExtractAllImages
+	default:
+		xcType = XcNone
+	}
+
+	return xcType
+}
+
+type ImageType int
+
+const (
+	UnknownImage = iota
+	PngImage
+	JpgImage
+	GifImage
+)
+
+// CryptScheme is the content encryption scheme
+type CryptScheme int
+
+const (
+	// CryptNone - clear
+	CryptNone CryptScheme = iota
+	// CryptAES128 - AES-128
+	CryptAES128
+	// CryptCENC - CENC AES-CTR
+	CryptCENC
+	// CryptCBC1 - CENC AES-CBC
+	CryptCBC1
+	// CryptCENS - CENC AES-CTR Pattern
+	CryptCENS
+	// CryptCBCS - CENC AES-CBC Pattern
+	CryptCBCS
+)
+
+// XcParams should match with txparams_t in avpipe_xc.h
+type XcParams struct {
+	Url                    string      `json:"url"`
+	BypassTranscoding      bool        `json:"bypass,omitempty"`
+	Format                 string      `json:"format,omitempty"`
+	StartTimeTs            int64       `json:"start_time_ts,omitempty"`
+	StartPts               int64       `json:"start_pts,omitempty"` // Start PTS for output
+	DurationTs             int64       `json:"duration_ts,omitempty"`
+	StartSegmentStr        string      `json:"start_segment_str,omitempty"`
+	VideoBitrate           int32       `json:"video_bitrate,omitempty"`
+	AudioBitrate           int32       `json:"audio_bitrate,omitempty"`
+	SampleRate             int32       `json:"sample_rate,omitempty"` // Audio sampling rate
+	RcMaxRate              int32       `json:"rc_max_rate,omitempty"`
+	RcBufferSize           int32       `json:"rc_buffer_size,omitempty"`
+	CrfStr                 string      `json:"crf_str,omitempty"`
+	Preset                 string      `json:"preset,omitempty"`
+	AudioSegDurationTs     int64       `json:"audio_seg_duration_ts,omitempty"`
+	VideoSegDurationTs     int64       `json:"video_seg_duration_ts,omitempty"`
+	SegDuration            string      `json:"seg_duration,omitempty"`
+	StartFragmentIndex     int32       `json:"start_fragment_index,omitempty"`
+	ForceKeyInt            int32       `json:"force_keyint,omitempty"`
+	Ecodec                 string      `json:"ecodec,omitempty"`    // Video encoder
+	Ecodec2                string      `json:"ecodec2,omitempty"`   // Audio encoder
+	Dcodec                 string      `json:"dcodec,omitempty"`    // Video decoder
+	Dcodec2                string      `json:"dcodec2,omitempty"`   // Audio decoder
+	GPUIndex               int32       `json:"gpu_index,omitempty"` // GPU index if encoder/decoder is GPU (nvidia)
+	EncHeight              int32       `json:"enc_height,omitempty"`
+	EncWidth               int32       `json:"enc_width,omitempty"`
+	CryptIV                string      `json:"crypt_iv,omitempty"`
+	CryptKey               string      `json:"crypt_key,omitempty"`
+	CryptKID               string      `json:"crypt_kid,omitempty"`
+	CryptKeyURL            string      `json:"crypt_key_url,omitempty"`
+	CryptScheme            CryptScheme `json:"crypt_scheme,omitempty"`
+	XcType                 XcType      `json:"xc_type,omitempty"`
+	CopyMpegts             bool        `json:"copy_mpegts,omitempty"`
+	Seekable               bool        `json:"seekable,omitempty"`
+	WatermarkText          string      `json:"watermark_text,omitempty"`
+	WatermarkTimecode      string      `json:"watermark_timecode,omitempty"`
+	WatermarkTimecodeRate  float32     `json:"watermark_timecode_rate,omitempty"`
+	WatermarkXLoc          string      `json:"watermark_xloc,omitempty"`
+	WatermarkYLoc          string      `json:"watermark_yloc,omitempty"`
+	WatermarkRelativeSize  float32     `json:"watermark_relative_size,omitempty"`
+	WatermarkFontColor     string      `json:"watermark_font_color,omitempty"`
+	WatermarkShadow        bool        `json:"watermark_shadow,omitempty"`
+	WatermarkShadowColor   string      `json:"watermark_shadow_color,omitempty"`
+	WatermarkOverlay       string      `json:"watermark_overlay,omitempty"`      // Buffer containing overlay image
+	WatermarkOverlayLen    int         `json:"watermark_overlay_len,omitempty"`  // Length of overlay image
+	WatermarkOverlayType   ImageType   `json:"watermark_overlay_type,omitempty"` // Type of overlay image (i.e PngImage, ...)
+	StreamId               int32       `json:"stream_id"`                        // Specify stream by ID (instead of index)
+	AudioIndex             []int32     `json:"audio_index"`                      // the length of this is equal to the number of audios
+	ChannelLayout          int         `json:"channel_layout"`                   // Audio channel layout
+	MaxCLL                 string      `json:"max_cll,omitempty"`
+	MasterDisplay          string      `json:"master_display,omitempty"`
+	BitDepth               int32       `json:"bitdepth,omitempty"`
+	SyncAudioToStreamId    int         `json:"sync_audio_to_stream_id"`
+	ForceEqualFDuration    bool        `json:"force_equal_frame_duration,omitempty"`
+	MuxingSpec             string      `json:"muxing_spec,omitempty"`
+	Listen                 bool        `json:"listen"`
+	ConnectionTimeout      int         `json:"connection_timeout"`
+	FilterDescriptor       string      `json:"filter_descriptor"`
+	SkipDecoding           bool        `json:"skip_decoding"`
+	DebugFrameLevel        bool        `json:"debug_frame_level"`
+	ExtractImageIntervalTs int64       `json:"extract_image_interval_ts,omitempty"`
+	ExtractImagesTs        []int64     `json:"extract_images_ts,omitempty"`
+	VideoTimeBase          int         `json:"video_time_base,omitempty"`
+	VideoFrameDurationTs   int         `json:"video_frame_duration_ts,omitempty"`
+	Rotate                 int         `json:"rotate,omitempty"`
+	Profile                string      `json:"profile,omitempty"`
+	Level                  int         `json:"level,omitempty"`
+	Deinterlace            int         `json:"deinterlace,omitempty"`
+}
+
+// NewXcParams initializes a XcParams struct with unset/default values
+func NewXcParams() *XcParams {
+	return &XcParams{
+		AudioBitrate:           128000,
+		AudioSegDurationTs:     -1,
+		BitDepth:               8,
+		CrfStr:                 "23",
+		DurationTs:             -1,
+		Ecodec:                 "libx264",
+		Ecodec2:                "aac",
+		EncHeight:              -1,
+		EncWidth:               -1,
+		ExtractImageIntervalTs: -1,
+		GPUIndex:               -1,
+		SampleRate:             -1,
+		SegDuration:            "30",
+		StartFragmentIndex:     1,
+		StartSegmentStr:        "1",
+		StreamId:               -1,
+		SyncAudioToStreamId:    -1,
+		VideoBitrate:           -1,
+		VideoSegDurationTs:     -1,
+		WatermarkFontColor:     "white",
+		WatermarkOverlayType:   JpgImage,
+		WatermarkRelativeSize:  0.05,
+		WatermarkShadow:        false,
+		WatermarkShadowColor:   "black",
+		WatermarkTimecodeRate:  -1,
+		WatermarkXLoc:          "W*0.05",
+		WatermarkYLoc:          "H*0.9",
+	}
+}
+
+// Custom unmarshalJSON for XcParams to make things backwards compatible with prior serialization
+//
+// Explanations of backwards compatible serializations:
+//  1. NEW: The number of audios is specified by the length of the `AudioIndex` slice.
+//     OLD: The number of audios was specified by a larger `AudioIndex` array and a `n_audio` field specifying the number.
+//     CONVERSION: If a `n_audio` field exists, the `AudioIndex` slice is shortened to be that length.
+func (p *XcParams) UnmarshalJSON(data []byte) error {
+	// The alias does not have the problematic unmarshal JSON that makes embedding XcParams into xcParamsDecoder bad
+	type xcpAlias XcParams
+
+	type xcParamsDecoder struct {
+		xcpAlias
+		NumAudio int32 `json:"n_audio"`
+	}
+
+	var xcpd xcParamsDecoder
+	xcpd.xcpAlias = xcpAlias(*p)
+	if err := json.Unmarshal(data, &xcpd); err != nil {
+		return err
+	}
+
+	*p = XcParams(xcpd.xcpAlias)
+
+	if xcpd.NumAudio != 0 && len(p.AudioIndex) > int(xcpd.NumAudio) {
+		p.AudioIndex = p.AudioIndex[:xcpd.NumAudio]
+	}
+
+	return nil
+}
+
+func (p *XcParams) UnmarshalMap(m map[string]interface{}) error {
+	// Pass through JSON unmarshalling for centralization of unmarshalling
+	b, err := json.Marshal(m)
+	if err != nil {
+		return err
+	}
+	return p.UnmarshalJSON(b)
+}
+
+type AVMediaType int
+
+const (
+	AVMEDIA_TYPE_UNKNOWN    = -1
+	AVMEDIA_TYPE_VIDEO      = 0
+	AVMEDIA_TYPE_AUDIO      = 1
+	AVMEDIA_TYPE_DATA       = 2 ///< Opaque data information usually continuous
+	AVMEDIA_TYPE_SUBTITLE   = 3
+	AVMEDIA_TYPE_ATTACHMENT = 4 ///< Opaque data information usually sparse
+	AVMEDIA_TYPE_NB         = 5
+)
+
+var AVMediaTypeNames = map[AVMediaType]string{
+	AVMEDIA_TYPE_UNKNOWN:    "unknown",
+	AVMEDIA_TYPE_VIDEO:      "video",
+	AVMEDIA_TYPE_AUDIO:      "audio",
+	AVMEDIA_TYPE_DATA:       "data",
+	AVMEDIA_TYPE_SUBTITLE:   "subtitle",
+	AVMEDIA_TYPE_ATTACHMENT: "attachment",
+	AVMEDIA_TYPE_NB:         "nb",
+}
+
+type AVFieldOrder int
+
+const (
+	AV_FIELD_UNKNOWN     = 0
+	AV_FIELD_PROGRESSIVE = 1
+	AV_FIELD_TT          = 2 //< Top coded_first, top displayed first
+	AV_FIELD_BB          = 3 //< Bottom coded first, bottom displayed first
+	AV_FIELD_TB          = 4 //< Top coded first, bottom displayed first
+	AV_FIELD_BT          = 5 //< Bottom coded first, top displayed first
+)
+
+var AVFieldOrderNames = map[AVFieldOrder]string{
+	AV_FIELD_UNKNOWN:     "",
+	AV_FIELD_PROGRESSIVE: "progressive",
+	AV_FIELD_TT:          "tt",
+	AV_FIELD_BB:          "bb",
+	AV_FIELD_TB:          "tb",
+	AV_FIELD_BT:          "bt",
+}

--- a/live/lhr_tool_test.go
+++ b/live/lhr_tool_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/eluv-io/avpipe"
+	"github.com/eluv-io/avpipe/goavpipe"
 	"github.com/eluv-io/errors-go"
 	elog "github.com/eluv-io/log-go"
 	"github.com/stretchr/testify/assert"
@@ -118,7 +119,7 @@ func putReqCtxByFD(fd int64, reqCtx *testCtx) {
 }
 
 func TestHLSVideoOnly(t *testing.T) {
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		Format:          "fmp4-segment",
 		DurationTs:      3 * 2700000,
 		StartSegmentStr: "1",
@@ -128,7 +129,7 @@ func TestHLSVideoOnly(t *testing.T) {
 		Ecodec:          defaultVideoEncoder(),
 		EncHeight:       720,
 		EncWidth:        1280,
-		XcType:          avpipe.XcVideo,
+		XcType:          goavpipe.XcVideo,
 		DebugFrameLevel: debugFrameLevel,
 		StreamId:        -1,
 	}
@@ -141,7 +142,7 @@ func TestHLSVideoOnly(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	readers, err := NewHLSReaders(manifestURL, avpipe.XcVideo) //readers, err := NewHLSReaders(manifestURL, STVideoOnly)
+	readers, err := NewHLSReaders(manifestURL, goavpipe.XcVideo) //readers, err := NewHLSReaders(manifestURL, STVideoOnly)
 	if err != nil {
 		t.Error(err)
 	}
@@ -170,7 +171,7 @@ func TestHLSVideoOnly(t *testing.T) {
 }
 
 func TestHLSAudioOnly(t *testing.T) {
-	params := &avpipe.XcParams{
+	params := &goavpipe.XcParams{
 		Format:          "fmp4-segment",
 		DurationTs:      3 * 2700000,
 		StartSegmentStr: "1",
@@ -178,7 +179,7 @@ func TestHLSAudioOnly(t *testing.T) {
 		SampleRate:      48000,
 		SegDuration:     "30",
 		Ecodec2:         "aac", // "ac3", "aac"
-		XcType:          avpipe.XcAudio,
+		XcType:          goavpipe.XcAudio,
 		DebugFrameLevel: debugFrameLevel,
 		StreamId:        -1,
 	}
@@ -193,7 +194,7 @@ func TestHLSAudioOnly(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	readers, err := NewHLSReaders(manifestURL, avpipe.XcAudio)
+	readers, err := NewHLSReaders(manifestURL, goavpipe.XcAudio)
 	if err != nil {
 		t.Error(err)
 	}
@@ -233,7 +234,7 @@ func TestHLSAudioVideoLive(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	readers, err := NewHLSReaders(manifestURL, avpipe.XcNone)
+	readers, err := NewHLSReaders(manifestURL, goavpipe.XcNone)
 	if err != nil {
 		t.Error(err)
 	}
@@ -246,7 +247,7 @@ func TestHLSAudioVideoLive(t *testing.T) {
 	done := make(chan bool, 2)
 	avpipe.InitIOHandler(&inputOpener{}, &outputOpener{dir: outputDir})
 
-	audioParams := &avpipe.XcParams{
+	audioParams := &goavpipe.XcParams{
 		Format:          "fmp4-segment",
 		DurationTs:      3 * 2700000,
 		StartSegmentStr: "1",
@@ -254,7 +255,7 @@ func TestHLSAudioVideoLive(t *testing.T) {
 		SampleRate:      48000,
 		SegDuration:     "30",
 		Ecodec2:         "aac",
-		XcType:          avpipe.XcAudio,
+		XcType:          goavpipe.XcAudio,
 		DebugFrameLevel: debugFrameLevel,
 		StreamId:        -1,
 	}
@@ -275,7 +276,7 @@ func TestHLSAudioVideoLive(t *testing.T) {
 		done <- true
 	}(audioReader)
 
-	videoParams := &avpipe.XcParams{
+	videoParams := &goavpipe.XcParams{
 		Format:          "fmp4-segment",
 		DurationTs:      3 * 2700000,
 		StartSegmentStr: "1",
@@ -285,7 +286,7 @@ func TestHLSAudioVideoLive(t *testing.T) {
 		Ecodec:          defaultVideoEncoder(),
 		EncHeight:       720,
 		EncWidth:        1280,
-		XcType:          avpipe.XcVideo,
+		XcType:          goavpipe.XcVideo,
 		Url:             "video_mez_hls",
 		DebugFrameLevel: debugFrameLevel,
 		StreamId:        -1,
@@ -495,7 +496,7 @@ func (i *inputCtx) Stat(streamIndex int, statType avpipe.AVStatType, statArgs in
 }
 
 func (oo *outputOpener) Open(h, fd int64, streamIndex, segIndex int, _ int64,
-	outType avpipe.AVType) (avpipe.OutputHandler, error) {
+	outType goavpipe.AVType) (avpipe.OutputHandler, error) {
 
 	tc, err := getReqCtxByFD(h)
 	if err != nil {
@@ -510,29 +511,29 @@ func (oo *outputOpener) Open(h, fd int64, streamIndex, segIndex int, _ int64,
 	var filename string
 
 	switch outType {
-	case avpipe.DASHVideoInit:
+	case goavpipe.DASHVideoInit:
 		fallthrough
-	case avpipe.DASHAudioInit:
+	case goavpipe.DASHAudioInit:
 		filename = fmt.Sprintf("./%s/video-init-stream%d.mp4", oo.dir, streamIndex)
-	case avpipe.DASHManifest:
+	case goavpipe.DASHManifest:
 		filename = fmt.Sprintf("./%s/dash.mpd", oo.dir)
-	case avpipe.DASHVideoSegment:
+	case goavpipe.DASHVideoSegment:
 		filename = fmt.Sprintf("./%s/video-chunk-stream%d-%05d.mp4", oo.dir, streamIndex, segIndex)
-	case avpipe.DASHAudioSegment:
+	case goavpipe.DASHAudioSegment:
 		filename = fmt.Sprintf("./%s/audio-chunk-stream%d-%05d.mp4", oo.dir, streamIndex, segIndex)
-	case avpipe.HLSMasterM3U:
+	case goavpipe.HLSMasterM3U:
 		filename = fmt.Sprintf("./%s/master.m3u8", oo.dir)
-	case avpipe.HLSVideoM3U:
+	case goavpipe.HLSVideoM3U:
 		filename = fmt.Sprintf("./%s/video-media_%d.m3u8", oo.dir, streamIndex)
-	case avpipe.HLSAudioM3U:
+	case goavpipe.HLSAudioM3U:
 		filename = fmt.Sprintf("./%s/audio-media_%d.m3u8", oo.dir, streamIndex)
-	case avpipe.AES128Key:
+	case goavpipe.AES128Key:
 		filename = fmt.Sprintf("./%s/%s-key.bin", oo.dir, url)
-	case avpipe.MP4Segment:
+	case goavpipe.MP4Segment:
 		filename = fmt.Sprintf("./%s/segment-%d.mp4", oo.dir, segIndex)
-	case avpipe.FMP4AudioSegment:
+	case goavpipe.FMP4AudioSegment:
 		filename = fmt.Sprintf("./%s/audio-mez-segment%d-%d.mp4", oo.dir, streamIndex, segIndex)
-	case avpipe.FMP4VideoSegment:
+	case goavpipe.FMP4VideoSegment:
 		filename = fmt.Sprintf("./%s/video-mez-segment-%d.mp4", oo.dir, segIndex)
 	}
 
@@ -582,7 +583,7 @@ func (o *outputCtx) Close() error {
 	return nil
 }
 
-func (o *outputCtx) Stat(streamIndex int, avType avpipe.AVType, statType avpipe.AVStatType, statArgs interface{}) error {
+func (o *outputCtx) Stat(streamIndex int, avType goavpipe.AVType, statType avpipe.AVStatType, statArgs interface{}) error {
 	doLog := func(args ...interface{}) {
 		if debugFrameLevel {
 			logArgs := []interface{}{"stat", statType.Name(), "avType", avType.Name(), "streamIndex", streamIndex}

--- a/live/live_probe_test.go
+++ b/live/live_probe_test.go
@@ -2,10 +2,12 @@ package live
 
 import (
 	"fmt"
-	"github.com/eluv-io/avpipe"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/eluv-io/avpipe"
+	"github.com/eluv-io/avpipe/goavpipe"
+	"github.com/stretchr/testify/assert"
 )
 
 // 1) Starts ffmpeg for streaming RTMP in listen mode
@@ -24,9 +26,9 @@ func TestProbeRTMPConnect(t *testing.T) {
 
 	time.Sleep(2 * time.Second)
 
-	XCParams := &avpipe.XcParams{
+	XCParams := &goavpipe.XcParams{
 		Seekable:        false,
-		XcType:          avpipe.Xcprobe,
+		XcType:          goavpipe.Xcprobe,
 		StreamId:        -1,
 		Url:             url,
 		DebugFrameLevel: debugFrameLevel,
@@ -64,9 +66,9 @@ func TestProbeRTMPListen(t *testing.T) {
 	liveSource := NewLiveSource()
 	url := fmt.Sprintf("rtmp://localhost:%d/rtmp/Doj1Nr3S", liveSource.Port)
 
-	XCParams := &avpipe.XcParams{
+	XCParams := &goavpipe.XcParams{
 		Seekable:          false,
-		XcType:            avpipe.Xcprobe,
+		XcType:            goavpipe.Xcprobe,
 		StreamId:          -1,
 		Url:               url,
 		DebugFrameLevel:   debugFrameLevel,
@@ -117,9 +119,9 @@ func TestProbeRTMPNoStream(t *testing.T) {
 	liveSource := NewLiveSource()
 	url := fmt.Sprintf("rtmp://localhost:%d/rtmp/Doj1Nr3S", liveSource.Port)
 
-	XCParams := &avpipe.XcParams{
+	XCParams := &goavpipe.XcParams{
 		Seekable:          false,
-		XcType:            avpipe.Xcprobe,
+		XcType:            goavpipe.Xcprobe,
 		StreamId:          -1,
 		Url:               url,
 		DebugFrameLevel:   debugFrameLevel,
@@ -154,9 +156,9 @@ func TestProbeUDPConnect(t *testing.T) {
 
 	time.Sleep(2 * time.Second)
 
-	XCParams := &avpipe.XcParams{
+	XCParams := &goavpipe.XcParams{
 		Seekable:          false,
-		XcType:            avpipe.Xcprobe,
+		XcType:            goavpipe.Xcprobe,
 		StreamId:          -1,
 		Url:               url,
 		DebugFrameLevel:   debugFrameLevel,
@@ -196,9 +198,9 @@ func TestProbeUDPListen(t *testing.T) {
 	liveSource := NewLiveSource()
 	url := fmt.Sprintf("udp://localhost:%d", liveSource.Port)
 
-	XCParams := &avpipe.XcParams{
+	XCParams := &goavpipe.XcParams{
 		Seekable:        false,
-		XcType:          avpipe.Xcprobe,
+		XcType:          goavpipe.Xcprobe,
 		StreamId:        -1,
 		Url:             url,
 		DebugFrameLevel: debugFrameLevel,
@@ -248,9 +250,9 @@ func TestProbeUDPNoStream(t *testing.T) {
 	liveSource := NewLiveSource()
 	url := fmt.Sprintf("udp://localhost:%d", liveSource.Port)
 
-	XCParams := &avpipe.XcParams{
+	XCParams := &goavpipe.XcParams{
 		Seekable:          false,
-		XcType:            avpipe.Xcprobe,
+		XcType:            goavpipe.Xcprobe,
 		StreamId:          -1,
 		Url:               url,
 		DebugFrameLevel:   debugFrameLevel,

--- a/live/rtmp_recorder_test.go
+++ b/live/rtmp_recorder_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/eluv-io/avpipe"
+	"github.com/eluv-io/avpipe/goavpipe"
 )
 
 func TestRtmpToMp4_1(t *testing.T) {
@@ -22,7 +23,7 @@ func TestRtmpToMp4_1(t *testing.T) {
 	done := make(chan bool, 1)
 	testComplete := make(chan bool, 1)
 
-	xcParams := &avpipe.XcParams{
+	xcParams := &goavpipe.XcParams{
 		Format:              "fmp4-segment",
 		Seekable:            false,
 		DurationTs:          -1,
@@ -36,7 +37,7 @@ func TestRtmpToMp4_1(t *testing.T) {
 		Ecodec:              "libx264", // libx264 software / h264_videotoolbox mac hardware
 		EncHeight:           720,       // 1080
 		EncWidth:            1280,      // 1920
-		XcType:              avpipe.XcAll,
+		XcType:              goavpipe.XcAll,
 		StreamId:            -1,
 		Url:                 url,
 		SyncAudioToStreamId: -1,
@@ -76,7 +77,7 @@ func TestRtmpToMp4_1(t *testing.T) {
 	xcParams.Dcodec2 = "aac"
 	xcParams.AudioIndex = nil
 	xcParams.AudioSegDurationTs = 96000 // almost 2 * 48000
-	xcParams.XcType = avpipe.XcAudio
+	xcParams.XcType = goavpipe.XcAudio
 	audioMezFiles := [2]string{"audio-mez-segment0-1.mp4", "audio-mez-segment0-2.mp4"}
 
 	// Now create audio dash segments out of audio mezzanines
@@ -102,7 +103,7 @@ func TestRtmpToMp4_1(t *testing.T) {
 
 	xcParams.Format = "dash"
 	xcParams.VideoSegDurationTs = 32000 // almost 2 * 16000
-	xcParams.XcType = avpipe.XcVideo
+	xcParams.XcType = goavpipe.XcVideo
 	videoMezFiles := [2]string{"video-mez-segment-1.mp4", "video-mez-segment-2.mp4"}
 
 	// Now create video dash segments out of audio mezzanines
@@ -142,7 +143,7 @@ func TestRtmpToMp4WithCancelling0(t *testing.T) {
 	liveSource := NewLiveSource()
 	url := fmt.Sprintf(RTMP_SOURCE, liveSource.Port)
 
-	xcParams := &avpipe.XcParams{
+	xcParams := &goavpipe.XcParams{
 		Format:              "fmp4-segment",
 		Seekable:            false,
 		DurationTs:          -1,
@@ -156,7 +157,7 @@ func TestRtmpToMp4WithCancelling0(t *testing.T) {
 		Ecodec:              "libx264", // libx264 software / h264_videotoolbox mac hardware
 		EncHeight:           720,       // 1080
 		EncWidth:            1280,      // 1920
-		XcType:              avpipe.XcAll,
+		XcType:              goavpipe.XcAll,
 		StreamId:            -1,
 		Url:                 url,
 		SyncAudioToStreamId: -1,
@@ -212,7 +213,7 @@ func TestRtmpToMp4WithCancelling1(t *testing.T) {
 	liveSource := NewLiveSource()
 	url := fmt.Sprintf(RTMP_SOURCE, liveSource.Port)
 
-	xcParams := &avpipe.XcParams{
+	xcParams := &goavpipe.XcParams{
 		Format:              "fmp4-segment",
 		Seekable:            false,
 		DurationTs:          -1,
@@ -226,7 +227,7 @@ func TestRtmpToMp4WithCancelling1(t *testing.T) {
 		Ecodec:              "libx264", // libx264 software / h264_videotoolbox mac hardware
 		EncHeight:           720,       // 1080
 		EncWidth:            1280,      // 1920
-		XcType:              avpipe.XcAll,
+		XcType:              goavpipe.XcAll,
 		StreamId:            -1,
 		Url:                 url,
 		SyncAudioToStreamId: -1,
@@ -282,7 +283,7 @@ func TestRtmpToMp4WithCancelling2(t *testing.T) {
 	url := fmt.Sprintf(RTMP_SOURCE, liveSource.Port)
 	done := make(chan bool, 1)
 
-	xcParams := &avpipe.XcParams{
+	xcParams := &goavpipe.XcParams{
 		Format:              "fmp4-segment",
 		Seekable:            false,
 		DurationTs:          -1,
@@ -296,7 +297,7 @@ func TestRtmpToMp4WithCancelling2(t *testing.T) {
 		Ecodec:              "libx264", // libx264 software / h264_videotoolbox mac hardware
 		EncHeight:           720,       // 1080
 		EncWidth:            1280,      // 1920
-		XcType:              avpipe.XcAll,
+		XcType:              goavpipe.XcAll,
 		StreamId:            -1,
 		Url:                 url,
 		SyncAudioToStreamId: -1,
@@ -362,7 +363,7 @@ func TestRtmpToMp4WithCancelling3(t *testing.T) {
 	url := fmt.Sprintf(RTMP_SOURCE, liveSource.Port)
 	done := make(chan bool, 1)
 
-	xcParams := &avpipe.XcParams{
+	xcParams := &goavpipe.XcParams{
 		Format:              "fmp4-segment",
 		Seekable:            false,
 		DurationTs:          -1,
@@ -376,7 +377,7 @@ func TestRtmpToMp4WithCancelling3(t *testing.T) {
 		Ecodec:              "libx264", // libx264 software / h264_videotoolbox mac hardware
 		EncHeight:           720,       // 1080
 		EncWidth:            1280,      // 1920
-		XcType:              avpipe.XcAll,
+		XcType:              goavpipe.XcAll,
 		StreamId:            -1,
 		Url:                 url,
 		SyncAudioToStreamId: -1,
@@ -445,7 +446,7 @@ func TestRtmpToMp4WithCancelling4(t *testing.T) {
 	url := fmt.Sprintf(RTMP_SOURCE, liveSource.Port)
 	done := make(chan bool, 1)
 
-	xcParams := &avpipe.XcParams{
+	xcParams := &goavpipe.XcParams{
 		Format:              "fmp4-segment",
 		Seekable:            false,
 		DurationTs:          -1,
@@ -459,7 +460,7 @@ func TestRtmpToMp4WithCancelling4(t *testing.T) {
 		Ecodec:              "libx264", // libx264 software / h264_videotoolbox mac hardware
 		EncHeight:           720,       // 1080
 		EncWidth:            1280,      // 1920
-		XcType:              avpipe.XcAll,
+		XcType:              goavpipe.XcAll,
 		StreamId:            -1,
 		Url:                 url,
 		SyncAudioToStreamId: -1,

--- a/live/srt_recorder_test.go
+++ b/live/srt_recorder_test.go
@@ -2,12 +2,14 @@ package live
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"path"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/eluv-io/avpipe"
+	"github.com/eluv-io/avpipe/goavpipe"
 )
 
 func TestSrtToMp4(t *testing.T) {
@@ -21,7 +23,7 @@ func TestSrtToMp4(t *testing.T) {
 	done := make(chan bool, 1)
 	testComplete := make(chan bool, 1)
 
-	xcParams := &avpipe.XcParams{
+	xcParams := &goavpipe.XcParams{
 		Format:              "fmp4-segment",
 		Seekable:            false,
 		DurationTs:          -1,
@@ -35,7 +37,7 @@ func TestSrtToMp4(t *testing.T) {
 		Ecodec:              "libx264", // libx264 software / h264_videotoolbox mac hardware
 		EncHeight:           720,       // 1080
 		EncWidth:            1280,      // 1920
-		XcType:              avpipe.XcAll,
+		XcType:              goavpipe.XcAll,
 		StreamId:            -1,
 		Url:                 url,
 		SyncAudioToStreamId: -1,
@@ -69,7 +71,7 @@ func TestSrtToMp4(t *testing.T) {
 	xcParams.Format = "dash"
 	xcParams.Dcodec2 = "aac"
 	xcParams.AudioSegDurationTs = 96000 // almost 2 * 48000
-	xcParams.XcType = avpipe.XcAudio
+	xcParams.XcType = goavpipe.XcAudio
 	audioMezFiles := [2]string{"audio-mez-segment0-1.mp4", "audio-mez-segment0-2.mp4"}
 
 	// Now create audio dash segments out of audio mezzanines
@@ -95,7 +97,7 @@ func TestSrtToMp4(t *testing.T) {
 
 	xcParams.Format = "dash"
 	xcParams.VideoSegDurationTs = 180000 // almost 2 * 90000
-	xcParams.XcType = avpipe.XcVideo
+	xcParams.XcType = goavpipe.XcVideo
 	videoMezFiles := [2]string{"video-mez-segment-1.mp4", "video-mez-segment-2.mp4"}
 
 	// Now create video dash segments out of audio mezzanines
@@ -135,7 +137,7 @@ func TestSrtToMp4WithCancelling0(t *testing.T) {
 	liveSource := NewLiveSource()
 	url := fmt.Sprintf("srt://localhost:%d?mode=listener&recv_buffer_size=256000&ffs=256000", liveSource.Port)
 
-	xcParams := &avpipe.XcParams{
+	xcParams := &goavpipe.XcParams{
 		Format:              "fmp4-segment",
 		Seekable:            false,
 		DurationTs:          -1,
@@ -149,7 +151,7 @@ func TestSrtToMp4WithCancelling0(t *testing.T) {
 		Ecodec:              "libx264", // libx264 software / h264_videotoolbox mac hardware
 		EncHeight:           720,       // 1080
 		EncWidth:            1280,      // 1920
-		XcType:              avpipe.XcAll,
+		XcType:              goavpipe.XcAll,
 		StreamId:            -1,
 		Url:                 url,
 		SyncAudioToStreamId: -1,
@@ -198,7 +200,7 @@ func TestSrtToMp4WithCancelling1(t *testing.T) {
 	liveSource := NewLiveSource()
 	url := fmt.Sprintf("srt://localhost:%d?mode=listener&recv_buffer_size=256000&ffs=256000", liveSource.Port)
 
-	xcParams := &avpipe.XcParams{
+	xcParams := &goavpipe.XcParams{
 		Format:              "fmp4-segment",
 		Seekable:            false,
 		DurationTs:          -1,
@@ -212,7 +214,7 @@ func TestSrtToMp4WithCancelling1(t *testing.T) {
 		Ecodec:              "libx264", // libx264 software / h264_videotoolbox mac hardware
 		EncHeight:           720,       // 1080
 		EncWidth:            1280,      // 1920
-		XcType:              avpipe.XcAll,
+		XcType:              goavpipe.XcAll,
 		StreamId:            -1,
 		Url:                 url,
 		SyncAudioToStreamId: -1,
@@ -266,7 +268,7 @@ func TestSrtToMp4WithCancelling2(t *testing.T) {
 	url := fmt.Sprintf("srt://localhost:%d?mode=listener&recv_buffer_size=256000&ffs=256000", liveSource.Port)
 	done := make(chan bool, 1)
 
-	xcParams := &avpipe.XcParams{
+	xcParams := &goavpipe.XcParams{
 		Format:              "fmp4-segment",
 		Seekable:            false,
 		DurationTs:          -1,
@@ -280,7 +282,7 @@ func TestSrtToMp4WithCancelling2(t *testing.T) {
 		Ecodec:              "libx264", // libx264 software / h264_videotoolbox mac hardware
 		EncHeight:           720,       // 1080
 		EncWidth:            1280,      // 1920
-		XcType:              avpipe.XcAll,
+		XcType:              goavpipe.XcAll,
 		StreamId:            -1,
 		Url:                 url,
 		SyncAudioToStreamId: -1,
@@ -340,7 +342,7 @@ func TestSrtToMp4WithCancelling3(t *testing.T) {
 	url := fmt.Sprintf("srt://localhost:%d?mode=listener&recv_buffer_size=256000&ffs=256000", liveSource.Port)
 	done := make(chan bool, 1)
 
-	xcParams := &avpipe.XcParams{
+	xcParams := &goavpipe.XcParams{
 		Format:              "fmp4-segment",
 		Seekable:            false,
 		DurationTs:          -1,
@@ -354,7 +356,7 @@ func TestSrtToMp4WithCancelling3(t *testing.T) {
 		Ecodec:              "libx264", // libx264 software / h264_videotoolbox mac hardware
 		EncHeight:           720,       // 1080
 		EncWidth:            1280,      // 1920
-		XcType:              avpipe.XcAll,
+		XcType:              goavpipe.XcAll,
 		StreamId:            -1,
 		Url:                 url,
 		SyncAudioToStreamId: -1,
@@ -422,7 +424,7 @@ func TestSrtToMp4WithCancelling4(t *testing.T) {
 	url := fmt.Sprintf("srt://localhost:%d?mode=listener&recv_buffer_size=256000&ffs=256000", liveSource.Port)
 	done := make(chan bool, 1)
 
-	xcParams := &avpipe.XcParams{
+	xcParams := &goavpipe.XcParams{
 		Format:              "fmp4-segment",
 		Seekable:            false,
 		DurationTs:          -1,
@@ -436,7 +438,7 @@ func TestSrtToMp4WithCancelling4(t *testing.T) {
 		Ecodec:              "libx264", // libx264 software / h264_videotoolbox mac hardware
 		EncHeight:           720,       // 1080
 		EncWidth:            1280,      // 1920
-		XcType:              avpipe.XcAll,
+		XcType:              goavpipe.XcAll,
 		StreamId:            -1,
 		Url:                 url,
 		SyncAudioToStreamId: -1,

--- a/live/ts_recorder_test.go
+++ b/live/ts_recorder_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/eluv-io/avpipe"
+	"github.com/eluv-io/avpipe/goavpipe"
 )
 
 func TestUdpToMp4(t *testing.T) {
@@ -27,7 +28,7 @@ func TestUdpToMp4(t *testing.T) {
 		t.Error(err)
 	}
 
-	xcParams := &avpipe.XcParams{
+	xcParams := &goavpipe.XcParams{
 		Format:              "fmp4-segment",
 		Seekable:            false,
 		DurationTs:          -1,
@@ -41,7 +42,7 @@ func TestUdpToMp4(t *testing.T) {
 		Ecodec:              "libx264", // libx264 software / h264_videotoolbox mac hardware
 		EncHeight:           720,       // 1080
 		EncWidth:            1280,      // 1920
-		XcType:              avpipe.XcAll,
+		XcType:              goavpipe.XcAll,
 		StreamId:            -1,
 		Url:                 url,
 		SyncAudioToStreamId: -1,
@@ -64,7 +65,7 @@ func TestUdpToMp4(t *testing.T) {
 	xcParams.Format = "dash"
 	xcParams.Dcodec2 = "aac"
 	xcParams.AudioSegDurationTs = 96106 // almost 2 * 48000
-	xcParams.XcType = avpipe.XcAudio
+	xcParams.XcType = goavpipe.XcAudio
 	audioMezFiles := [3]string{"audio-mez-segment0-1.mp4", "audio-mez-segment0-2.mp4", "audio-mez-segment0-3.mp4"}
 
 	// Now create audio dash segments out of audio mezzanines
@@ -90,7 +91,7 @@ func TestUdpToMp4(t *testing.T) {
 
 	xcParams.Format = "dash"
 	xcParams.VideoSegDurationTs = 180000 // almost 2 * 90000
-	xcParams.XcType = avpipe.XcVideo
+	xcParams.XcType = goavpipe.XcVideo
 	videoMezFiles := [3]string{"video-mez-segment-1.mp4", "video-mez-segment-2.mp4", "video-mez-segment-3.mp4"}
 
 	// Now create video dash segments out of audio mezzanines
@@ -130,7 +131,7 @@ func TestMultiAudioUdpToMp4(t *testing.T) {
 		t.Error(err)
 	}
 
-	xcParams := &avpipe.XcParams{
+	xcParams := &goavpipe.XcParams{
 		Format:              "fmp4-segment",
 		Seekable:            false,
 		DurationTs:          -1,
@@ -144,7 +145,7 @@ func TestMultiAudioUdpToMp4(t *testing.T) {
 		Ecodec:              "libx264", // libx264 software / h264_videotoolbox mac hardware
 		EncHeight:           720,       // 1080
 		EncWidth:            1280,      // 1920
-		XcType:              avpipe.XcAll,
+		XcType:              goavpipe.XcAll,
 		StreamId:            -1,
 		Url:                 url,
 		SyncAudioToStreamId: -1,
@@ -172,7 +173,7 @@ func TestMultiAudioUdpToMp4(t *testing.T) {
 	xcParams.Format = "dash"
 	xcParams.Dcodec2 = "aac"
 	xcParams.AudioSegDurationTs = 96106 // almost 2 * 48000
-	xcParams.XcType = avpipe.XcAudio
+	xcParams.XcType = goavpipe.XcAudio
 	audioMezFiles := [3]string{"audio-mez-segment1-1.mp4", "audio-mez-segment1-2.mp4", "audio-mez-segment1-3.mp4"}
 
 	// Now create audio dash segments out of audio mezzanines
@@ -213,7 +214,7 @@ func TestUdpToMp4WithCancelling1(t *testing.T) {
 		t.Error(err)
 	}
 
-	xcParams := &avpipe.XcParams{
+	xcParams := &goavpipe.XcParams{
 		Format:              "fmp4-segment",
 		Seekable:            false,
 		DurationTs:          -1,
@@ -227,7 +228,7 @@ func TestUdpToMp4WithCancelling1(t *testing.T) {
 		Ecodec:              "libx264", // libx264 software / h264_videotoolbox mac hardware
 		EncHeight:           720,       // 1080
 		EncWidth:            1280,      // 1920
-		XcType:              avpipe.XcAll,
+		XcType:              goavpipe.XcAll,
 		StreamId:            -1,
 		Url:                 url,
 		SyncAudioToStreamId: -1,
@@ -272,7 +273,7 @@ func TestUdpToMp4WithCancelling2(t *testing.T) {
 		t.Error(err)
 	}
 
-	xcParams := &avpipe.XcParams{
+	xcParams := &goavpipe.XcParams{
 		Format:              "fmp4-segment",
 		Seekable:            false,
 		DurationTs:          -1,
@@ -286,7 +287,7 @@ func TestUdpToMp4WithCancelling2(t *testing.T) {
 		Ecodec:              "libx264", // libx264 software / h264_videotoolbox mac hardware
 		EncHeight:           720,       // 1080
 		EncWidth:            1280,      // 1920
-		XcType:              avpipe.XcAll,
+		XcType:              goavpipe.XcAll,
 		StreamId:            -1,
 		Url:                 url,
 		SyncAudioToStreamId: -1,
@@ -344,7 +345,7 @@ func TestUdpToMp4WithCancelling3(t *testing.T) {
 		t.Error(err)
 	}
 
-	xcParams := &avpipe.XcParams{
+	xcParams := &goavpipe.XcParams{
 		Format:              "fmp4-segment",
 		Seekable:            false,
 		DurationTs:          -1,
@@ -358,7 +359,7 @@ func TestUdpToMp4WithCancelling3(t *testing.T) {
 		Ecodec:              "libx264", // libx264 software / h264_videotoolbox mac hardware
 		EncHeight:           720,       // 1080
 		EncWidth:            1280,      // 1920
-		XcType:              avpipe.XcAll,
+		XcType:              goavpipe.XcAll,
 		StreamId:            -1,
 		Url:                 url,
 		SyncAudioToStreamId: -1,
@@ -416,7 +417,7 @@ func TestUdpToMp4WithCancelling4(t *testing.T) {
 		t.Error(err)
 	}
 
-	xcParams := &avpipe.XcParams{
+	xcParams := &goavpipe.XcParams{
 		Format:              "fmp4-segment",
 		Seekable:            false,
 		DurationTs:          -1,
@@ -430,7 +431,7 @@ func TestUdpToMp4WithCancelling4(t *testing.T) {
 		Ecodec:              "libx264", // libx264 software / h264_videotoolbox mac hardware
 		EncHeight:           720,       // 1080
 		EncWidth:            1280,      // 1920
-		XcType:              avpipe.XcAll,
+		XcType:              goavpipe.XcAll,
 		StreamId:            -1,
 		Url:                 url,
 		SyncAudioToStreamId: -1,


### PR DESCRIPTION
This PR moves some structs from the main `avpipe` package into a smaller package called `goavpipe`, which allows `legacy_imf_dash_extract` to depend on it without needing a C toolchain.

I will make an associated PR in content-fabric to update dependencies as well.