### PR TITLE
Fix probe rtp:// by using alt_url to rewrite to udp://

### DIFF
--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -4040,6 +4040,7 @@ avpipe_probe(
     }
 
     inctx.params = params;
+    inctx.alt_url = (char *)calloc(1, MAX_URL_SIZE);
     if (in_handlers->avpipe_opener(url, &inctx) < 0) {
         rc = eav_open_input;
         goto avpipe_probe_end;
@@ -4190,6 +4191,8 @@ avpipe_probe_end:
 
     /* Close input handler resources */
     in_handlers->avpipe_closer(&inctx);
+
+    free(inctx.alt_url);
 
     return rc;
 }


### PR DESCRIPTION
The main xc (transcoding) code path rewrites temporarily `rtp://` URLs to `udp://` so we can use a straight MPEGTS decoder (the RTP decoder doesn't process MPEGTS stream IDs correctly - it's not MPEGTS aware, but rather generic RTP).

The probe fix allows the same behavior by allocating `inctx->alt_url`

```
   /*
     * Rewrite rtp:// to udp:// so ffmpeg uses the MPEGTS demuxer directly.
     * This ensures stream IDs and indexes are detected deterministically.
     * The live_proto remains avp_proto_rtp so all avpipe logic is unchanged.
     */
    if (decoder_context->live_proto == avp_proto_rtp && inctx->alt_url) {
        snprintf(inctx->alt_url, MAX_URL_SIZE, "udp://%s", inctx->url + 6);
        elv_log("Rewriting RTP URL for ffmpeg: %s -> %s", inctx->url, inctx->alt_url);
    }
```

## Test - exc

Before the fix probe fails like this:
```
./bin/exc -command probe -f rtp://127.0.0.1:11000   -listen 1
Error: avpipe probe failed on file rtp://127.0.0.1:11000 with no valid stream (err=13).
```

And logs:
```
2026-03-13 15:16:39.588 LOG PI STREAMS url=rtp://127.0.0.1:11000, format=rtp, nb_streams=2
2026-03-13 15:16:39.588 LOG PI STREAM[0] id=256 codec_type=video codec=h264
2026-03-13 15:16:39.588 LOG PI STREAM[1] id=257 codec_type=audio codec=aac
2026-03-13 15:16:39.588 ERR PI Unsupported live source: proto=4 container=rtp
2026-03-13 15:16:39.588 ERR PI avpipe_probe failed to prepare decoder, url=rtp://127.0.0.1:11000
2026-03-13 15:16:39.588 DBG PI IN io_close custom writer fd=0
2026-03-13 15:16:39.588 DBG PI Releasing probe resources
```

After the fix:

```
./bin/exc -command probe -f rtp://127.0.0.1:11000   -listen 1
Stream[0]
	stream_id: 256
	codec_type: video
	codec_id: 27
	codec_name: h264
	profile: High
	...
```

