### PR TITLE
Handle unreadable or corrupt muxer input

### DIFF
--- a/avpipe.c
+++ b/avpipe.c
@@ -355,11 +355,17 @@ udp_in_opener(
         elv_warn("Failed to set UDP socket buf size to=%"PRId64", url=%s, errno=%d", bufsz, url, errno);
     }
 
+    socklen_t optlen = sizeof(bufsz);
+    if (getsockopt(sockfd, SOL_SOCKET, SO_RCVBUF, &bufsz, &optlen) < 0) {
+        elv_warn("Failed to get UDP socket buf size to=%"PRId64", url=%s, errno=%d", bufsz, url, errno);
+    } else if (bufsz < UDP_PIPE_BUFSIZE) {
+        elv_warn("Failed to set desired UDP socket buf size expect=%"PRId64" actual=%"PRId64, UDP_PIPE_BUFSIZE, bufsz);
+    }
+
     if (set_sock_nonblocking(sockfd) < 0) {
         elv_err("Failed to make UDP socket nonblocking, errno=%d", errno);
         return -1;
     }
-
 
     elv_channel_init(&inctx->udp_channel, MAX_UDP_CHANNEL, NULL);
     inctx->opaque = (int *) calloc(1, sizeof(int)+sizeof(int64_t));

--- a/libavpipe/src/avpipe_copy_mpegts.c
+++ b/libavpipe/src/avpipe_copy_mpegts.c
@@ -21,7 +21,7 @@ copy_mpegts_set_encoder_options(
     coderctx_t *decoder_context,
     xcparams_t *params,
     int stream_index,
-    int timebase)
+    int timebase /* PENDING(SS) should rename timescale */)
 {
     if (timebase <= 0) {
         elv_err("Setting mpegts encoder options failed, invalid timebase=%d (check encoding params), url=%s",
@@ -34,12 +34,11 @@ copy_mpegts_set_encoder_options(
 
     /* Precalculate seg_duration_ts based on seg_duration if seg_duration is set */
     seg_duration = atof(params->seg_duration);
-    seg_duration_ts = seg_duration * timebase;
-
     if (seg_duration <= 0) {
-        elv_err("Setting mpegts encoder options failed, invalid seg_duration=%d, url=%s", seg_duration, params->url);
+        elv_err("Setting mpegts encoder options failed, invalid seg_duration=%f, url=%s", seg_duration, params->url);
         return eav_param;
     }
+    seg_duration_ts = seg_duration * timebase;
 
     av_opt_set_int(encoder_context->format_context->priv_data, "segment_duration_ts", seg_duration_ts, 0);
 
@@ -52,6 +51,8 @@ copy_mpegts_set_encoder_options(
         // Initial offset needs to be in microseconds
         int64_t offset_microseconds = av_rescale_q(stream_start_time, (AVRational){1, timebase}, AV_TIME_BASE_Q);
         av_opt_set_int(encoder_context->format_context->priv_data, "initial_offset", offset_microseconds, 0);
+        // PENDING(SS) Should replace "initial_offset" (deprecated) with "output_ts_offset"
+        //av_opt_set_int(encoder_context->format_context->priv_data, "output_ts_offset", offset_microseconds, 0);
         elv_log("Set initial segment offset to %"PRId64" microseconds, based on stream start time of %"PRId64" and timebase %d", offset_microseconds, stream_start_time, timebase);
     }
 

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -3461,6 +3461,10 @@ avpipe_xc(
         }
 
         rc = av_read_frame(decoder_context->format_context, input_packet);
+        if (rc == AVERROR(EAGAIN) || rc == AVERROR(EIO) || rc == AVERROR_INVALIDDATA) {
+            elv_warn("packet unreadable or corrupt - %s (%d)", av_err2str(rc), rc);
+            continue;
+        }
         if (rc < 0) {
             av_packet_free(&input_packet);
             av_read_frame_rc = rc;

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -1691,8 +1691,8 @@ set_idr_frame_key_flag(
     if (params->force_keyint > 0) {
         if (encoder_context->forced_keyint_countdown <= 0) {
             if (debug_frame_level) {
-                elv_dbg("FRAME SET KEY flag, forced_keyint=%d pts=%"PRId64", forced_keyint_countdown=%d",
-                    params->force_keyint, frame->pts, encoder_context->forced_keyint_countdown);
+                elv_log("FRAME SET KEY flag, forced_keyint=%d lastkeyframe=%"PRId64" pts=%"PRId64", forced_keyint_countdown=%d",
+                    params->force_keyint, encoder_context->last_key_frame, frame->pts, encoder_context->forced_keyint_countdown);
             }
             if (encoder_context->forced_keyint_countdown < 0)
                 elv_log("force_keyint_countdown=%d", encoder_context->forced_keyint_countdown);
@@ -2049,10 +2049,12 @@ encode_frame(
                 2*encoder_context->calculated_frame_duration &&
             params->xc_type != xc_extract_images &&
             params->xc_type != xc_extract_all_images) {
-            elv_log("GAP detected, packet->pts=%"PRId64", video_encoder_prev_pts=%"PRId64", url=%s",
-                output_packet->pts, encoder_context->video_encoder_prev_pts, params->url);
-            encoder_context->forced_keyint_countdown -=
-                (output_packet->pts - encoder_context->video_encoder_prev_pts)/encoder_context->calculated_frame_duration - 1;
+
+            int fc = (output_packet->pts - encoder_context->video_encoder_prev_pts)/encoder_context->calculated_frame_duration - 1;
+            encoder_context->forced_keyint_countdown -= fc;
+
+            elv_log("GAP detected packet->pts=%"PRId64" video_encoder_prev_pts=%"PRId64" count=%d keying_count=%d url=%s",
+                output_packet->pts, encoder_context->video_encoder_prev_pts, fc, encoder_context->forced_keyint_countdown, params->url);
         }
 
         if (stream_index == decoder_context->video_stream_index &&
@@ -3394,14 +3396,30 @@ avpipe_xc(
 
     int video_stream_index = decoder_context->video_stream_index;
     if (params->xc_type & xc_video) {
+
+        if (av_cmp_q(decoder_context->format_context->streams[video_stream_index]->r_frame_rate, decoder_context->format_context->streams[video_stream_index]->avg_frame_rate)) {
+            elv_log("frame rate discrepancy r=%d/%d avg=%d/%d",
+                decoder_context->format_context->streams[video_stream_index]->r_frame_rate.num, decoder_context->format_context->streams[0]->r_frame_rate.den,
+                decoder_context->format_context->streams[video_stream_index]->avg_frame_rate.num, decoder_context->format_context->streams[0]->avg_frame_rate.den);
+        }
+
+        int enc_calc_frame_duration = 0;
         if (encoder_context->format_context->streams[0]->avg_frame_rate.num != 0 &&
             decoder_context->stream[video_stream_index]->time_base.num != 0) {
-            encoder_context->calculated_frame_duration =
+
+            encoder_context->calculated_frame_duration = enc_calc_frame_duration =
                 /* In very rare cases this might overflow, so type cast to 64bit int to avoid overflow */
-                ((int64_t)decoder_context->stream[video_stream_index]->time_base.den * (int64_t)encoder_context->format_context->streams[0]->avg_frame_rate.den) /
-                    ((int64_t)encoder_context->format_context->streams[0]->avg_frame_rate.num * (int64_t) decoder_context->stream[video_stream_index]->time_base.num);
+                ((int64_t)encoder_context->stream[0]->time_base.den * (int64_t)encoder_context->format_context->streams[0]->avg_frame_rate.den) /
+                    ((int64_t)encoder_context->format_context->streams[0]->avg_frame_rate.num * (int64_t) encoder_context->stream[0]->time_base.num);
+            decoder_context->calculated_frame_duration =
+                ((int64_t)decoder_context->stream[video_stream_index]->time_base.den * (int64_t)decoder_context->format_context->streams[video_stream_index]->avg_frame_rate.den) /
+                    ((int64_t)decoder_context->format_context->streams[video_stream_index]->avg_frame_rate.num * (int64_t) decoder_context->stream[video_stream_index]->time_base.num);
         }
-        elv_log("calculated_frame_duration=%d", encoder_context->calculated_frame_duration);
+
+        if (params->video_frame_duration_ts > 0) {
+            encoder_context->calculated_frame_duration = params->video_frame_duration_ts;
+        }
+        elv_log("calculated_frame_duration enc=%d (%d) dec=%d", encoder_context->calculated_frame_duration, enc_calc_frame_duration, decoder_context->calculated_frame_duration);
     }
 
     xctx->do_instrument = do_instrument;

--- a/utils/src/elv_channel.c
+++ b/utils/src/elv_channel.c
@@ -58,6 +58,7 @@ elv_channel_send(
 
     pthread_mutex_lock(&channel->_mutex);
     while (channel->_count >= channel->_capacity && channel->_closed == 0) {
+        elv_log("elv_channel_send: full so wait");
         pthread_cond_wait(&channel->_cond_recv, &channel->_mutex);
     }
 


### PR DESCRIPTION
Several fixes:

1. Keep demuxing loop robust to minor network errors or corruptions - continue reading and only exit after 300 tries
  - low risk since we exit after 300 tries
  - I chose 300 to be approx 5 sec at 60fps

2. Fix calculated_frame_duration
  - I now have both a decoder and encoder frame duration since they are not the same when we change timebase/timescale and frame durations
  - Honor param video_frame_duration_ts - when set, the 'calculated_frame_duration' needs to be set to that

3. For mpegts parts, use the source timebase and calculations (since we are not changing timebase or frame durations in TS output) 
  - prior logic was copied from video encoder prep and used the encoder values

4. Additional logging


Here are some examples of infrequent IO errors that cause the decoding loop to terminate currently, which is not desirable:
```
log/qfab.log:2025-08-16T13:01:54.771Z ERROR PI av_read_frame() rc=-5, url=srt://host-27-32-84-163.contentfabric.io:11012?mode=listener logger=/avpipe gid=1880 avp=6fc67ee2
log/qfab.log:2025-08-17T04:58:59.678Z ERROR PI av_read_frame() rc=-5, url=srt://host-27-32-84-163.contentfabric.io:11011?mode=listener logger=/avpipe gid=534194 avp=0cd1f6b8
log/qfab.log:2025-08-19T04:22:32.897Z ERROR PI av_read_frame() rc=-5, url=srt://host-27-32-84-163.contentfabric.io:11012?mode=listener logger=/avpipe gid=3618528 avp=176e4c70

```