### PR TITLE
Add functionality to the pipe to enable self-discovery from available streamsinfo

### DIFF
--- a/avpipe.c
+++ b/avpipe.c
@@ -300,6 +300,15 @@ in_stat(
     case in_stat_data_scte35:
         rc = AVPipeStatInput(fd, stream_index, stat_type, c->data);
         break;
+    case in_stat_data_stream_info:
+        struct cbor_buf_data_t {
+            uint8_t *data;
+            size_t   size;
+        } cbor_data_t;
+        cbor_data_t.data = c->data;
+        cbor_data_t.size = c->data_size;
+        rc = AVPipeStatInput(fd, stream_index, stat_type, &cbor_data_t);
+        break;
 
     default:
         rc = -1;

--- a/avpipe.go
+++ b/avpipe.go
@@ -23,10 +23,13 @@ package avpipe
 // #cgo pkg-config: libswscale
 // #cgo pkg-config: libavutil
 // #cgo pkg-config: libpostproc
+// #cgo pkg-config: libcbor
+// #cgo LDFLAGS: -lcbor
 // #cgo netint pkg-config: xcoder
 // #cgo pkg-config: srt
 // #cgo CFLAGS: -I${SRCDIR}/libavpipe/include
 // #cgo CFLAGS: -I${SRCDIR}/utils/include
+// #cgo CFLAGS: -g
 // #cgo LDFLAGS: -L${SRCDIR}
 // #cgo linux LDFLAGS: -Wl,-rpath,$ORIGIN/../lib
 

--- a/avpipe.go
+++ b/avpipe.go
@@ -327,6 +327,32 @@ func (h *ioHandler) InStat(stream_index C.int, avp_stat C.avp_stat_t, stat_args 
 	case C.in_stat_data_scte35:
 		statArgs := C.GoString((*C.char)(stat_args))
 		err = h.input.Stat(streamIndex, goavpipe.AV_IN_STAT_DATA_SCTE35, statArgs)
+	case C.in_stat_data_stream_info:
+		if stat_args != nil {
+			// stat_args points to a CBOR-encoded buffer.
+			// Assume stat_args is a pointer to a struct:
+			// typedef struct {
+			//     uint8_t* data;
+			//     size_t len;
+			// } cbor_buf_t;
+			type cborBuf struct {
+				data uintptr
+				len  uint64
+			}
+			cbuf := (*cborBuf)(stat_args)
+			cborBytes := unsafe.Slice((*byte)(unsafe.Pointer(cbuf.data)), cbuf.len)
+
+			streams, uerr := UnpackStreamProbesFromCBOR(cborBytes)
+			if uerr != nil {
+				err = fmt.Errorf("failed to unpack stream info from CBOR: %w", uerr)
+				break
+			}
+
+			err = h.input.Stat(streamIndex, goavpipe.AV_IN_STAT_DATA_STREAM_INFO, streams)
+
+		} else {
+			err = fmt.Errorf("stat_args is nil for in_stat_data_stream_info")
+		}
 	}
 
 	return err

--- a/avpipe_errors.go
+++ b/avpipe_errors.go
@@ -13,13 +13,8 @@ package avpipe
 // #cgo pkg-config: libswscale
 // #cgo pkg-config: libavutil
 // #cgo pkg-config: libpostproc
-// #cgo netint pkg-config: xcoder
-// #cgo pkg-config: srt
-// #cgo CFLAGS: -I${SRCDIR}/include
-// #cgo CFLAGS: -I${SRCDIR}/libavpipe/include
-// #cgo CFLAGS: -I${SRCDIR}/utils/include
-// #cgo LDFLAGS: -L${SRCDIR}
-// #cgo linux LDFLAGS: -Wl,-rpath,$ORIGIN/../lib
+// #cgo pkg-config: libcbor
+// #cgo LDFLAGS: -lcbor
 // #include "avpipe.h"
 import "C"
 

--- a/avpipe_errors.go
+++ b/avpipe_errors.go
@@ -15,6 +15,13 @@ package avpipe
 // #cgo pkg-config: libpostproc
 // #cgo pkg-config: libcbor
 // #cgo LDFLAGS: -lcbor
+// #cgo netint pkg-config: xcoder
+// #cgo pkg-config: srt
+// #cgo CFLAGS: -I${SRCDIR}/include
+// #cgo CFLAGS: -I${SRCDIR}/libavpipe/include
+// #cgo CFLAGS: -I${SRCDIR}/utils/include
+// #cgo LDFLAGS: -L${SRCDIR}
+// #cgo linux LDFLAGS: -Wl,-rpath,$ORIGIN/../lib
 // #include "avpipe.h"
 import "C"
 

--- a/avpipe_test.go
+++ b/avpipe_test.go
@@ -47,6 +47,7 @@ type testStatsInfo struct {
 	firstKeyFramePTS        uint64
 	encodingAudioFrameStats avpipe.EncodingFrameStats
 	encodingVideoFrameStats avpipe.EncodingFrameStats
+	streams                 []avpipe.StreamInfo
 }
 
 var statsInfo testStatsInfo
@@ -163,6 +164,12 @@ func (i *fileInput) Stat(streamIndex int, statType goavpipe.AVStatType, statArgs
 			log.Debug("AVP TEST IN STAT", "video first keyframe PTS", *keyFramePTS, "streamIndex", streamIndex)
 		}
 		statsInfo.firstKeyFramePTS = *keyFramePTS
+	case goavpipe.AV_IN_STAT_DATA_STREAM_INFO:
+		streamInfo := statArgs.([]avpipe.StreamInfo)
+		if debugFrameLevel {
+			log.Debug("AVP TEST IN STAT", "data stream info", streamInfo, "streamIndex", streamIndex)
+		}
+		statsInfo.streams = streamInfo
 	}
 	return nil
 }
@@ -2109,6 +2116,11 @@ func TestAVPipeStats(t *testing.T) {
 	//assert.Equal(t, int64(1406), statsInfo.encodingAudioFrameStats.FramesWritten)
 	assert.Equal(t, uint64(5625), statsInfo.audioFramesRead)
 	assert.Equal(t, uint64(2880), statsInfo.videoFramesRead)
+	// add an assert to check duration and height width
+	assert.NotEqual(t, 0, len(statsInfo.streams))
+	assert.Equal(t, int64(2880), statsInfo.streams[0].DurationTs)
+	assert.Equal(t, int(1920), statsInfo.streams[0].Width)
+	assert.Equal(t, int(1080), statsInfo.streams[0].Height)
 }
 
 // This unit test is almost a complete test for mez, abr, muxing and probing. It does:
@@ -2301,7 +2313,7 @@ func TestUnmarshalParams(t *testing.T) {
 	bytes := []byte(`{"video_bitrate":8000000,"seg_duration_ts":180000,"seg_duration_fr":50,"enc_height":720,"enc_width":1280,"xc_type":1}`)
 	err := json.Unmarshal(bytes, &params)
 	assert.NoError(t, err)
-	assert.Equal(t, goavpipe.XcVideo, int(params.XcType))
+	assert.Equal(t, int(goavpipe.XcVideo), int(params.XcType))
 	// TODO: More checks
 }
 

--- a/elvxc/Makefile
+++ b/elvxc/Makefile
@@ -4,7 +4,7 @@ TOP_DIR ?= $(shell pwd)
 all: elvxc install
 
 elvxc: main.go ../avpipe.go cmd/transcode.go
-	CGO_CFLAGS="-I${TOP_DIR}/.. -I${TOP_DIR}/../include -I${SRT_DIST} -I${SRT_DIST}/srtcore" CGO_LDFLAGS="-L${TOP_DIR}/../lib ${LIBS}" go build -v -x
+	CGO_CFLAGS="-I${TOP_DIR}/.. -I${TOP_DIR}/../include -I${SRT_DIST} -I${SRT_DIST}/srt" CGO_LDFLAGS="-L${TOP_DIR}/../lib ${LIBS}" go build -v -x
 
 clean:
 	@echo "Making clean elvxc"

--- a/go.mod
+++ b/go.mod
@@ -18,11 +18,13 @@ require (
 	github.com/eluv-io/apexlog-go v1.9.1-elv3 // indirect
 	github.com/eluv-io/stack v1.8.2 // indirect
 	github.com/eluv-io/utc-go v1.0.0 // indirect
+	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.3 // indirect
+	github.com/x448/float16 v0.8.4 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/eluv-io/utc-go v1.0.0/go.mod h1:KWZ6T0xsckDHJBrOJaA/BVJBAkNhocaTueV92
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
+github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-test/deep v1.1.0 h1:WOcxcdHcvdgThNXjw0t76K42FXTU7HpNQWHpA2HHNlg=
@@ -133,6 +135,8 @@ github.com/tj/go-elastic v0.0.0-20171221160941-36157cbbebc2/go.mod h1:WjeM0Oo1eN
 github.com/tj/go-kinesis v0.0.0-20171128231115-08b17f58cb1b/go.mod h1:/yhzCV0xPfx6jb1bBgRFjl5lytqVqZXEaeqWP8lTEao=
 github.com/tj/go-spin v1.1.0/go.mod h1:Mg1mzmePZm4dva8Qz60H2lHwmJ2loum4VIrLgVnKwh4=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
+github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
+github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=

--- a/goavpipe/structs.go
+++ b/goavpipe/structs.go
@@ -20,6 +20,7 @@ const (
 	AV_OUT_STAT_START_FILE              = 10
 	AV_OUT_STAT_END_FILE                = 11
 	AV_IN_STAT_DATA_SCTE35              = 12
+	AV_IN_STAT_DATA_STREAM_INFO         = 13
 )
 
 func (a AVStatType) Name() string {
@@ -48,6 +49,8 @@ func (a AVStatType) Name() string {
 		return "AV_OUT_STAT_END_FILE"
 	case AV_IN_STAT_DATA_SCTE35:
 		return "AV_IN_STAT_DATA_SCTE35"
+	case AV_IN_STAT_DATA_STREAM_INFO:
+		return "AV_IN_STAT_DATA_STREAM_INFO"
 	default:
 		return fmt.Sprintf("Unknown(%d)", a)
 	}

--- a/init-cgo.sh
+++ b/init-cgo.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-export CGO_CFLAGS="-g -O0 -I/home/jan/ELV/avpipe -I/home/jan/ELV/avpipe/libavpipe/include -I/home/jan/ELV/avpipe/utils/include -I/home/jan/.local/include/srt -I/home/jan/.local/include"
-export CGO_LDFLAGS="-L/home/jan/ELV/avpipe -lcbor"
+export CGO_CFLAGS="-g -O0 -I'$HOME/ELV/avpipe' -I$HOME/ELV/avpipe/libavpipe/include -I$HOME/ELV/avpipe/utils/include -I$HOME/.local/include/srt -I$HOME/.local/include"
+export CGO_LDFLAGS="-L$HOME/ELV/avpipe -lcbor"

--- a/init-cgo.sh
+++ b/init-cgo.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+export CGO_CFLAGS="-g -O0 -I/home/jan/ELV/avpipe -I/home/jan/ELV/avpipe/libavpipe/include -I/home/jan/ELV/avpipe/utils/include -I/home/jan/.local/include/srt -I/home/jan/.local/include"
+export CGO_LDFLAGS="-L/home/jan/ELV/avpipe -lcbor"

--- a/init-local.sh
+++ b/init-local.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 export FFMPEG_DIST="$HOME/.local"
-export SRT_DIST="$HOME/.local/bin"
+export SRT_DIST="$HOME/.local/include"
 export PKG_CONFIG_PATH="$HOME/.local/lib/pkgconfig"
 echo FFMPEG_DIST=$FFMPEG_DIST
 echo SRT_DIST=$SRT_DIST

--- a/libavpipe/Makefile
+++ b/libavpipe/Makefile
@@ -20,6 +20,10 @@ OSNAME := $(shell uname -s)
 
 INCDIRS=-I${FFMPEG_DIST}/include -I../utils/include -Iinclude
 
+# Add libcbor support
+LIBCBOR_CFLAGS := $(shell pkg-config --cflags libcbor 2>/dev/null || echo "")
+LIBCBOR_LIBS := $(shell pkg-config --libs libcbor 2>/dev/null || echo "")
+
 OBJS=$(SRCS:%.c=$(BINDIR)/%.o)
 
 ifdef AVP_VERSION
@@ -28,7 +32,7 @@ else
 VERSION := $(GIT_VERSION)
 endif
 
-FLAGS=-O0 -ggdb -Wall -fPIC -DVERSION=\"$(VERSION)\"
+FLAGS=-O0 -ggdb -Wall -fPIC -DVERSION=\"$(VERSION)\" $(LIBCBOR_CFLAGS)
 
 all: avpipelib install
 

--- a/libavpipe/include/avpipe_xc.h
+++ b/libavpipe/include/avpipe_xc.h
@@ -104,7 +104,8 @@ typedef enum avp_stat_t {
     out_stat_encoding_end_pts = 9,          // The last PTS encoded. This stat is recorded when a file is closed
     out_stat_start_file = 10,               // Sent when a new file is opened and reports the segment index
     out_stat_end_file = 11,                 // Sent when a file is closed and reports the segment index
-    in_stat_data_scte35 = 12               // SCTE data arrived
+    in_stat_data_scte35 = 12,               // SCTE data arrived
+    in_stat_data_stream_info = 13           // Stream info in CBOR format
 } avp_stat_t;
 
 typedef enum avp_live_proto_t {
@@ -202,6 +203,7 @@ typedef struct ioctx_t {
     int     seg_index;          /* segment index if this ioctx is a segment */
 
     uint8_t *data;  /* Data stream buffer (e.g. SCTE-35) */
+    size_t   data_size; /* Size of data stream buffer */
 
     io_mux_ctx_t    *in_mux_ctx;   /* Input muxer context */
     int             in_mux_index;

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -3253,6 +3253,8 @@ get_filter_str(
     return 0;
 }
 
+
+
 /*
  * The general flow of transcoding:
  *
@@ -3303,7 +3305,7 @@ pack_stream_probes_to_cbor(
         stream_info_t *stream = &stream_probes[i];
 
         // Create a CBOR map for this stream (start with a reasonable size)
-        cbor_item_t *stream_map = cbor_new_definite_map(25);
+        cbor_item_t *stream_map = cbor_new_definite_map(35);
         if (!stream_map) {
             elv_err("Failed to create CBOR stream map for stream %d", i);
             cbor_decref(&root);
@@ -3404,8 +3406,6 @@ pack_stream_probes_to_cbor(
             ADD_CBOR_ITEM(stream_map, "side_data", side_data_map);
         }
 
-        #undef ADD_CBOR_ITEM
-
         // Add the stream map to the root array
         if (!cbor_array_push(root, stream_map)) {
             elv_err("Failed to add stream %d to CBOR array", i);
@@ -3498,7 +3498,7 @@ avpipe_xc(
         if (in_handlers->avpipe_stater) {
            inctx->data = cbor_data;
            inctx->data_size = cbor_size;
-           rc = in_handlers->avpipe_stater(inctx, input_packet->stream_index, in_stat_data_stream_info);
+           rc = in_handlers->avpipe_stater(inctx, 0, in_stat_data_stream_info);
         }else{
               elv_warn("No stater callback to send stream info");
         }

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -688,8 +688,13 @@ set_encoder_options(
         }
 
         if (!strcmp(params->format, "fmp4-segment")) {
-            if ((i = selected_decoded_audio(decoder_context, stream_index)) >= 0)
-                av_opt_set(encoder_context->format_context2[i]->priv_data, "segment_format_options", "movflags="FRAG_OPTS, 0);
+            if ((i = selected_decoded_audio(decoder_context, stream_index)) >= 0) {
+                // AC3 codec requires delay_moov flag to write packets before moov atom
+                if (params->ecodec2 && !strcmp(params->ecodec2, "ac3"))
+                    av_opt_set(encoder_context->format_context2[i]->priv_data, "segment_format_options", "movflags="FRAG_OPTS"+delay_moov", 0);
+                else
+                    av_opt_set(encoder_context->format_context2[i]->priv_data, "segment_format_options", "movflags="FRAG_OPTS, 0);
+            }
             if (stream_index == decoder_context->video_stream_index)
                 av_opt_set(encoder_context->format_context->priv_data, "segment_format_options", "movflags="FRAG_OPTS, 0);
         }

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -3479,7 +3479,7 @@ avpipe_xc(
     xcprobe_t *probe = (xcprobe_t *)calloc(1, sizeof(xcprobe_t));
     if (!probe) {
         elv_err("Failed to allocate memory for probe");
-        return NULL;
+        return eav_mem_alloc;
     }
 
 
@@ -4360,9 +4360,10 @@ avpipe_probe(
     int nb_skipped_streams=0;
 
     probe = (xcprobe_t *)calloc(1, sizeof(xcprobe_t));
-    if (!probe) {
+    if (probe == NULL) {
         elv_err("Failed to allocate memory for probe");
-        return NULL;
+        rc = eav_mem_alloc;
+        goto avpipe_probe_end;
     }
 
     stream_info_t**  stream_probes = make_stream_info(decoder_ctx, nb_streams, &nb_skipped_streams, probe);

--- a/rules.make
+++ b/rules.make
@@ -11,8 +11,8 @@ OSNAME := $(shell uname -s)
 LDFLAGS := \
 		-lavpipe \
 		-lutils \
-		$(shell pkg-config --libs libavfilter libavcodec libavformat libavdevice libswresample libavresample libswscale libavutil libpostproc srt)
-CFLAGS := $(shell pkg-config --cflags libavfilter libavcodec libavformat libavdevice libswresample libavresample libswscale libavutil libpostproc srt)
+		$(shell pkg-config --libs libavfilter libavcodec libavformat libavdevice libswresample libavresample libswscale libavutil libpostproc srt libcbor)
+CFLAGS := $(shell pkg-config --cflags libavfilter libavcodec libavformat libavdevice libswresample libavresample libswscale libavutil libpostproc srt libcbor)
 
 ifeq ($(OSNAME), Darwin)
 	LDFLAGS := ${LDFLAGS} \
@@ -40,3 +40,6 @@ ifeq ($(OSNAME), Linux)
 		$(shell pkg-config --libs xcoder)
 	CFLAGS := ${CFLAGS} $(shell pkg-config --cflags xcoder)
 endif
+
+# Alias for compatibility with different makefiles
+LIBS := ${LDFLAGS}

--- a/unpack.go
+++ b/unpack.go
@@ -1,0 +1,211 @@
+package avpipe
+
+// #cgo pkg-config: libavcodec
+// #cgo pkg-config: libavfilter
+// #cgo pkg-config: libavformat
+// #cgo pkg-config: libavutil
+// #cgo pkg-config: libswresample
+// #cgo pkg-config: libavresample
+// #cgo pkg-config: libavdevice
+// #cgo pkg-config: libswscale
+// #cgo pkg-config: libavutil
+// #cgo pkg-config: libpostproc
+// #cgo pkg-config: libcbor
+// #cgo LDFLAGS: -lcbor
+// #cgo netint pkg-config: xcoder
+// #cgo pkg-config: srt
+// #cgo CFLAGS: -I${SRCDIR}/libavpipe/include
+// #cgo CFLAGS: -I${SRCDIR}/utils/include
+// #cgo CFLAGS: -g
+// #cgo LDFLAGS: -L${SRCDIR}
+// #cgo linux LDFLAGS: -Wl,-rpath,$ORIGIN/../lib
+
+// #include <string.h>
+// #include <stdlib.h>
+// #include "avpipe_xc.h"
+// #include "avpipe.h"
+// #include "elv_log.h"
+import "C"
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/fxamacker/cbor/v2"
+)
+
+// AVRational represents a rational number (fraction) with numerator and denominator
+type AVRational struct {
+	Num uint32 `cbor:"num" json:"num"`
+	Den uint32 `cbor:"den" json:"den"`
+}
+
+// ToBigRat converts AVRational to *big.Rat
+func (r *AVRational) ToBigRat() *big.Rat {
+	if r.Den == 0 {
+		return big.NewRat(0, 1)
+	}
+	return big.NewRat(int64(r.Num), int64(r.Den))
+}
+
+// SideDataCBOR represents stream side data from CBOR
+type SideDataCBOR struct {
+	DisplayMatrix SideDataDisplayMatrix `cbor:"display_matrix" json:"display_matrix"`
+}
+
+// StreamInfoCBOR represents the CBOR-serialized version of stream information
+// This matches the structure packed by pack_stream_probes_to_cbor() in C
+type StreamInfoCBOR struct {
+	StreamIndex        uint32       `cbor:"stream_index" json:"stream_index"`
+	StreamId           uint32       `cbor:"stream_id" json:"stream_id"`
+	CodecType          uint32       `cbor:"codec_type" json:"codec_type"`
+	CodecID            uint32       `cbor:"codec_id" json:"codec_id"`
+	CodecName          string       `cbor:"codec_name" json:"codec_name"`
+	DurationTs         uint64       `cbor:"duration_ts" json:"duration_ts"`
+	TimeBase           AVRational   `cbor:"time_base" json:"time_base"`
+	NBFrames           uint64       `cbor:"nb_frames" json:"nb_frames"`
+	StartTime          uint64       `cbor:"start_time" json:"start_time"`
+	AvgFrameRate       AVRational   `cbor:"avg_frame_rate" json:"avg_frame_rate"`
+	FrameRate          AVRational   `cbor:"frame_rate" json:"frame_rate"`
+	SampleRate         uint32       `cbor:"sample_rate" json:"sample_rate"`
+	Channels           uint32       `cbor:"channels" json:"channels"`
+	ChannelLayout      uint32       `cbor:"channel_layout" json:"channel_layout"`
+	TicksPerFrame      uint32       `cbor:"ticks_per_frame" json:"ticks_per_frame"`
+	BitRate            uint64       `cbor:"bit_rate" json:"bit_rate"`
+	HasBFrames         uint32       `cbor:"has_b_frames" json:"has_b_frames"`
+	Width              uint32       `cbor:"width" json:"width"`
+	Height             uint32       `cbor:"height" json:"height"`
+	PixFmt             uint32       `cbor:"pix_fmt" json:"pix_fmt"`
+	SampleAspectRatio  AVRational   `cbor:"sample_aspect_ratio" json:"sample_aspect_ratio"`
+	DisplayAspectRatio AVRational   `cbor:"display_aspect_ratio" json:"display_aspect_ratio"`
+	FieldOrder         uint32       `cbor:"field_order" json:"field_order"`
+	Profile            uint32       `cbor:"profile" json:"profile"`
+	Level              uint32       `cbor:"level" json:"level"`
+	SideData           SideDataCBOR `cbor:"side_data" json:"side_data"`
+}
+
+// ToStreamInfo converts StreamInfoCBOR to StreamInfo struct
+func (s *StreamInfoCBOR) ToStreamInfo() StreamInfo {
+	sideData := make([]interface{}, 0)
+
+	// Add display matrix if it has data
+	if s.SideData.DisplayMatrix.Rotation != 0 || s.SideData.DisplayMatrix.RotationCw != 0 {
+		sideData = append(sideData, SideDataDisplayMatrix{
+			Type:       "display_matrix",
+			Rotation:   s.SideData.DisplayMatrix.Rotation,
+			RotationCw: s.SideData.DisplayMatrix.RotationCw,
+		})
+	}
+
+	return StreamInfo{
+		StreamIndex:        int(s.StreamIndex),
+		StreamId:           int32(s.StreamId),
+		CodecType:          getCodecTypeName(s.CodecType),
+		CodecID:            int(s.CodecID),
+		CodecName:          s.CodecName,
+		DurationTs:         int64(s.DurationTs),
+		TimeBase:           s.TimeBase.ToBigRat(),
+		NBFrames:           int64(s.NBFrames),
+		StartTime:          int64(s.StartTime),
+		AvgFrameRate:       s.AvgFrameRate.ToBigRat(),
+		FrameRate:          s.FrameRate.ToBigRat(),
+		SampleRate:         int(s.SampleRate),
+		Channels:           int(s.Channels),
+		ChannelLayout:      int(s.ChannelLayout),
+		TicksPerFrame:      int(s.TicksPerFrame),
+		BitRate:            int64(s.BitRate),
+		Has_B_Frames:       s.HasBFrames != 0,
+		Width:              int(s.Width),
+		Height:             int(s.Height),
+		PixFmt:             int(s.PixFmt),
+		SampleAspectRatio:  s.SampleAspectRatio.ToBigRat(),
+		DisplayAspectRatio: s.DisplayAspectRatio.ToBigRat(),
+		FieldOrder:         getFieldOrderName(s.FieldOrder),
+		Profile:            int(s.Profile),
+		Level:              int(s.Level),
+		SideData:           sideData,
+		Tags:               make(map[string]string), // Tags are not packed in CBOR
+	}
+}
+
+// UnpackStreamProbesFromCBOR unpacks a CBOR-encoded byte array back into stream information
+// This is the counterpart to pack_stream_probes_to_cbor() in C
+func UnpackStreamProbesFromCBOR(cborData []byte) ([]StreamInfo, error) {
+	if len(cborData) == 0 {
+		return nil, fmt.Errorf("empty CBOR data")
+	}
+
+	// The CBOR data is packed as an array of stream info maps
+	var streamsCBOR []StreamInfoCBOR
+
+	// Unmarshal the CBOR data
+	if err := cbor.Unmarshal(cborData, &streamsCBOR); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal CBOR data: %w", err)
+	}
+
+	// Convert to StreamInfo structs
+	streams := make([]StreamInfo, len(streamsCBOR))
+	for i, streamCBOR := range streamsCBOR {
+		streams[i] = streamCBOR.ToStreamInfo()
+	}
+
+	return streams, nil
+}
+
+// getCodecTypeName maps codec type integer to string name
+// Based on AVMediaType enum from FFmpeg
+func getCodecTypeName(codecType uint32) string {
+	switch codecType {
+	case 0:
+		return "unknown"
+	case 1:
+		return "video"
+	case 2:
+		return "audio"
+	case 3:
+		return "data"
+	case 4:
+		return "subtitle"
+	case 5:
+		return "attachment"
+	default:
+		return fmt.Sprintf("unknown_%d", codecType)
+	}
+}
+
+// getFieldOrderName maps field order integer to string name
+// Based on AVFieldOrder enum from FFmpeg
+func getFieldOrderName(fieldOrder uint32) string {
+	switch fieldOrder {
+	case 0:
+		return "unknown"
+	case 1:
+		return "progressive"
+	case 2:
+		return "tt" // top coded_first, top displayed first
+	case 3:
+		return "bb" // bottom coded first, bottom displayed first
+	case 4:
+		return "tb" // top coded first, bottom displayed first
+	case 5:
+		return "bt" // bottom coded first, top displayed first
+	default:
+		return fmt.Sprintf("unknown_%d", fieldOrder)
+	}
+}
+
+// UnpackStreamProbesFromCBORToProbeInfo is a convenience function that creates a ProbeInfo
+// struct with the unpacked stream information (container info will be empty)
+func UnpackStreamProbesFromCBORToProbeInfo(cborData []byte) (*ProbeInfo, error) {
+	streams, err := UnpackStreamProbesFromCBOR(cborData)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ProbeInfo{
+		ContainerInfo: ContainerInfo{
+			Duration:   0,  // Not available in CBOR data
+			FormatName: "", // Not available in CBOR data
+		},
+		StreamInfo: streams,
+	}, nil
+}

--- a/unpack_test.go
+++ b/unpack_test.go
@@ -1,0 +1,68 @@
+package avpipe
+
+import (
+	"testing"
+
+	"github.com/fxamacker/cbor/v2"
+)
+
+func TestUnpackStreamProbesFromCBOR(t *testing.T) {
+	// This is a simple test to verify the functionality works
+	// You would replace this with actual CBOR data from your C function
+
+	// Create test data that matches the expected structure
+	testData := []StreamInfoCBOR{
+		{
+			StreamIndex: 0,
+			StreamId:    1,
+			CodecType:   1,  // video
+			CodecID:     27, // H.264
+			CodecName:   "h264",
+			Width:       1920,
+			Height:      1080,
+			TimeBase: AVRational{
+				Num: 1,
+				Den: 25,
+			},
+			FrameRate: AVRational{
+				Num: 25,
+				Den: 1,
+			},
+		},
+	}
+
+	// Encode to CBOR
+	cborData, err := cbor.Marshal(testData)
+	if err != nil {
+		t.Fatalf("Failed to marshal test data: %v", err)
+	}
+
+	// Now test unpacking
+	streams, err := UnpackStreamProbesFromCBOR(cborData)
+	if err != nil {
+		t.Fatalf("Failed to unpack CBOR data: %v", err)
+	}
+
+	if len(streams) != 1 {
+		t.Fatalf("Expected 1 stream, got %d", len(streams))
+	}
+
+	stream := streams[0]
+	if stream.StreamIndex != 0 {
+		t.Errorf("Expected stream index 0, got %d", stream.StreamIndex)
+	}
+
+	if stream.CodecType != "video" {
+		t.Errorf("Expected codec type 'video', got '%s'", stream.CodecType)
+	}
+
+	if stream.Width != 1920 {
+		t.Errorf("Expected width 1920, got %d", stream.Width)
+	}
+
+	if stream.Height != 1080 {
+		t.Errorf("Expected height 1080, got %d", stream.Height)
+	}
+
+	t.Logf("Successfully unpacked stream: %+v", stream)
+}

--- a/unpack_test.go
+++ b/unpack_test.go
@@ -8,7 +8,6 @@ import (
 
 func TestUnpackStreamProbesFromCBOR(t *testing.T) {
 	// This is a simple test to verify the functionality works
-	// You would replace this with actual CBOR data from your C function
 
 	// Create test data that matches the expected structure
 	testData := []StreamInfoCBOR{


### PR DESCRIPTION
This pull request introduces support for packing and transmitting stream information as CBOR blobs AVPipe. The changes include new CBOR serialization logic in the C code, corresponding handling and decoding in Go, updates to build scripts for libcbor support, and enhancements to tests to verify this functionality.

**Note this pull requires [libcbor](https://github.com/PJK/libcbor)**


**Support for CBOR-encoded stream info:**

* Added a new stat type `in_stat_data_stream_info` to both C (`avpipe_xc.h`) and Go (`goavpipe/structs.go`) enums, with corresponding string representations. 
* Implemented a function in C (`pack_stream_probes_to_cbor`) to serialize an array of `stream_info_t` structures into a CBOR blob using libcbor, and integrated this into the main AVPipe processing flow. The CBOR blob is passed to the Go layer via the input context. 
* In Go, added logic to receive and decode the CBOR blob using a new case in the `InStat` handler, converting it to a slice of `StreamInfo` and passing it to the input's `Stat` method.
