### PR TITLE
add function RemoveUrlMuxIOHandler and call it

### DIFF
--- a/avpipe.go
+++ b/avpipe.go
@@ -594,6 +594,7 @@ func AVPipeCloseMuxOutput(fd C.int64_t) C.int {
 	if outHandler == nil {
 		return C.int(-1)
 	}
+	defer goavpipe.DeleteMuxOutputHandler(int64(fd))
 
 	err := outHandler.Close()
 	if err != nil {

--- a/avpipe_test.go
+++ b/avpipe_test.go
@@ -16,12 +16,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/eluv-io/avpipe"
 	"github.com/eluv-io/avpipe/elvxc/cmd"
 	"github.com/eluv-io/avpipe/goavpipe"
 	"github.com/eluv-io/avpipe/xc"
 	"github.com/eluv-io/log-go"
-	"github.com/stretchr/testify/assert"
 )
 
 const baseOutPath = "test_out"
@@ -1959,6 +1960,7 @@ func TestABRMuxing(t *testing.T) {
 	log.Debug(f, "muxSpec", string(muxSpec))
 
 	goavpipe.InitUrlMuxIOHandler(url, &cmd.AVCmdMuxInputOpener{URL: url}, &cmd.AVCmdMuxOutputOpener{})
+	defer goavpipe.RemoveUrlMuxIOHandler(url)
 	params.Url = url
 	params.Timecode = "01:00:00:00"
 	err := avpipe.Mux(params)

--- a/elvxc/cmd/mux.go
+++ b/elvxc/cmd/mux.go
@@ -8,9 +8,10 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/spf13/cobra"
+
 	"github.com/eluv-io/avpipe"
 	"github.com/eluv-io/avpipe/goavpipe"
-	"github.com/spf13/cobra"
 )
 
 type AVCmdMuxInputOpener struct {
@@ -229,6 +230,7 @@ func doMux(cmd *cobra.Command, args []string) error {
 	}
 
 	goavpipe.InitUrlMuxIOHandler(filename, &AVCmdMuxInputOpener{URL: filename}, &AVCmdMuxOutputOpener{})
+	defer goavpipe.RemoveUrlMuxIOHandler(filename)
 
 	return avpipe.Mux(params)
 }

--- a/goavpipe/handlers.go
+++ b/goavpipe/handlers.go
@@ -265,6 +265,14 @@ func PutMuxOutputOpener(fd int64, muxOutputHandler OutputHandler) {
 	gMutex.Unlock()
 }
 
+// DeleteMuxOutputHandler removes the mux output handler entry for fd.
+// Called from AVPipeCloseMuxOutput.
+func DeleteMuxOutputHandler(fd int64) {
+	gMutex.Lock()
+	delete(gMuxHandlers, fd)
+	gMutex.Unlock()
+}
+
 func GetOutputOpenerByHandler(h int64) OutputOpener {
 	gMutex.Lock()
 	defer gMutex.Unlock()

--- a/goavpipe/handlers.go
+++ b/goavpipe/handlers.go
@@ -7,61 +7,64 @@ import (
 const traceIo bool = false
 
 type InputOpener interface {
+	// Open returns an InputHandler or an error
 	// fd determines uniquely opening input.
 	// url determines input string for transcoding
 	Open(fd int64, url string) (InputHandler, error)
 }
 
 type InputHandler interface {
-	// Reads from input stream into buf.
+	// Read reads from input stream into buf.
 	// Returns (0, nil) to indicate EOF.
 	Read(buf []byte) (int, error)
 
-	// Seeks to specific offset of the input.
+	// Seek to specific offset of the input.
 	Seek(offset int64, whence int) (int64, error)
 
-	// Closes the input.
+	// Close the input.
 	Close() error
 
-	// Returns the size of input, if the size is not known returns 0 or -1.
+	// Size returns the size of input, if the size is not known returns 0 or -1.
 	Size() int64
 
-	// Reports some stats
+	// Stat reports some stats
 	Stat(streamIndex int, statType AVStatType, statArgs interface{}) error
 }
 
 type OutputOpener interface {
+	// Open returns an OutputHandler or an error
 	// h determines uniquely opening input.
 	// fd determines uniquely opening output.
-	Open(h, fd int64, stream_index, seg_index int, pts int64, out_type AVType) (OutputHandler, error)
+	Open(h, fd int64, streamIndex, segIndex int, pts int64, outType AVType) (OutputHandler, error)
 }
 
 type MuxOutputOpener interface {
+	// Open returns an OutputHandler or an error
 	// url and fd determines uniquely opening output.
-	Open(url string, fd int64, out_type AVType) (OutputHandler, error)
+	Open(url string, fd int64, outType AVType) (OutputHandler, error)
 }
 
 type OutputHandler interface {
-	// Writes encoded stream to the output.
+	// Write writes encoded stream to the output.
 	Write(buf []byte) (int, error)
 
-	// Seeks to specific offset of the output.
+	// Seek to specific offset of the output.
 	Seek(offset int64, whence int) (int64, error)
 
-	// Closes the output.
+	// Close the output.
 	Close() error
 
-	// Reports some stats
+	// Stat reports some stats
 	Stat(streamIndex int, avType AVType, statType AVStatType, statArgs interface{}) error
 }
 
 // Global table of handlers
-var gHandlers map[int64]any = make(map[int64]any)
-var gMuxHandlers map[int64]OutputHandler = make(map[int64]OutputHandler)
-var gURLInputOpeners map[string]InputOpener = make(map[string]InputOpener)             // Keeps InputOpener for specific URL
-var gURLOutputOpeners map[string]OutputOpener = make(map[string]OutputOpener)          // Keeps OutputOpener for specific URL
-var gURLMuxOutputOpeners map[string]MuxOutputOpener = make(map[string]MuxOutputOpener) // Keeps MuxOutputOpener for specific URL
-var gURLOutputOpenersByHandler map[int64]OutputOpener = make(map[int64]OutputOpener)   // Keeps OutputOpener for specific URL
+var gHandlers = make(map[int64]any)
+var gMuxHandlers = make(map[int64]OutputHandler)
+var gURLInputOpeners = make(map[string]InputOpener)           // Keeps InputOpener for specific URL
+var gURLOutputOpeners = make(map[string]OutputOpener)         // Keeps OutputOpener for specific URL
+var gURLMuxOutputOpeners = make(map[string]MuxOutputOpener)   // Keeps MuxOutputOpener for specific URL
+var gURLOutputOpenersByHandler = make(map[int64]OutputOpener) // Keeps OutputOpener for specific URL
 // gHandleNum is used for both FDs and handles so that they will not collide if misused.
 var gHandleNum int64
 var gMutex sync.Mutex
@@ -69,7 +72,7 @@ var gInputOpener InputOpener
 var gOutputOpener OutputOpener
 var gMuxOutputOpener MuxOutputOpener
 
-// Globals wraps the global variables used in avpipe. It should be gradually replaced in the
+// GlobalsT wraps the global variables used in avpipe. It should be gradually replaced in the
 // future, but for now is a global singleton.
 type GlobalsT struct{}
 
@@ -137,7 +140,7 @@ func (g *GlobalsT) GetMuxOutputHandler(fd int64) OutputHandler {
 	return gMuxHandlers[fd]
 }
 
-// This is used to set global input/output opener for avpipe
+// InitIOHandler is used to set global input/output opener for avpipe
 // If there is no specific input/output opener for a URL, the global
 // input/output opener will be used.
 func InitIOHandler(inputOpener InputOpener, outputOpener OutputOpener) {
@@ -145,13 +148,13 @@ func InitIOHandler(inputOpener InputOpener, outputOpener OutputOpener) {
 	gOutputOpener = outputOpener
 }
 
-// Sets the global handlers for muxing (similar to InitIOHandler for transcoding)
+// InitMuxIOHandler sets the global handlers for muxing (similar to InitIOHandler for transcoding)
 func InitMuxIOHandler(inputOpener InputOpener, muxOutputOpener MuxOutputOpener) {
 	gInputOpener = inputOpener
 	gMuxOutputOpener = muxOutputOpener
 }
 
-// This is used to set input/output opener specific to a URL.
+// InitUrlIOHandler is used to set input/output opener specific to a URL.
 // The input/output opener set by this function, is only valid for the URL and will be unset after
 // Xc() or Probe() is complete.
 func InitUrlIOHandler(url string, inputOpener InputOpener, outputOpener OutputOpener) {
@@ -190,7 +193,7 @@ func InitUrlIOHandlerIfNotPresent(url string, inputOpener InputOpener, outputOpe
 	return
 }
 
-// Sets specific IO handler for muxing a url/file (similar to InitUrlIOHandler)
+// InitUrlMuxIOHandler sets specific IO handler for muxing a url/file (similar to InitUrlIOHandler)
 func InitUrlMuxIOHandler(url string, inputOpener InputOpener, muxOutputOpener MuxOutputOpener) {
 	if inputOpener != nil {
 		gMutex.Lock()
@@ -204,6 +207,16 @@ func InitUrlMuxIOHandler(url string, inputOpener InputOpener, muxOutputOpener Mu
 		gMutex.Unlock()
 	}
 	Log.Debug("InitUrlMuxIOHandler", "url", url, "urlInputOpener", inputOpener == nil, "urlOutputOpener", muxOutputOpener == nil)
+}
+
+// RemoveUrlMuxIOHandler removes IO handlers used for muxing a url/file
+func RemoveUrlMuxIOHandler(url string) {
+	gMutex.Lock()
+	delete(gURLInputOpeners, url)
+	delete(gURLMuxOutputOpeners, url)
+	gMutex.Unlock()
+
+	Log.Debug("RemoveUrlMuxIOHandler", "url", url)
 }
 
 func GetInputOpener(url string) InputOpener {

--- a/goavpipe/handlers.go
+++ b/goavpipe/handlers.go
@@ -194,6 +194,7 @@ func InitUrlIOHandlerIfNotPresent(url string, inputOpener InputOpener, outputOpe
 }
 
 // InitUrlMuxIOHandler sets specific IO handler for muxing a url/file (similar to InitUrlIOHandler)
+// To clean up - call RemoveUrlMuxIOHandler.
 func InitUrlMuxIOHandler(url string, inputOpener InputOpener, muxOutputOpener MuxOutputOpener) {
 	if inputOpener != nil {
 		gMutex.Lock()
@@ -259,6 +260,8 @@ func GetMuxOutputOpener(url string) MuxOutputOpener {
 	return gMuxOutputOpener
 }
 
+// PutMuxOutputOpener registers a mux output handler keyed by fd.
+// To clean up - call DeleteMuxOutputHandler.
 func PutMuxOutputOpener(fd int64, muxOutputHandler OutputHandler) {
 	gMutex.Lock()
 	gMuxHandlers[fd] = muxOutputHandler

--- a/goavpipe/handlers_test.go
+++ b/goavpipe/handlers_test.go
@@ -1,0 +1,234 @@
+package goavpipe
+
+import "testing"
+
+// stubOutputHandler is a no-op OutputHandler used only for exercising the
+// gMuxHandlers Put/Delete bookkeeping. The methods are never called.
+type stubOutputHandler struct{}
+
+func (stubOutputHandler) Write(buf []byte) (int, error)                   { return len(buf), nil }
+func (stubOutputHandler) Seek(offset int64, whence int) (int64, error)    { return 0, nil }
+func (stubOutputHandler) Close() error                                    { return nil }
+func (stubOutputHandler) Stat(int, AVType, AVStatType, interface{}) error { return nil }
+
+// stubInputOpener / stubOutputOpener — interface-satisfying no-ops, used
+// only to exercise the per-URL and per-handler bookkeeping maps.
+type stubInputOpener struct{}
+
+func (stubInputOpener) Open(int64, string) (InputHandler, error) { return nil, nil }
+
+type stubOutputOpener struct{}
+
+func (stubOutputOpener) Open(int64, int64, int, int, int64, AVType) (OutputHandler, error) {
+	return nil, nil
+}
+
+// TestMuxOutputHandlerPutDelete verifies that DeleteMuxOutputHandler removes
+// the entry PutMuxOutputOpener adds. Without the delete, gMuxHandlers would
+// grow unboundedly across mux operations.
+func TestMuxOutputHandlerPutDelete(t *testing.T) {
+	// Use a large negative fd unlikely to collide with any concurrent state.
+	// gMutex guarantees our Put/Delete are atomic, but we still avoid stomping.
+	const fd int64 = -424242
+
+	gMutex.Lock()
+	_, existedBefore := gMuxHandlers[fd]
+	gMutex.Unlock()
+	if existedBefore {
+		t.Fatalf("test fd %d already present in gMuxHandlers — pick a different sentinel", fd)
+	}
+
+	h := stubOutputHandler{}
+	PutMuxOutputOpener(fd, h)
+
+	gMutex.Lock()
+	got, ok := gMuxHandlers[fd]
+	gMutex.Unlock()
+	if !ok {
+		t.Fatalf("PutMuxOutputOpener did not insert entry for fd %d", fd)
+	}
+	if got != h {
+		t.Fatalf("PutMuxOutputOpener stored %v, want %v", got, h)
+	}
+
+	DeleteMuxOutputHandler(fd)
+
+	gMutex.Lock()
+	_, stillPresent := gMuxHandlers[fd]
+	gMutex.Unlock()
+	if stillPresent {
+		t.Fatalf("DeleteMuxOutputHandler left entry for fd %d in gMuxHandlers", fd)
+	}
+}
+
+// TestMuxOutputHandlerDeleteMissingIsSafe verifies that DeleteMuxOutputHandler
+// on a never-inserted fd is a no-op (important because AVPipeCloseMuxOutput
+// defers the delete even on the error path).
+func TestMuxOutputHandlerDeleteMissingIsSafe(t *testing.T) {
+	const fd int64 = -424243
+
+	gMutex.Lock()
+	_, existedBefore := gMuxHandlers[fd]
+	lenBefore := len(gMuxHandlers)
+	gMutex.Unlock()
+	if existedBefore {
+		t.Fatalf("test fd %d already present in gMuxHandlers — pick a different sentinel", fd)
+	}
+
+	DeleteMuxOutputHandler(fd) // must not panic or mutate other entries
+
+	gMutex.Lock()
+	lenAfter := len(gMuxHandlers)
+	gMutex.Unlock()
+	if lenAfter != lenBefore {
+		t.Fatalf("DeleteMuxOutputHandler on missing fd changed map size: before=%d after=%d",
+			lenBefore, lenAfter)
+	}
+}
+
+// TestIOHandlerPutDelete verifies the gHandlers Put/Delete symmetry used by
+// the non-mux transcode path. DeleteCIOHandlerAndOutputOpeners must drop the
+// entry that PutCIOHandler inserted.
+func TestIOHandlerPutDelete(t *testing.T) {
+	const fd int64 = -525252
+
+	gMutex.Lock()
+	_, existedBefore := gHandlers[fd]
+	gMutex.Unlock()
+	if existedBefore {
+		t.Fatalf("test fd %d already present in gHandlers — pick a different sentinel", fd)
+	}
+
+	sentinel := &struct{ name string }{name: "ioh"}
+	Globals.PutCIOHandler(fd, sentinel)
+
+	got, ok := Globals.GetCIOHandler(fd)
+	if !ok {
+		t.Fatalf("GetCIOHandler did not find entry for fd %d", fd)
+	}
+	if got != sentinel {
+		t.Fatalf("GetCIOHandler returned %v, want %v", got, sentinel)
+	}
+
+	Globals.DeleteCIOHandlerAndOutputOpeners(fd)
+
+	if _, stillPresent := Globals.GetCIOHandler(fd); stillPresent {
+		t.Fatalf("DeleteCIOHandlerAndOutputOpeners left entry for fd %d in gHandlers", fd)
+	}
+}
+
+// TestAssignOutputOpenerAndDelete verifies that AssignOutputOpener inserts
+// into gURLOutputOpenersByHandler and DeleteCIOHandlerAndOutputOpeners (which
+// also handles gHandlers) clears it.
+func TestAssignOutputOpenerAndDelete(t *testing.T) {
+	opener := stubOutputOpener{}
+	fd := Globals.AssignOutputOpener(opener)
+	if fd <= 0 {
+		t.Fatalf("AssignOutputOpener returned invalid fd: %d", fd)
+	}
+
+	gMutex.Lock()
+	_, ok := gURLOutputOpenersByHandler[fd]
+	gMutex.Unlock()
+	if !ok {
+		t.Fatalf("AssignOutputOpener did not insert entry for fd %d", fd)
+	}
+
+	if got := GetOutputOpenerByHandler(fd); got != opener {
+		t.Fatalf("GetOutputOpenerByHandler returned %v, want %v", got, opener)
+	}
+
+	Globals.DeleteCIOHandlerAndOutputOpeners(fd)
+
+	gMutex.Lock()
+	_, stillPresent := gURLOutputOpenersByHandler[fd]
+	gMutex.Unlock()
+	if stillPresent {
+		t.Fatalf("DeleteCIOHandlerAndOutputOpeners left entry for fd %d in gURLOutputOpenersByHandler", fd)
+	}
+}
+
+// TestAssignOutputOpenerNilReturnsSentinel verifies the documented contract
+// that a nil opener yields fd == -1 and no map mutation.
+func TestAssignOutputOpenerNilReturnsSentinel(t *testing.T) {
+	gMutex.Lock()
+	lenBefore := len(gURLOutputOpenersByHandler)
+	gMutex.Unlock()
+
+	fd := Globals.AssignOutputOpener(nil)
+	if fd != -1 {
+		t.Fatalf("AssignOutputOpener(nil) returned fd=%d, want -1", fd)
+	}
+
+	gMutex.Lock()
+	lenAfter := len(gURLOutputOpenersByHandler)
+	gMutex.Unlock()
+	if lenAfter != lenBefore {
+		t.Fatalf("AssignOutputOpener(nil) mutated map: before=%d after=%d", lenBefore, lenAfter)
+	}
+}
+
+// TestRemoveURLHandlers verifies RemoveURLHandlers clears both per-URL maps
+// set by InitUrlIOHandler.
+func TestRemoveURLHandlers(t *testing.T) {
+	const url = "test://removeURLHandlers/sentinel"
+
+	gMutex.Lock()
+	_, inExists := gURLInputOpeners[url]
+	_, outExists := gURLOutputOpeners[url]
+	gMutex.Unlock()
+	if inExists || outExists {
+		t.Fatalf("test url %q already present — pick a different sentinel", url)
+	}
+
+	InitUrlIOHandler(url, stubInputOpener{}, stubOutputOpener{})
+
+	gMutex.Lock()
+	_, inOk := gURLInputOpeners[url]
+	_, outOk := gURLOutputOpeners[url]
+	gMutex.Unlock()
+	if !inOk || !outOk {
+		t.Fatalf("InitUrlIOHandler did not populate both maps: in=%v out=%v", inOk, outOk)
+	}
+
+	Globals.RemoveURLHandlers(url)
+
+	gMutex.Lock()
+	_, inStill := gURLInputOpeners[url]
+	_, outStill := gURLOutputOpeners[url]
+	gMutex.Unlock()
+	if inStill || outStill {
+		t.Fatalf("RemoveURLHandlers left entries: in=%v out=%v", inStill, outStill)
+	}
+}
+
+// TestRemoveUrlMuxIOHandler verifies the mux-side per-URL cleanup added in
+// this branch clears both gURLInputOpeners and gURLMuxOutputOpeners.
+func TestRemoveUrlMuxIOHandler(t *testing.T) {
+	const url = "test://removeUrlMuxIOHandler/sentinel"
+
+	gMutex.Lock()
+	_, inExists := gURLInputOpeners[url]
+	_, muxExists := gURLMuxOutputOpeners[url]
+	gMutex.Unlock()
+	if inExists || muxExists {
+		t.Fatalf("test url %q already present — pick a different sentinel", url)
+	}
+
+	InitUrlMuxIOHandler(url, stubInputOpener{}, nil) // mux opener nil — tolerated by InitUrlMuxIOHandler
+	// Populate gURLMuxOutputOpeners directly since InitUrlMuxIOHandler skips nil openers;
+	// a stub MuxOutputOpener would add more interface-method boilerplate for little value.
+	gMutex.Lock()
+	gURLMuxOutputOpeners[url] = nil
+	gMutex.Unlock()
+
+	RemoveUrlMuxIOHandler(url)
+
+	gMutex.Lock()
+	_, inStill := gURLInputOpeners[url]
+	_, muxStill := gURLMuxOutputOpeners[url]
+	gMutex.Unlock()
+	if inStill || muxStill {
+		t.Fatalf("RemoveUrlMuxIOHandler left entries: in=%v mux=%v", inStill, muxStill)
+	}
+}


### PR DESCRIPTION
This patch adds a function `RemoveUrlMuxIOHandler` symmetric to function `InitUrlMuxIOHandler` that is called to set specific IO handler for muxing a url or a file, therefore allowing to release the memory used by these handlers.

Also:
* fix some comments and redundant declarations