### PR TITLE
Fix opus audio codec

### DIFF
--- a/libavpipe/src/avpipe_format.c
+++ b/libavpipe/src/avpipe_format.c
@@ -214,7 +214,7 @@ packet_clone(
 
 /*
  * Update an audio frame by skipping the necessary number of samples.
- * Return the remaining samples in the frame (which may be 0 if the frame is to be skipped entirely)
+ * Update frame nb_samples to the remaining samples in the frame (which may be 0 if the frame is to be skipped entirely)
  * Many audio decoders use the concept of 'priming' and require skipping of a number of samples.
  * Opus specifically sets codec_context->delay to the number of samples to be skipped.
  * In most cases the audio frames to be skipped might have a negative PTS but that is not a rule/standard.
@@ -229,19 +229,19 @@ audio_skip_samples(
 
     // Only skipping for Opus inputs currently
     if (codec_ctx->codec_id != AV_CODEC_ID_OPUS) {
-        return frame->nb_samples;
+        return eav_success;
     }
 
     int samples_to_skip = codec_ctx->delay; // Defined by the Opus format
     if (samples_to_skip <= 0) {
-        return frame->nb_samples;
+        return eav_success;
     }
 
     if (samples_to_skip > frame->nb_samples) {
         // Unexpected - we need to skip more than one frame
         elv_warn("Unexpected audio stream delay nb_frames=%d skip_now=%d", frame->nb_samples, samples_to_skip);
         frame->nb_samples = 0;
-        return 0; // Entire frame needs to be skipped
+        return eav_success;
     }
 
     int sample_size = av_get_bytes_per_sample(codec_ctx->sample_fmt);
@@ -260,5 +260,5 @@ audio_skip_samples(
     }
 
     frame->nb_samples -= samples_to_skip;
-    return frame->nb_samples;
+    return eav_success;
 }

--- a/libavpipe/src/avpipe_format.c
+++ b/libavpipe/src/avpipe_format.c
@@ -212,3 +212,53 @@ packet_clone(
     return 0;
 }
 
+/*
+ * Update an audio frame by skipping the necessary number of samples.
+ * Return the remaining samples in the frame (which may be 0 if the frame is to be skipped entirely)
+ * Many audio decoders use the concept of 'priming' and require skipping of a number of samples.
+ * Opus specifically sets codec_context->delay to the number of samples to be skipped.
+ * In most cases the audio frames to be skipped might have a negative PTS but that is not a rule/standard.
+ * Limitation: we expect we only skip samples in the first frame (log warning if not true)
+ *
+ * PENDING(SS) Currently unused but will be used in encode_frame()
+ */
+int
+audio_skip_samples(
+    AVCodecContext *codec_ctx,
+    AVFrame *frame) {
+
+    // Only skipping for Opus inputs currently
+    if (codec_ctx->codec_id != AV_CODEC_ID_OPUS) {
+        return frame->nb_samples;
+    }
+
+    int samples_to_skip = codec_ctx->delay; // Defined by the Opus format
+    if (samples_to_skip <= 0) {
+        return frame->nb_samples;
+    }
+
+    if (samples_to_skip > frame->nb_samples) {
+        // Unexpected - we need to skip more than one frame
+        elv_warn("Unexpected audio stream delay nb_frames=%d skip_now=%d", frame->nb_samples, samples_to_skip);
+        frame->nb_samples = 0;
+        return 0; // Entire frame needs to be skipped
+    }
+
+    int sample_size = av_get_bytes_per_sample(codec_ctx->sample_fmt);
+    if (sample_size <= 0) {
+        // Unknown sample format - this frame is not good
+        return eav_receive_frame;
+    }
+
+    // Skip samples in either packed (one channel, interleaved) or planar data (multiple channels)
+    int channels = codec_ctx->channels;
+    int skip_bytes = samples_to_skip * sample_size;
+    for (int ch = 0; ch < channels; ch++) {
+        if (frame->data[ch]) {
+            frame->data[ch] += skip_bytes;
+        }
+    }
+
+    frame->nb_samples -= samples_to_skip;
+    return frame->nb_samples;
+}

--- a/libavpipe/src/avpipe_utils.c
+++ b/libavpipe/src/avpipe_utils.c
@@ -93,13 +93,13 @@ dump_decoder(
         elv_dbg("DECODER[%d]: ff_log -- %s", i, ctx_str);
         av_free(ctx_str);
 
-        elv_dbg("DECODER[%d] url=%s codec_type=%d profile=%d level=%d start_time=%d duration=%d nb_frames=%d"
+        elv_dbg("DECODER[%d] url=%s codec_type=%d profile=%d level=%d start_time=%d duration=%d nb_frames=%d delay=%d"
             " time_base=%d/%d frame_rate=%d/%d avg_frame_rate=%d/%d, sample_aspect_ratio=%d/%d"
             " bit_rate=%d width=%d height=%d pix_fmt=%s channels=%d channel_layout=%s\n",
             i, url ? url : "",
             s->codecpar->codec_type, codec_context->profile, codec_context->level,
             (int)s->start_time, (int)s->duration,
-            (int)s->nb_frames,
+            (int)s->nb_frames, codec_context->delay,
             s->time_base.num, s->time_base.den,
             s->r_frame_rate.num, s->r_frame_rate.den,
             s->avg_frame_rate.num, s->avg_frame_rate.den,

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -2183,6 +2183,10 @@ encode_frame(
          * and after rescaling it becomes pretty big number which causes audio sync problem.
          * The only solution that I could come up for this was skipping this frame. (-RM)
          */
+        /*
+         * PENDING(SS): must discard the samples that the codec requires be skipped using audio_skip_samples()
+         * and forward this frame to the muxer (don't skip here - the negative PTS will work correctly),
+         */
         if (selected_decoded_audio(decoder_context, stream_index) >= 0 && output_packet->pts < 0) {
             elv_log("Skipping encoded packet with negative pts %"PRId64, output_packet->pts);
             goto end_encode_frame;

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -2046,7 +2046,7 @@ encode_frame(
     int debug_frame_level)
 {
     int ret;
-    int index = stream_index; 
+    int index = stream_index;
     int rc = eav_success;
     AVFormatContext *format_context = encoder_context->format_context;
     AVCodecContext *codec_context = encoder_context->codec_context[stream_index];
@@ -2179,7 +2179,7 @@ encode_frame(
         }
 
         /*
-         * Sometimes the first audio frame comes out from encoder with a negarive pts (i.e replay rtmp with ffmpeg),
+         * Sometimes the first audio frame comes out from encoder with a negative pts (i.e replay rtmp with ffmpeg),
          * and after rescaling it becomes pretty big number which causes audio sync problem.
          * The only solution that I could come up for this was skipping this frame. (-RM)
          */
@@ -2247,18 +2247,15 @@ encode_frame(
             encoder_context->video_encoder_prev_pts = output_packet->pts;
 
         /*
-         * Rescale using the stream time_base (not the codec context):
-         *   - if the stream is a video or
-         *   - if it is audio then the decoding stream and encoding stream has the same codec id.
+         * Rescale using the stream time_base (not the codec context)
          */
         if ((stream_index == decoder_context->video_stream_index ||
-            (selected_decoded_audio(decoder_context, stream_index) >= 0 &&
-             params->ecodec2 != NULL &&
-             !strcmp(avcodec_get_name(decoder_context->codec_parameters[stream_index]->codec_id), params->ecodec2))) &&
+            (selected_decoded_audio(decoder_context, stream_index) >= 0)) &&
             (decoder_context->stream[stream_index]->time_base.den !=
             encoder_context->stream[index]->time_base.den ||
             decoder_context->stream[stream_index]->time_base.num !=
             encoder_context->stream[index]->time_base.num)) {
+
             av_packet_rescale_ts(output_packet,
                 decoder_context->stream[stream_index]->time_base,
                 encoder_context->stream[index]->time_base


### PR DESCRIPTION
The main problem was that the audio PTS/DTS was not scaled from the original timebase of 1/1000 to the target timebase of 1/48000.

webm/matroska containers use timebase 1/1000 for both audio and video and use opus codec for audio predominantly.

The code to rescale was in place but it was conditioned on the input codec being the same as the output codec which is not correct (in the case input codec is opus and output is AAC).

### Future prep - skip first audio samples

I have also researched the situation with audio frames having nagative PTS and preambles.  I documented it in this ticket: https://github.com/eluv-io/avpipe/issues/105
