### PR TITLE
Fix image overlay video filters - apply overlay before scaling

### DIFF
--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -3186,8 +3186,22 @@ get_filter_str(
         char *filt_buf = NULL;
         int filt_buf_size;
         int filt_str_len;
-        const char* filt_template =
-            "[in] scale=%d:%d [in-1]; movie='%s', setpts=PTS [over]; [in-1] setpts=PTS [in-1a]; [in-1a][over]  overlay='%s:%s:alpha=0.1' [out]";
+
+        /*
+         * Create an overlay filter that expects the image be sized for the source video so we apply the
+         * overlay first and then scale the result.
+         *
+         *  [in]: source video
+         *  movie='%s': overlay image, assumed same size as input
+         *  overlay=0:0: aligned at top-left
+         *  alpha=0.1: transparency
+         *  scale=%d:%d: output resolution
+         *
+         * Previous filter:
+         * "[in] scale=%d:%d [in-1]; movie='%s', setpts=PTS [over]; [in-1] setpts=PTS [in-1a]; [in-1a][over]  overlay='%s:%s:alpha=0.1' [out]";
+         */
+        const char * filt_template =
+            "[in] movie='%s', setpts=PTS [overlay]; [in][overlay] overlay=0:0:format=auto:alpha=0.1 [combined]; [combined] scale=%d:%d [out]";
 
         /* Return an error if one of the watermark params is not set properly */
         if ((!params->watermark_xloc || *params->watermark_xloc == '\0') ||

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -3201,7 +3201,7 @@ get_filter_str(
          * "[in] scale=%d:%d [in-1]; movie='%s', setpts=PTS [over]; [in-1] setpts=PTS [in-1a]; [in-1a][over]  overlay='%s:%s:alpha=0.1' [out]";
          */
         const char * filt_template =
-            "[in] movie='%s', setpts=PTS [overlay]; [in][overlay] overlay=0:0:format=auto:alpha=0.1 [combined]; [combined] scale=%d:%d [out]";
+            "movie='%s', setpts=PTS[ov]; [in][ov] overlay=%s:%s:format=auto:alpha=0.1, scale=%d:%d [out]";
 
         /* Return an error if one of the watermark params is not set properly */
         if ((!params->watermark_xloc || *params->watermark_xloc == '\0') ||
@@ -3222,10 +3222,10 @@ get_filter_str(
         filt_str_len = filt_buf_size+FILTER_STRING_SZ;
         *filter_str = (char *) calloc(filt_str_len, 1);
         int ret = snprintf(*filter_str, filt_str_len, filt_template,
-                        encoder_context->codec_context[encoder_context->video_stream_index]->width,
-                        encoder_context->codec_context[encoder_context->video_stream_index]->height,
                         filt_buf,
-                        params->watermark_xloc, params->watermark_yloc);
+                        params->watermark_xloc, params->watermark_yloc,
+                        encoder_context->codec_context[encoder_context->video_stream_index]->width,
+                        encoder_context->codec_context[encoder_context->video_stream_index]->height);
         free(filt_buf);
         if (ret < 0) {
             free(*filter_str);

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -3188,14 +3188,11 @@ get_filter_str(
         int filt_str_len;
 
         /*
-         * Create an overlay filter that expects the image be sized for the source video so we apply the
+         * Create an overlay filter that expects the image be sized for the source video - apply the
          * overlay first and then scale the result.
          *
-         *  [in]: source video
-         *  movie='%s': overlay image, assumed same size as input
-         *  overlay=0:0: aligned at top-left
-         *  alpha=0.1: transparency
-         *  scale=%d:%d: output resolution
+         * - movie='%s': overlay image, assumed same size as input
+         * - scale=%d:%d: output resolution
          *
          * Previous filter:
          * "[in] scale=%d:%d [in-1]; movie='%s', setpts=PTS [over]; [in-1] setpts=PTS [in-1a]; [in-1a][over]  overlay='%s:%s:alpha=0.1' [out]";


### PR DESCRIPTION
The previous image overlay filter requires images be sized to the target resolution which makes the result slightly inconsistent (may jump when player switches resolution) and the resulting quality is not great.

The correct processing is to apply the overlay to the source video and scale the result.  This way we don't require the image be scaled by the caller (e.g using a Go library in content fabric).

> BREAKING CHANGE - caller code has to adapt to ensure the image is sized for the source video.