### PR TITLE
Fix types in TestUnmarshalParams

### DIFF
--- a/avpipe_test.go
+++ b/avpipe_test.go
@@ -2301,7 +2301,7 @@ func TestUnmarshalParams(t *testing.T) {
 	bytes := []byte(`{"video_bitrate":8000000,"seg_duration_ts":180000,"seg_duration_fr":50,"enc_height":720,"enc_width":1280,"xc_type":1}`)
 	err := json.Unmarshal(bytes, &params)
 	assert.NoError(t, err)
-	assert.Equal(t, goavpipe.XcVideo, int(params.XcType))
+	assert.Equal(t, int(goavpipe.XcVideo), int(params.XcType), "XcVideo type expected")
 	// TODO: More checks
 }
 


### PR DESCRIPTION
Simple fix for #134.

The test now succeeds:

```sh
avpipe git:(fix-test-types) ✗ go test -run TestUnmarshalParams
PASS
ok      github.com/eluv-io/avpipe       0.367s
```