### PR TITLE
Set opaque null after free in exc

### DIFF
--- a/exc/elv_xc.c
+++ b/exc/elv_xc.c
@@ -193,6 +193,7 @@ in_closer(
     int fd = *((int *)(inctx->opaque));
     elv_dbg("IN io_close custom writer fd=%d\n", fd);
     free(inctx->opaque);
+    inctx->opaque = NULL;
     close(fd);
     return 0;
 }


### PR DESCRIPTION
Fixes crash in avpipe exc.

We should make ownership semantics a bit more explicit.