### PR TITLE
Jan/tc malloc in tests

### DIFF
--- a/DEBUG_BUILD_README.md
+++ b/DEBUG_BUILD_README.md
@@ -1,0 +1,265 @@
+# Debug Build Guide for avpipe
+
+## Overview
+This guide explains how to build avpipe with debug symbols for debugging with GDB, analyzing memory leaks, and investigating crashes.
+
+## Quick Start
+
+### Build Debug Version
+```bash
+make avpipe-debug
+```
+
+This creates:
+- `avpipe.debug` - Go binary with debug symbols
+- C libraries in subdirectories built with `-g -O0 -DDEBUG` flags
+
+### Run with GDB
+```bash
+gdb ./avpipe.debug
+(gdb) run <arguments>
+```
+
+### Run Tests with Debug Symbols
+```bash
+go test -v -gcflags="all=-N -l" -run TestMXF_H265MezMaker
+```
+
+## Debug Build Features
+
+### Go Binary Debug Flags
+- `-gcflags="all=-N -l"`
+  - `-N` - Disables optimizations (preserves variable values)
+  - `-l` - Disables inlining (preserves function call stack)
+
+### C Library Debug Flags
+- `-g` - Includes debug symbols (DWARF format)
+- `-O0` - Disables optimizations (preserves code structure)
+- `-DDEBUG` - Defines DEBUG macro for conditional debug code
+
+## Debug Build Control
+
+The `DEBUG` variable controls C compilation:
+
+### Build Everything with Debug Symbols
+```bash
+make DEBUG=1
+```
+
+### Build Only C Libraries with Debug Symbols
+```bash
+make debug-libs
+```
+
+### Build Individual Components with Debug
+```bash
+make -C utils DEBUG=1
+make -C libavpipe DEBUG=1
+make -C exc DEBUG=1
+make -C elvxc DEBUG=1
+```
+
+## Debugging Workflow
+
+### 1. Build with Debug Symbols
+```bash
+make clean
+make avpipe-debug
+```
+
+### 2. Run with GDB
+```bash
+# Basic debugging
+gdb ./avpipe.debug
+
+# With arguments
+gdb --args ./avpipe.debug --config sample.json
+
+# Attach to running process
+gdb -p <pid>
+```
+
+### 3. Useful GDB Commands
+```gdb
+# Set breakpoint
+break avpipe.c:123
+break xcTranscode
+
+# Run program
+run
+
+# Step through code
+next          # Step over
+step          # Step into
+continue      # Continue execution
+
+# Inspect variables
+print variable_name
+print *pointer
+info locals
+
+# Backtrace
+bt            # Full backtrace
+bt full       # Backtrace with local variables
+
+# Core dump analysis
+gdb ./avpipe.debug core
+```
+
+## Debugging with tcmalloc
+
+Combine debug builds with memory leak detection:
+
+```bash
+# Build debug version
+make avpipe-debug
+
+# Run tests with tcmalloc and debug symbols
+LD_PRELOAD=/lib/x86_64-linux-gnu/libtcmalloc.so.4 \
+HEAPCHECK=normal \
+PPROF_PATH=/bin/false \
+go test -v -gcflags="all=-N -l" -run TestMXF_H265MezMaker
+```
+
+Or use the provided script:
+```bash
+./run_tests_leak_check.sh -run TestMXF_H265MezMaker
+```
+
+## Symbol Verification
+
+### Check Go Binary for Symbols
+```bash
+go tool nm ./avpipe.debug | grep main.main
+objdump -g ./avpipe.debug | head -20
+```
+
+### Check C Libraries for Symbols
+```bash
+objdump -g lib/libavpipe.a | head -20
+nm -C lib/libavpipe.a | grep avpipe
+```
+
+### Check Shared Library Symbols
+```bash
+nm -D /lib/x86_64-linux-gnu/libtcmalloc.so.4 | grep malloc
+```
+
+## Core Dump Analysis
+
+### Enable Core Dumps
+```bash
+ulimit -c unlimited
+```
+
+### Generate Core on Crash
+```bash
+./avpipe.debug <args>
+# If it crashes, core file is created
+```
+
+### Analyze Core Dump
+```bash
+gdb ./avpipe.debug core
+(gdb) bt full
+(gdb) info threads
+(gdb) thread <n>
+(gdb) frame <n>
+(gdb) print <variable>
+```
+
+## Performance Considerations
+
+### Debug Build Performance
+- Debug builds are **significantly slower** than release builds
+- `-O0` disables all optimizations
+- Use debug builds only for debugging, not production
+
+### Storage Requirements
+- Debug symbols increase binary size substantially
+- Plan for 5-10x larger binaries
+- Temporary build artifacts also larger
+
+## Common Issues
+
+### Missing Symbols in Backtrace
+**Problem**: Stack traces show `??` or memory addresses
+**Solution**: Ensure built with `-g` flag and `-gcflags="all=-N -l"`
+
+### Optimized Code Behavior
+**Problem**: Variables show `<optimized out>` in GDB
+**Solution**: Use `-O0` flag (already set in debug builds)
+
+### CGO Symbol Resolution
+**Problem**: Can't see C function names in Go stack traces
+**Solution**: Both Go and C must be built with debug flags
+
+### PPROF Errors During Leak Detection
+**Problem**: tcmalloc tries to run pprof but fails
+**Solution**: Set `PPROF_PATH=/bin/false` (included in scripts)
+
+## Makefile Targets
+
+| Target | Description |
+|--------|-------------|
+| `make avpipe` | Build release version (optimized, no symbols) |
+| `make avpipe-debug` | Build debug version (symbols, no optimization) |
+| `make debug-libs` | Build only C libraries with debug symbols |
+| `make clean` | Clean all build artifacts |
+| `make test-tcmalloc` | Run tests with tcmalloc leak detection |
+
+## Environment Variables
+
+### Debug Build Control
+- `DEBUG=1` - Enable debug flags in C compilation
+
+### GDB Configuration
+- `set print pretty on` - Pretty-print structures
+- `set pagination off` - Disable paging for long output
+- `set logging on` - Log GDB output to file
+
+### Core Dump Configuration
+- `ulimit -c unlimited` - Enable unlimited core dump size
+- `sysctl kernel.core_pattern` - Check core dump location
+
+## See Also
+
+- [TCMALLOC_README.md](TCMALLOC_README.md) - Memory leak detection setup
+- [TCMALLOC_SETUP_SUMMARY.md](TCMALLOC_SETUP_SUMMARY.md) - Quick tcmalloc reference
+- [doc/dev.md](doc/dev.md) - Development documentation
+
+## Example Debug Session
+
+```bash
+# 1. Build debug version
+make clean
+make avpipe-debug
+
+# 2. Run specific test with leak detection and symbols
+LD_PRELOAD=/lib/x86_64-linux-gnu/libtcmalloc.so.4 \
+HEAPCHECK=normal \
+PPROF_PATH=/bin/false \
+go test -v -gcflags="all=-N -l" -run TestMXF_H265MezMaker 2>&1 | tee test.log
+
+# 3. If crash occurs, analyze with GDB
+gdb ./avpipe.test core
+(gdb) bt full
+(gdb) frame 5
+(gdb) print *ctx
+(gdb) info locals
+
+# 4. Set breakpoint and re-run
+gdb --args ./avpipe.test -test.run TestMXF_H265MezMaker
+(gdb) break avpipe.c:456
+(gdb) run
+(gdb) next
+(gdb) print variable_name
+```
+
+## Tips
+
+1. **Always clean before debug builds**: `make clean` prevents mixing debug and release object files
+2. **Use test binaries**: Go creates `<package>.test` binary that can be run directly or with GDB
+3. **Combine with tcmalloc**: Debug symbols make tcmalloc leak reports much more useful
+4. **Check symbols early**: Verify symbols exist before lengthy debug sessions
+5. **Save GDB sessions**: Use `set logging on` to record debugging sessions

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,18 @@ avpipe:
 	go build -v
 	mkdir -p ./O
 
+avpipe-debug: debug-libs
+	@echo "Building avpipe with debug symbols..."
+	go build -v -gcflags="all=-N -l" -o avpipe.debug
+	mkdir -p ./O
+
+debug-libs:
+	@echo "Building C libraries with debug symbols..."
+	$(MAKE) -C utils DEBUG=1
+	$(MAKE) -C libavpipe DEBUG=1
+	$(MAKE) -C exc DEBUG=1
+	$(MAKE) -C elvxc DEBUG=1
+
 libavpipego: $(OBJS)
 	@(if [ ! -d $(LIBDIR) ]; then mkdir $(LIBDIR); fi)
 	@echo Making libavpipe_handler
@@ -54,3 +66,9 @@ endif
 
 test:
 	@./run_tests.sh
+
+test-tcmalloc:
+	@./run_tests_with_tcmalloc.sh
+
+test-tcmalloc-strict:
+	@HEAPCHECK=strict ./run_tests_with_tcmalloc.sh

--- a/TCMALLOC_README.md
+++ b/TCMALLOC_README.md
@@ -1,0 +1,141 @@
+# Memory Leak Detection with tcmalloc
+
+This directory contains tools for detecting memory leaks in avpipe using Google's tcmalloc.
+
+## Prerequisites
+
+Install tcmalloc (Google perftools):
+
+```bash
+# Ubuntu/Debian
+sudo apt-get install libtcmalloc-minimal4 google-perftools
+
+# For heap profiling analysis, also install:
+sudo apt-get install google-perftools
+```
+
+## Usage
+
+### 1. Quick Leak Detection (Recommended)
+
+Run tests with basic leak detection:
+
+```bash
+# Test all
+./run_tests_leak_check.sh
+
+# Test specific test
+./run_tests_leak_check.sh TestMXF_H265MezMaker
+
+# More aggressive leak checking
+HEAPCHECK=strict ./run_tests_leak_check.sh TestMXF_H265MezMaker
+```
+
+### 2. With Heap Profiling
+
+Run tests with detailed heap profiling:
+
+```bash
+# Basic profiling
+./run_tests_with_tcmalloc.sh TestProbe
+
+# Strict leak checking
+HEAPCHECK=strict ./run_tests_with_tcmalloc.sh TestProbe
+
+# Most aggressive
+HEAPCHECK=draconian ./run_tests_with_tcmalloc.sh TestProbe
+```
+
+### 3. Using Make Targets
+
+```bash
+# Quick leak detection
+make test-tcmalloc
+
+# Strict leak checking
+make test-tcmalloc-strict
+```
+
+## Interpreting Results
+
+### Exit Codes
+- `0`: No leaks detected, tests passed
+- `1`: Tests failed or memory leaks detected
+
+### Leak Detection Levels
+
+- **`HEAPCHECK=normal`** (default): Basic leak detection
+- **`HEAPCHECK=strict`**: More thorough, catches more leaks but may have false positives
+- **`HEAPCHECK=draconian`**: Most aggressive, highest false positive rate
+
+### Understanding Output
+
+When leaks are detected, you'll see output like:
+
+```
+Leak check _main_ detected leaks of 9342 bytes in 7 objects
+The 5 largest leaks:
+  Leak of 4096 bytes in 1 objects allocated from:
+    @ 0x7f8b9c8d1234
+    @ 0x7f8b9c8d5678
+```
+
+This indicates:
+- Total leaked memory: 9342 bytes
+- Number of leaked objects: 7
+- Stack traces showing where memory was allocated
+
+## Analyzing Heap Profiles
+
+If heap profiles are generated (`/tmp/avpipe_heap*.heap`):
+
+```bash
+# Text summary
+pprof --text ./avpipe.test /tmp/avpipe_heap*.heap
+
+# Interactive web interface
+pprof -http=:8080 ./avpipe.test /tmp/avpipe_heap*.heap
+
+# Generate PDF
+pprof --pdf ./avpipe.test /tmp/avpipe_heap*.heap > heap.pdf
+```
+
+## Common Issues
+
+### "No such file or directory" for tcmalloc
+Install the library:
+```bash
+sudo apt-get install libtcmalloc-minimal4
+```
+
+### False Positives
+- Some libraries may report false leaks (especially with CGO)
+- Use `HEAPCHECK=normal` (default) to reduce false positives
+- Known false positives can be suppressed (see tcmalloc documentation)
+
+### Tests Timeout
+- Heap checking adds overhead
+- Increase timeout: `-timeout 60m`
+
+## Environment Variables
+
+- `HEAPCHECK`: Leak detection level (normal/strict/draconian)
+- `HEAPPROFILE`: Where to write heap profiles (default: /tmp/avpipe_heap)
+- `TCMALLOC_VERBOSE`: Enable verbose output (0/1)
+- `MALLOCSTATS`: Dump malloc stats at exit (0/1)
+- `LD_PRELOAD`: Path to tcmalloc library (auto-detected)
+
+## CGO Integration
+
+The avpipe.go file includes:
+```go
+// #cgo LDFLAGS: -ltcmalloc
+```
+
+This links tcmalloc into the Go binary, but using `LD_PRELOAD` (as done in the scripts) is more reliable and flexible.
+
+## References
+
+- [tcmalloc Heap Checker](https://gperftools.github.io/gperftools/heap_checker.html)
+- [Google Performance Tools](https://github.com/gperftools/gperftools)
+- [pprof Documentation](https://github.com/google/pprof)

--- a/avpipe.c
+++ b/avpipe.c
@@ -650,7 +650,7 @@ out_write_packet(
         outctx->write_pos += bwritten;
     }
 
-    if ((outctx->type == avpipe_video_fmp4_segment && 
+    if ((outctx->type == avpipe_video_fmp4_segment &&
         outctx->written_bytes - outctx->write_reported > VIDEO_BYTES_WRITE_REPORT) ||
         (outctx->type == avpipe_audio_fmp4_segment &&
         outctx->written_bytes - outctx->write_reported > AUDIO_BYTES_WRITE_REPORT)) {
@@ -872,7 +872,7 @@ xc_table_cancel(
                     /* Close and purge the channel */
                     elv_channel_close(xctx->inctx->udp_channel, 1);
                     pthread_join(xctx->inctx->utid, NULL);
-                } 
+                }
             } else {
                 elv_err("xc_table_cancel index=%d doesn't match with handle=%d at %d",
                     xc_table[i]->xctx->index, handle, i);
@@ -1021,7 +1021,7 @@ end_tx:
 int
 xc_cancel(
     int32_t handle)
-{ 
+{
     return xc_table_cancel(handle);
 }
 
@@ -1147,7 +1147,7 @@ read_next_input:
         fd = *((int64_t *)(c->opaque));
 
 #if 0
-        /* PENDING(RM) complete this for multiple mez inputs */ 
+        /* PENDING(RM) complete this for multiple mez inputs */
         if (new_video)
             in_mux_ctx->video.header_size = read_header(fd, in_mux_ctx->mux_type);
         else if (new_audio)

--- a/avpipe.go
+++ b/avpipe.go
@@ -29,6 +29,7 @@ package avpipe
 // #cgo CFLAGS: -I${SRCDIR}/utils/include
 // #cgo LDFLAGS: -L${SRCDIR}
 // #cgo linux LDFLAGS: -Wl,-rpath,$ORIGIN/../lib
+// #cgo LDFLAGS: -ltcmalloc
 
 // #include <string.h>
 // #include <stdlib.h>

--- a/avpipe_test.go
+++ b/avpipe_test.go
@@ -1825,7 +1825,7 @@ func TestMXF_H265MezMaker(t *testing.T) {
 		// Test takes ~2 minutes with HD MPEG-2 source
 		t.Skip("SKIPPING " + f)
 	}
-	url := "./media/BBB0_HD_8_XDCAM_120s_CCBYblendercloud.mxf"
+	url := "./media/SIN5_4K_MOS_J2K_60s_CCBYblendercloud.mxf"
 	if fileMissing(url, fn()) {
 		return
 	}
@@ -1840,20 +1840,21 @@ func TestMXF_H265MezMaker(t *testing.T) {
 		StartSegmentStr:   "1",
 		SegDuration:       "30.03",
 		Ecodec:            "libx265",
-		Dcodec:            "", // Auto-detect MPEG-2 decoder
-		EncHeight:         -1, // Keep original 720p resolution
+		Dcodec:            "",
+		EncHeight:         -1,
 		EncWidth:          -1,
 		XcType:            goavpipe.XcVideo,
 		StreamId:          -1,
 		Url:               url,
 		DebugFrameLevel:   debugFrameLevel,
-		ForceKeyInt:       120, // ~2 seconds at 59.94fps
+		ForceKeyInt:       48,
+		BitDepth:          8,
 	}
 
 	xcTestResult := &XcTestResult{
 		mezFile:   []string{fmt.Sprintf("%s/vsegment-1.mp4", outputDir)},
-		timeScale: 60000, // Matches input timebase (60000/1001)
-		level:     120,   // H.265 Level 4.0 for 720p60 (encoded as 120)
+		timeScale: 24000,
+		level:     150,
 		pixelFmt:  "yuv420p",
 	}
 

--- a/avpipe_test.go
+++ b/avpipe_test.go
@@ -1822,7 +1822,7 @@ func TestIrregularTsMezMaker_1_10000(t *testing.T) {
 func TestMXF_H265MezMaker(t *testing.T) {
 	f := fn()
 	if testing.Short() {
-		// Test takes ~2 minutes with HD MPEG-2 source
+		// Test takes ~2 minutes with 4K JPEG2000 MXF source
 		t.Skip("SKIPPING " + f)
 	}
 	url := "./media/SIN5_4K_MOS_J2K_60s_CCBYblendercloud.mxf"

--- a/avpipe_test.go
+++ b/avpipe_test.go
@@ -1822,10 +1822,10 @@ func TestIrregularTsMezMaker_1_10000(t *testing.T) {
 func TestMXF_H265MezMaker(t *testing.T) {
 	f := fn()
 	if testing.Short() {
-		// 558.20s on 2018 MacBook Pro (2.9 GHz 6-Core i9, 32 GB RAM, Radeon Pro 560X 4 GB)
+		// Test takes ~2 minutes with HD MPEG-2 source
 		t.Skip("SKIPPING " + f)
 	}
-	url := "./media/SIN5_4K_MOS_J2K_60s_CCBYblendercloud.mxf"
+	url := "./media/BBB0_HD_8_XDCAM_120s_CCBYblendercloud.mxf"
 	if fileMissing(url, fn()) {
 		return
 	}
@@ -1840,20 +1840,20 @@ func TestMXF_H265MezMaker(t *testing.T) {
 		StartSegmentStr:   "1",
 		SegDuration:       "30.03",
 		Ecodec:            "libx265",
-		Dcodec:            "jpeg2000",
-		EncHeight:         -1,
+		Dcodec:            "", // Auto-detect MPEG-2 decoder
+		EncHeight:         -1, // Keep original 720p resolution
 		EncWidth:          -1,
 		XcType:            goavpipe.XcVideo,
 		StreamId:          -1,
 		Url:               url,
 		DebugFrameLevel:   debugFrameLevel,
-		ForceKeyInt:       48,
+		ForceKeyInt:       120, // ~2 seconds at 59.94fps
 	}
 
 	xcTestResult := &XcTestResult{
 		mezFile:   []string{fmt.Sprintf("%s/vsegment-1.mp4", outputDir)},
-		timeScale: 24000,
-		level:     150,
+		timeScale: 60000, // Matches input timebase (60000/1001)
+		level:     120,   // H.265 Level 4.0 for 720p60 (encoded as 120)
 		pixelFmt:  "yuv420p",
 	}
 

--- a/rules.make
+++ b/rules.make
@@ -7,12 +7,24 @@ BINDIR=bin
 LIBDIR=lib
 INCDIR=include
 
+# Debug build support
+DEBUG ?= 0
+ifeq ($(DEBUG), 1)
+	CFLAGS_DEBUG := -g -O0 -DDEBUG
+	LDFLAGS_DEBUG := -g
+else
+	CFLAGS_DEBUG :=
+	LDFLAGS_DEBUG :=
+endif
+
 OSNAME := $(shell uname -s)
 LDFLAGS := \
 		-lavpipe \
 		-lutils \
-		$(shell pkg-config --libs libavfilter libavcodec libavformat libavdevice libswresample libavresample libswscale libavutil libpostproc srt)
-CFLAGS := $(shell pkg-config --cflags libavfilter libavcodec libavformat libavdevice libswresample libavresample libswscale libavutil libpostproc srt)
+		$(shell pkg-config --libs libavfilter libavcodec libavformat libavdevice libswresample libavresample libswscale libavutil libpostproc srt) \
+		$(LDFLAGS_DEBUG)
+CFLAGS := $(shell pkg-config --cflags libavfilter libavcodec libavformat libavdevice libswresample libavresample libswscale libavutil libpostproc srt) \
+		$(CFLAGS_DEBUG)
 
 ifeq ($(OSNAME), Darwin)
 	LDFLAGS := ${LDFLAGS} \

--- a/run_tests_leak_check.sh
+++ b/run_tests_leak_check.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+#
+# Run avpipe tests with tcmalloc heap leak detection (minimal profiling)
+#
+# Usage:
+#   ./run_tests_leak_check.sh [test_name]
+#
+# Examples:
+#   ./run_tests_leak_check.sh                    # Run all tests
+#   ./run_tests_leak_check.sh TestMXF_H265MezMaker  # Run specific test
+#
+
+set -e
+
+# Important: We need to build the test binary FIRST without LD_PRELOAD,
+# otherwise tcmalloc will check the compiler itself for leaks!
+
+# Find tcmalloc library
+TCMALLOC_LIB=""
+for lib in libtcmalloc.so.4 libtcmalloc.so libtcmalloc_minimal.so.4 libtcmalloc_minimal.so; do
+    LIB_PATH=$(ldconfig -p | grep "$lib" | awk '{print $NF}' | head -1)
+    if [ -n "$LIB_PATH" ] && [ -f "$LIB_PATH" ]; then
+        TCMALLOC_LIB="$LIB_PATH"
+        break
+    fi
+done
+
+if [ -z "$TCMALLOC_LIB" ]; then
+    echo "ERROR: tcmalloc library not found!"
+    echo "Please install: sudo apt-get install libtcmalloc-minimal4"
+    exit 1
+fi
+
+# tcmalloc heap checker environment variables
+HEAPCHECK="${HEAPCHECK:-normal}"
+
+# Disable verbose output unless requested
+TCMALLOC_VERBOSE="${TCMALLOC_VERBOSE:-0}"
+
+# Disable pprof symbol resolution to avoid errors
+# The -gcflags will provide symbols in stack traces anyway
+PPROF_PATH="/bin/false"
+
+echo "======================================"
+echo "Running avpipe tests with leak detection"
+echo "======================================"
+echo "Using: $TCMALLOC_LIB"
+echo "HEAPCHECK: $HEAPCHECK"
+echo "======================================"
+echo ""
+
+# Step 1: Build the test binary WITHOUT tcmalloc to avoid checking the compiler
+echo "Building test binary with debug symbols..."
+if [ -z "$1" ]; then
+    go test -c -gcflags="all=-N -l" -o avpipe.test
+else
+    go test -c -gcflags="all=-N -l" -o avpipe.test
+fi
+
+if [ $? -ne 0 ]; then
+    echo "ERROR: Failed to build test binary"
+    exit 1
+fi
+echo "Build successful!"
+echo ""
+
+# Step 2: Run the test binary with tcmalloc preloaded
+echo "Running tests with leak detection..."
+if [ -z "$1" ]; then
+    LD_PRELOAD="$TCMALLOC_LIB" \
+    HEAPCHECK="$HEAPCHECK" \
+    PPROF_PATH="$PPROF_PATH" \
+    TCMALLOC_VERBOSE="$TCMALLOC_VERBOSE" \
+    ./avpipe.test -test.v -test.timeout 30m
+else
+    LD_PRELOAD="$TCMALLOC_LIB" \
+    HEAPCHECK="$HEAPCHECK" \
+    PPROF_PATH="$PPROF_PATH" \
+    TCMALLOC_VERBOSE="$TCMALLOC_VERBOSE" \
+    ./avpipe.test -test.v -test.timeout 30m -test.run "$1"
+fi
+
+EXIT_CODE=$?
+echo ""
+if [ $EXIT_CODE -eq 0 ]; then
+    echo "✓ Tests passed with no memory leaks detected"
+else
+    echo "✗ Tests failed or memory leaks detected (exit code: $EXIT_CODE)"
+fi
+
+exit $EXIT_CODE

--- a/run_tests_with_tcmalloc.sh
+++ b/run_tests_with_tcmalloc.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+#
+# Run avpipe tests with tcmalloc heap checking
+#
+# Usage:
+#   ./run_tests_with_tcmalloc.sh [test_name]
+#
+# Examples:
+#   ./run_tests_with_tcmalloc.sh                    # Run all tests
+#   ./run_tests_with_tcmalloc.sh TestMXF_H265MezMaker  # Run specific test
+#
+
+set -e
+
+# Find tcmalloc library
+TCMALLOC_LIB=""
+for lib in libtcmalloc.so.4 libtcmalloc.so libtcmalloc_minimal.so.4 libtcmalloc_minimal.so; do
+    LIB_PATH=$(ldconfig -p | grep "$lib" | awk '{print $NF}' | head -1)
+    if [ -n "$LIB_PATH" ] && [ -f "$LIB_PATH" ]; then
+        TCMALLOC_LIB="$LIB_PATH"
+        break
+    fi
+done
+
+if [ -z "$TCMALLOC_LIB" ]; then
+    echo "ERROR: tcmalloc library not found!"
+    echo "Please install: sudo apt-get install libtcmalloc-minimal4"
+    exit 1
+fi
+
+# tcmalloc heap checker environment variables
+# HEAPCHECK=normal   - Check for memory leaks
+# HEAPCHECK=strict   - More aggressive leak checking
+# HEAPCHECK=draconian - Most aggressive leak checking
+export HEAPCHECK="${HEAPCHECK:-normal}"
+
+# Where to write the heap profile
+export HEAPPROFILE="${HEAPPROFILE:-/tmp/avpipe_heap}"
+
+# Enable tcmalloc verbose output
+export TCMALLOC_VERBOSE="${TCMALLOC_VERBOSE:-1}"
+
+# Dump heap stats at exit
+export MALLOCSTATS="${MALLOCSTATS:-1}"
+
+# Preload tcmalloc
+export LD_PRELOAD="$TCMALLOC_LIB${LD_PRELOAD:+:$LD_PRELOAD}"
+
+# Disable pprof symbol resolution to avoid the -symbols error
+# tcmalloc will still report leaks, just without attempting to symbolize
+export PPROF_PATH="${PPROF_PATH:-/bin/false}"
+
+# Set pprof path if available and user wants symbolization
+if [ "${USE_PPROF:-0}" = "1" ] && command -v pprof &> /dev/null; then
+    export PPROF_PATH=$(command -v pprof)
+fi
+
+# Go test flags for better debugging
+GO_TEST_FLAGS="${GO_TEST_FLAGS:--v -timeout 30m}"
+
+echo "======================================"
+echo "Running avpipe tests with tcmalloc"
+echo "======================================"
+echo "TCMALLOC_LIB: $TCMALLOC_LIB"
+echo "LD_PRELOAD: $LD_PRELOAD"
+echo "HEAPCHECK: $HEAPCHECK"
+echo "HEAPPROFILE: $HEAPPROFILE"
+echo "TCMALLOC_VERBOSE: $TCMALLOC_VERBOSE"
+echo "GO_TEST_FLAGS: $GO_TEST_FLAGS"
+echo "======================================"
+echo ""
+
+# Run the tests with symbols and debug info
+# -gcflags="all=-N -l" keeps symbols for better stack traces
+if [ -z "$1" ]; then
+    # Run all tests
+    go test $GO_TEST_FLAGS -gcflags="all=-N -l"
+else
+    # Run specific test
+    go test $GO_TEST_FLAGS -gcflags="all=-N -l" -run "$1"
+fi
+
+EXIT_CODE=$?
+
+echo ""
+echo "======================================"
+echo "Test run complete (exit code: $EXIT_CODE)"
+echo "======================================"
+if [ -f "${HEAPPROFILE}"* ]; then
+    echo "Heap profiles written to: ${HEAPPROFILE}*"
+    echo ""
+    echo "To analyze heap profiles, use:"
+    echo "  pprof --text ./avpipe.test ${HEAPPROFILE}.*.heap"
+fi
+
+exit $EXIT_CODE


### PR DESCRIPTION
Changes include:

1. **A bunch of the changes simply remove extra whitespace.**  
2. This does require libopenjpeg and gpertools to be installed on the machine that builds ffmpeg or avpipe. 
- `sudo apt-get install libopenjp2-7-dev` on Ubuntu
- `brew install openjpeg` on the Mac. 
3.  Includes a debug build for avpipe and test harness for running under tcmalloc heapcheck/profile
4. ffmpeg and ffprobe will now handle jpeg2000 read and write along with avpipe.
5. New jpeg2000 version of test file pushed to gcloud.  The old one was corrupted and written by our old ffmpeg
6. Documentation for building and debugging including tcmalloc
7. Branch `jan/enable-libopenjpeg` on elv-toolchain to build a new ffmpeg with libopenjpeg support