### PR TITLE
Fix audio rescale flow - rescale before filter

### DIFF
--- a/doc/dev.md
+++ b/doc/dev.md
@@ -4,6 +4,14 @@
 
 ## HOW TO
 
+### Ingest source file into mez parts
+
+
+Example: audio 2 mono to 1 stereo
+```
+./bin/exc -f sample.mxf -xc-type audio-join   -format fmp4-segment -seg-duration 30.080 -audio-index 1,2 -channel-layout 3 -audio-bitrate 128000
+```
+
 ### Transcode Mez Parts into ABR segments
 
 #### Transcode a "mez part" into ABR segments

--- a/libavpipe/include/avpipe_xc.h
+++ b/libavpipe/include/avpipe_xc.h
@@ -276,7 +276,7 @@ typedef struct avpipe_io_handler_t {
  *
  * This structure supports:
  *   - one video stream (at most) - video_stream_index
- *   - one ore more audio streams - audio_stream_index[]
+ *   - one or more audio streams - audio_stream_index[]
  *   - one SCTE-35 data stream    - data_scte35_stream_index
  *   - one arbitrary data stream  - data_stream_index (not used currently)
  *

--- a/libavpipe/include/avpipe_xc.h
+++ b/libavpipe/include/avpipe_xc.h
@@ -271,7 +271,62 @@ typedef struct avpipe_io_handler_t {
 #define MAX_WRAP_PTS        ((int64_t)8589000000)
 #define MAX_AVFILENAME_LEN  128
 
-/* Decoder/encoder context, keeps both video and audio stream ffmpeg contexts */
+/*
+ * Decoder/encoder context, keeps both video and audio stream ffmpeg contexts
+ *
+ * This structure supports:
+ *   - one video stream (at most) - video_stream_index
+ *   - one ore more audio streams - audio_stream_index[]
+ *   - one SCTE-35 data stream    - data_scte35_stream_index
+ *   - one arbitrary data stream  - data_stream_index (not used currently)
+ *
+ * The caller specifies which source media audio streams to encode, using xc_params->audio_index, eg.
+ *   - audio_index[0] = 1;
+ *   - audio_index[1] = 3;
+ *   - audio_index[2] = 4;
+ *   (and xc->params->n_audio is 3)
+ *
+ * Audio stream index mapping is stored as follows:
+ *
+ * - decoder
+ *   - the audio_stream_index array stores the selected stream index values the same way as xc_params
+ *     - audio_stream_index[0] = 1;
+ *     - audio_stream_index[1] = 3;
+ *     - audio_stream_index[2] = 4;
+ *     (and the number of streams is stored in 'n_audio')
+ *
+ * - encoder
+ *   - if the encoding operation is audio join, merge or pan (which effectively takes multiple input steams and makes one output stream)
+ *      - audio_stream_index[0] = 0; (output stream index is considered 0 and nb_audio_output is 1)
+ *   - otherwise it uses a strange convention (needs fixed - this is impossible to traverse)
+ *      - audio_stream_index[0] unset
+ *      - audio_stream_index[1] = 1
+ *      - audio_stream_index[2] unset
+ *      - audio_stream_index[3] = 3
+ *      - audio_stream_index[4] = 4
+ *
+ * The video format context is stored in 'format_context'
+ * Audio format contexts for each audio output is stored in 'format_context2[]'
+ *   - this array is contiguous and has 'n_audio' elements eg. for the xc_params above
+ *     - format_context2[0] is the context for audio stream index 1
+ *     - format_context2[1] is the context for audio stream index 3
+ *     - format_context2[2] is the context for audio stream index 4
+ *
+ * Codec contexts (AVCodecContext) are stored in 'codec_context[]' as follows:
+ *
+ * - decoder
+ *   - the codec_context array is indexed using the source media stream index values, eg. for the xc_params above
+ *     - codec_context[0]  video  (if the source has video on stream_index 0, for example)
+ *     - codec_context[1]  audio stream index 1
+ *     - codec_context[2]  audio stream index 2 (not selected, per xc_params->audio_index)
+ *     - codec_context[3]  audio stream index 3
+ *     - codec_context[4]  audio stream index 4
+ *
+ * - encoder
+ *   - if the encoding operation is audio join, merge or pan
+ *     - codec_context[0]  is the codec context for the one output audio stream
+ *   - otherwise the array is indexed the same way as the decoder (example above)
+ */
 typedef struct coderctx_t {
     AVFormatContext     *format_context;                                /* Input format context or video output format context */
     AVFormatContext     *format_context2[MAX_STREAMS];                  /* Audio output format context, indexed by audio index */

--- a/libavpipe/include/avpipe_xc.h
+++ b/libavpipe/include/avpipe_xc.h
@@ -325,7 +325,12 @@ typedef struct avpipe_io_handler_t {
  * - encoder
  *   - if the encoding operation is audio join, merge or pan
  *     - codec_context[0]  is the codec context for the one output audio stream
- *   - otherwise the array is indexed the same way as the decoder (example above)
+ *   - otherwise the array is indexed the same way as the encoder 'audio_stream_index' array, eg.
+ *      - codec_context[0] codec context for the video stream
+ *      - codec_context[1] codec context for audio stream index 1
+ *      - codec_context[2] unset
+ *      - codec_context[3] codec context for audio stream index 3
+ *      - codec_context[4] codec context for audio stream index 4
  */
 typedef struct coderctx_t {
     AVFormatContext     *format_context;                                /* Input format context or video output format context */

--- a/libavpipe/src/avpipe_format.c
+++ b/libavpipe/src/avpipe_format.c
@@ -117,8 +117,9 @@ num_audio_output(
 }
 
 /*
- * Given a source audio stream index, return the index in the xc_params audio_index array, if selected.
- * Return -1 if this stream index is not selected (not part of the xc_params audio_index array)
+ * Given a source audio stream index, return the array index in the decoder 'audio_stream_index' array, if selected.
+ * This is used to index the 'format_context2' array.
+ * Return -1 if this stream index is not selected (was not part of the xc_params audio_index array)
  */
 int
 selected_decoded_audio(
@@ -137,22 +138,8 @@ selected_decoded_audio(
 }
 
 /*
- * Return the output stream index for a given audio xc_param audio_index.
- * The source has one or multiple audio streams - they each have a 'stream_index'
- * The xc_params audio_index specifies which of these audio streams are selected for encoding. This is a
- * contiguous array with each element specifying the source stream_index, eg:
- *   audio_index[0] = 1;
- *   audio_index[1] = 3;
- *   audio_index[2] = 4;
- * This function takes the index into the audio_index params (eg. 0, 1, 2 above). This is often the output of selected_decoded_audio()
- * The convention for the encoder (output) audio_stream_index[] storage is different than the input:
- * - for audio join/merge/pan always store the audio at index 0
- * - for VOD ad live ingest:
- *   audio_stream_index[0] = unset
- *   audio_stream_index[1] = 1
- *   audio_stream_index[2] = unset
- *   audio_stream_index[3] = 3
- *   audio_stream_index[4] = 4
+ * Return the array index into the encoder 'audio_stream_index' array (which is also used by the encoder 'codec_context' array),
+ * from the array index into the decoder 'audio_stream_index' array (as returned by selected_decoded_audio)
  */
 int
 audio_output_stream_index(

--- a/libavpipe/src/avpipe_format.c
+++ b/libavpipe/src/avpipe_format.c
@@ -312,14 +312,14 @@ audio_skip_samples(
  * When rescaling a decoded frame before sending it to the filter or encoder, use the
  * decoder codec_context timebase as source and the encoder codec timebase as target
  */
-void frame_rescale(
-    AVFrame *frame, AVRational src, AVRational dst) {
+void frame_rescale_time_base(
+    AVFrame *frame, AVRational src_time_base, AVRational dst_time_base) {
     if (frame->pts != AV_NOPTS_VALUE)
-        frame->pts = av_rescale_q(frame->pts, src, dst);
+        frame->pts = av_rescale_q(frame->pts, src_time_base, dst_time_base);
 
     if (frame->pkt_dts != AV_NOPTS_VALUE)
-        frame->pkt_dts = av_rescale_q(frame->pkt_dts, src, dst);
+        frame->pkt_dts = av_rescale_q(frame->pkt_dts, src_time_base, dst_time_base);
 
     if (frame->pkt_duration > 0)
-        frame->pkt_duration = av_rescale_q(frame->pkt_duration, src, dst);
+        frame->pkt_duration = av_rescale_q(frame->pkt_duration, src_time_base, dst_time_base);
 }

--- a/libavpipe/src/avpipe_format.c
+++ b/libavpipe/src/avpipe_format.c
@@ -262,3 +262,20 @@ audio_skip_samples(
     frame->nb_samples -= samples_to_skip;
     return eav_success;
 }
+
+/*
+ * Rescale an AVFrame before sending to the filter or encoder.
+ * When rescaling a decoded frame before sending it to the filter or encoder, use the
+ * decoder codec_context timebase as source and the encoder codec timebase as target
+ */
+void frame_rescale(
+    AVFrame *frame, AVRational src, AVRational dst) {
+    if (frame->pts != AV_NOPTS_VALUE)
+        frame->pts = av_rescale_q(frame->pts, src, dst);
+
+    if (frame->pkt_dts != AV_NOPTS_VALUE)
+        frame->pkt_dts = av_rescale_q(frame->pkt_dts, src, dst);
+
+    if (frame->pkt_duration > 0)
+        frame->pkt_duration = av_rescale_q(frame->pkt_duration, src, dst);
+}

--- a/libavpipe/src/avpipe_format.h
+++ b/libavpipe/src/avpipe_format.h
@@ -48,6 +48,13 @@ selected_decoded_audio(
 );
 
 int
+audio_output_stream_index(
+    coderctx_t *decoder_context,
+    xcparams_t* params,
+    int audio_stream_index
+);
+
+int
 get_channel_layout_for_encoder(
     int channel_layout
 );

--- a/libavpipe/src/avpipe_format.h
+++ b/libavpipe/src/avpipe_format.h
@@ -64,3 +64,8 @@ packet_clone(
     AVPacket *src,
     AVPacket **dst
 );
+
+void frame_rescale(
+    AVFrame *frame,
+    AVRational src_tb,
+    AVRational dst_tb);

--- a/libavpipe/src/avpipe_format.h
+++ b/libavpipe/src/avpipe_format.h
@@ -72,7 +72,7 @@ packet_clone(
     AVPacket **dst
 );
 
-void frame_rescale(
+void frame_rescale_time_base(
     AVFrame *frame,
-    AVRational src_tb,
-    AVRational dst_tb);
+    AVRational src_time_base,
+    AVRational dst_time_base);

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -3152,7 +3152,6 @@ flush_decoder(
             if (i >= 0) {
                 int output_stream_index = audio_output_stream_index(decoder_context, p, i);
                 AVCodecContext *enc_codec_context = encoder_context->codec_context[output_stream_index];
-                elv_log("SSDBG flush audio stream_index=%d output_stream_index=%d", stream_index, output_stream_index);
                 frame_rescale(frame, codec_context->time_base, enc_codec_context->time_base);
             }
 


### PR DESCRIPTION
Fix audio rescale in the main transcoding flow.

The general idea is to rescale the decoded audio frame before sending to the filter (and then to the encoder).
Initialize the audio buffer source filter using the desired encoder timebase, such that the filter expects the frames to be in the encoder timebase and process correctly.
No longer rescale audio packets before sending them to the packager, because they are now returned by the encoder in the correct timescale of the encoder.

I left the video transcoding flow unchanged and will come back with a separate PR for video.  