### PR TITLE
Fix ac3 MPEG-TS to fmp4

### DIFF
--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -688,8 +688,13 @@ set_encoder_options(
         }
 
         if (!strcmp(params->format, "fmp4-segment")) {
-            if ((i = selected_decoded_audio(decoder_context, stream_index)) >= 0)
-                av_opt_set(encoder_context->format_context2[i]->priv_data, "segment_format_options", "movflags="FRAG_OPTS, 0);
+            if ((i = selected_decoded_audio(decoder_context, stream_index)) >= 0) {
+                // AC3 codec requires delay_moov flag to write packets before moov atom
+                if (params->ecodec2 && !strcmp(params->ecodec2, "ac3"))
+                    av_opt_set(encoder_context->format_context2[i]->priv_data, "segment_format_options", "movflags="FRAG_OPTS"+delay_moov", 0);
+                else
+                    av_opt_set(encoder_context->format_context2[i]->priv_data, "segment_format_options", "movflags="FRAG_OPTS, 0);
+            }
             if (stream_index == decoder_context->video_stream_index)
                 av_opt_set(encoder_context->format_context->priv_data, "segment_format_options", "movflags="FRAG_OPTS, 0);
         }


### PR DESCRIPTION
As explained in #136, `TestAudioAC3Ts2AC3MezMaker` fails since ffmpeg refuses to write a `moov` box before processing samples. 

Some documentation for this can be found in

- FFmpeg movenc.c source: https://ffmpeg.org/doxygen/trunk/movenc_8c_source.html
- FFmpeg patchwork discussion: https://patchwork.ffmpeg.org/patch/11972/

The solution is to add an extra flag `delay_moov` for the cases where one wants to output AC3 in fMP4 format.
This PR fixes #136 and makes the test succeed:

```sh
avpipe git:(fix-ac3-ts-to-fmp4)  go test -run TestAudioAC3Ts2AC3MezMaker
PASS
ok      github.com/eluv-io/avpipe       0.625s
```