### PR TITLE
Fix for contamination from TestGIDAssociation on other tests

### DIFF
--- a/goavpipe/log.go
+++ b/goavpipe/log.go
@@ -99,6 +99,12 @@ func AssociateGIDWithHandle(handle int32) {
 	}
 }
 
+// DissociateGIDFromHandle removes the association between the current goroutine ID and its handle
+func DissociateGIDFromHandle() {
+	gid := gls.GoID()
+	gidHandleMap.Delete(gid)
+}
+
 // XCEnded releases resources associated with the handle
 func XCEnded() {
 	handleUntyped, ok := gidHandleMap.LoadAndDelete(gls.GoID())

--- a/goavpipe/log_test.go
+++ b/goavpipe/log_test.go
@@ -18,6 +18,7 @@ func TestGIDAssociation(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			AssociateGIDWithHandle(handle)
+			defer DissociateGIDFromHandle()
 			// Randomize scheduling a bit
 			time.Sleep(time.Millisecond*20 + time.Millisecond*time.Duration(rand.IntN(10)))
 			rHandle, ok := GIDHandle()


### PR DESCRIPTION
`TestGIDAssociation` leaves lots of associated GIDs, which makes later tests like `TestErrorCapturing` and `TestCorrectChanClosure` fail.

A new function `DissociateGIDFromHandle` is introduced and used in `TestGIDAssociation`. It should probably be used in other parts of the code as well to not leak resources.

Can be tested with

```sh
cd goavpipe
go test -run "TestGIDAssociation|TestCorrectChanClosure|TestErrorCapturing"
```

which should now succeed.