### PR TITLE
Full support for HDR and SBS

### DIFF
--- a/avpipe.go
+++ b/avpipe.go
@@ -107,6 +107,13 @@ type StreamInfo struct {
 	FieldOrder         string            `json:"field_order,omitempty"`
 	Profile            int               `json:"profile,omitempty"`
 	Level              int               `json:"level,omitempty"`
+	ColorPrimaries     string            `json:"color_primaries,omitempty"`
+	ColorTransfer      string            `json:"color_transfer,omitempty"`
+	ColorSpace         string            `json:"color_space,omitempty"`
+	ColorRange         string            `json:"color_range,omitempty"`       // "tv" or "pc"
+	MasteringDisplay   string            `json:"mastering_display,omitempty"` // x265 master-display string
+	MaxCLL             string            `json:"max_cll,omitempty"`           // "<MaxCLL>,<MaxFALL>"
+	Stereo3DType       string            `json:"stereo3d_type,omitempty"`     // Description eg. "side by side"
 	SideData           []interface{}     `json:"side_data,omitempty"`
 	Tags               map[string]string `json:"tags,omitempty"`
 }
@@ -1077,6 +1084,14 @@ func Probe(params *goavpipe.XcParams) (*ProbeInfo, error) {
 		probeInfo.StreamInfo[i].FieldOrder = goavpipe.AVFieldOrderNames[goavpipe.AVFieldOrder(probeArray[i].field_order)]
 		probeInfo.StreamInfo[i].Profile = int(probeArray[i].profile)
 		probeInfo.StreamInfo[i].Level = int(probeArray[i].level)
+
+		probeInfo.StreamInfo[i].ColorPrimaries = C.GoString((*C.char)(unsafe.Pointer(&probeArray[i].color_primaries)))
+		probeInfo.StreamInfo[i].ColorTransfer = C.GoString((*C.char)(unsafe.Pointer(&probeArray[i].color_transfer)))
+		probeInfo.StreamInfo[i].ColorSpace = C.GoString((*C.char)(unsafe.Pointer(&probeArray[i].color_space)))
+		probeInfo.StreamInfo[i].ColorRange = C.GoString((*C.char)(unsafe.Pointer(&probeArray[i].color_range)))
+		probeInfo.StreamInfo[i].MasteringDisplay = C.GoString((*C.char)(unsafe.Pointer(&probeArray[i].mastering_display)))
+		probeInfo.StreamInfo[i].MaxCLL = C.GoString((*C.char)(unsafe.Pointer(&probeArray[i].max_cll)))
+		probeInfo.StreamInfo[i].Stereo3DType = C.GoString((*C.char)(unsafe.Pointer(&probeArray[i].stereo3d_type)))
 
 		rot := float64(probeArray[i].side_data.display_matrix.rotation)
 		if rot != 0.0 {

--- a/avpipe.go
+++ b/avpipe.go
@@ -841,6 +841,7 @@ func getCParams(params *goavpipe.XcParams) (*C.xcparams_t, error) {
 		seekable:                  C.int(0),
 		max_cll:                   C.CString(params.MaxCLL),
 		master_display:            C.CString(params.MasterDisplay),
+		video_layout:              C.int(params.VideoLayout),
 		bitdepth:                  C.int(params.BitDepth),
 		mux_spec:                  C.CString(params.MuxingSpec),
 		sync_audio_to_stream_id:   C.int(params.SyncAudioToStreamId),

--- a/avpipe_test.go
+++ b/avpipe_test.go
@@ -30,6 +30,14 @@ const h264Codec = "libx264"
 const videoBigBuckBunnyPath = "media/bbb_1080p_30fps_60sec.mp4"
 const videoBigBuckBunny3AudioPath = "media/caminandes_llamigos_1080p_4audios.mp4"
 
+// HDR10 test settings
+const (
+	hdr10TestSource     = "./media/hdr10-plus-injected.mp4"
+	hdr10TestDurationTs = int64(35 * 24000) // 35s @ 1/24000 timebase = 1 full mez seg + fragment
+	hdr10MasterDisplay  = "G(8500,39850)B(6550,2300)R(35400,14600)WP(15635,16450)L(10000000,10)"
+	hdr10MaxCLL         = "1000,400"
+)
+
 type XcTestResult struct {
 	mezFile           []string
 	timeScale         int
@@ -1806,6 +1814,104 @@ func TestHEVC_H265ABRTranscode(t *testing.T) {
 
 }
 
+// TestHEVC_HDR10_MezAndABR creates a mez from source and ABR rungs from mez
+// Validates: pix_fmt, profile, and colr/mdcv/clli
+func TestHEVC_HDR10_MezAndABR(t *testing.T) {
+	f := fn()
+	if testing.Short() {
+		t.Skip("SKIPPING " + f + " (fast mode)")
+	}
+	if fileMissing(hdr10TestSource, f) {
+		return
+	}
+
+	mezDir := path.Join(baseOutPath, f, "Mez")
+	bypassDir := path.Join(baseOutPath, f, "ABRBypass")
+	abrDir := path.Join(baseOutPath, f, "ABR720")
+
+	// Stage 1: source → mez (no bitdepth and profile specified)
+	mezParams := &goavpipe.XcParams{
+		Url:               hdr10TestSource,
+		BypassTranscoding: false,
+		Format:            "fmp4-segment",
+		StartTimeTs:       0,
+		StartPts:          0,
+		DurationTs:        hdr10TestDurationTs,
+		StartSegmentStr:   "1",
+		SegDuration:       "30",
+		Ecodec:            "libx265",
+		Dcodec:            "hevc",
+		EncHeight:         -1, // preserve 2160
+		EncWidth:          -1, // preserve 3840
+		XcType:            goavpipe.XcVideo,
+		StreamId:          -1,
+		MasterDisplay:     hdr10MasterDisplay,
+		MaxCLL:            hdr10MaxCLL,
+		DebugFrameLevel:   debugFrameLevel,
+	}
+
+	setupOutDir(t, mezDir)
+	xcTest(t, mezDir, mezParams, nil, true)
+
+	mezExpected := expectedHDR10{
+		PixFmt:           "yuv420p10le",
+		ProfileName:      "Main 10",
+		ColorPrimaries:   "bt2020",
+		ColorTransfer:    "smpte2084",
+		ColorSpace:       "bt2020nc",
+		ColorRange:       "tv",
+		Width:            3840,
+		Height:           2160,
+		MasteringDisplay: hdr10MasterDisplay, // round-trips bit-exact through x265 → mp4 → probe
+		MaxCLL:           hdr10MaxCLL,
+	}
+	assertHDR10(t, path.Join(mezDir, "vsegment-1.mp4"), mezExpected)
+	assertHDR10(t, path.Join(mezDir, "vsegment-2.mp4"), mezExpected)
+
+	mezSeg := path.Join(mezDir, "vsegment-1.mp4")
+
+	// Stage 2a: mez → ABR bypass
+	{
+		bypassParams := *mezParams
+		bypassParams.Url = mezSeg
+		bypassParams.Format = "dash"
+		bypassParams.BypassTranscoding = true
+		bypassParams.VideoSegDurationTs = 48000
+		bypassParams.DurationTs = -1
+
+		setupOutDir(t, bypassDir)
+		goavpipe.InitUrlIOHandler(mezSeg,
+			&xc.FileInputOpener{URL: mezSeg},
+			&xc.FileOutputOpener{Dir: bypassDir})
+		boilerXc(t, &bypassParams)
+
+		assertHDR10(t, dashVideoInit(t, bypassDir), mezExpected)
+	}
+
+	// Stage 2b: mez → ABR
+	{
+		scaledExpected := mezExpected
+		scaledExpected.Width = 0 // computed from aspect ratio (16:9 → 1280)
+		scaledExpected.Height = 720
+
+		abrParams := *mezParams
+		abrParams.Url = mezSeg
+		abrParams.Format = "dash"
+		abrParams.VideoSegDurationTs = 48000
+		abrParams.EncHeight = 720
+		abrParams.EncWidth = -1
+		abrParams.DurationTs = -1
+
+		setupOutDir(t, abrDir)
+		goavpipe.InitUrlIOHandler(mezSeg,
+			&xc.FileInputOpener{URL: mezSeg},
+			&xc.FileOutputOpener{Dir: abrDir})
+		boilerXc(t, &abrParams)
+
+		assertHDR10(t, dashVideoInit(t, abrDir), scaledExpected)
+	}
+}
+
 func TestAVPipeStats(t *testing.T) {
 	url := "./media/Rigify-2min.mp4"
 	if fileMissing(url, fn()) {
@@ -2658,4 +2764,80 @@ func nvidiaExist() bool {
 
 	log.Info("NVIDIA doesn't exist")
 	return false
+}
+
+// expectedHDR10 stores expected HDR10 specific info
+type expectedHDR10 struct {
+	PixFmt           string // e.g. "yuv420p10le"
+	ProfileName      string // e.g. "Main 10"
+	ColorPrimaries   string // e.g. "bt2020"
+	ColorTransfer    string // e.g. "smpte2084"
+	ColorSpace       string // e.g. "bt2020nc"
+	ColorRange       string // e.g. "tv"
+	Width, Height    int    // 0 = don't check
+	MasteringDisplay string // x265 format "G(...)B(...)R(...)WP(...)L(...)"; "*" = require non-empty
+	MaxCLL           string // "<MaxCLL>,<MaxFALL>"; "*" = require non-empty.
+}
+
+// assertHDR10 probes and asserts the mp4 video stream matches the expected.
+func assertHDR10(t *testing.T, mp4 string, want expectedHDR10) {
+	t.Helper()
+	probe, err := avpipe.Probe(&goavpipe.XcParams{Url: mp4, Seekable: true})
+	failNowOnError(t, err)
+
+	var si *avpipe.StreamInfo
+	for i := range probe.StreamInfo {
+		if probe.StreamInfo[i].CodecType == "video" {
+			si = &probe.StreamInfo[i]
+			break
+		}
+	}
+	if !assert.NotNil(t, si, "no video stream in %s", mp4) {
+		return
+	}
+
+	if want.PixFmt != "" {
+		assert.Equal(t, want.PixFmt, avpipe.GetPixelFormatName(si.PixFmt), "pix_fmt in %s", mp4)
+	}
+	if want.ProfileName != "" {
+		assert.Equal(t, want.ProfileName, avpipe.GetProfileName(si.CodecID, si.Profile), "profile in %s", mp4)
+	}
+	if want.ColorPrimaries != "" {
+		assert.Equal(t, want.ColorPrimaries, si.ColorPrimaries, "color_primaries in %s", mp4)
+	}
+	if want.ColorTransfer != "" {
+		assert.Equal(t, want.ColorTransfer, si.ColorTransfer, "color_transfer in %s", mp4)
+	}
+	if want.ColorSpace != "" {
+		assert.Equal(t, want.ColorSpace, si.ColorSpace, "color_space in %s", mp4)
+	}
+	if want.ColorRange != "" {
+		assert.Equal(t, want.ColorRange, si.ColorRange, "color_range in %s", mp4)
+	}
+	if want.Width > 0 {
+		assert.Equal(t, want.Width, si.Width, "width in %s", mp4)
+	}
+	if want.Height > 0 {
+		assert.Equal(t, want.Height, si.Height, "height in %s", mp4)
+	}
+	if want.MasteringDisplay == "*" {
+		assert.NotEmpty(t, si.MasteringDisplay, "Mastering display side data missing in %s", mp4)
+	} else if want.MasteringDisplay != "" {
+		assert.Equal(t, want.MasteringDisplay, si.MasteringDisplay, "mastering_display in %s", mp4)
+	}
+	if want.MaxCLL == "*" {
+		assert.NotEmpty(t, si.MaxCLL, "Content light level side data missing in %s", mp4)
+	} else if want.MaxCLL != "" {
+		assert.Equal(t, want.MaxCLL, si.MaxCLL, "max_cll in %s", mp4)
+	}
+}
+
+// dashVideoInit returns the path to the video init segment in the output directory
+func dashVideoInit(t *testing.T, dashDir string) string {
+	t.Helper()
+	init := path.Join(dashDir, "vinit-stream0.m4s")
+	if !fileExist(init) {
+		t.Fatalf("DASH init segment missing: %s", init)
+	}
+	return init
 }

--- a/exc/elv_xc.c
+++ b/exc/elv_xc.c
@@ -1542,6 +1542,15 @@ main(
                 }
                 if (p.video_time_base <= 0)
                     usage(argv[0], argv[i], EXIT_FAILURE);
+            } else if (!strcmp(argv[i], "-video-layout")) {
+                /* Accept both label and numeric CICP */
+                if (!strcmp(argv[i+1], "sbs") || !strcmp(argv[i+1], "3")) {
+                    p.video_layout = video_layout_sbs;
+                } else if (!strcmp(argv[i+1], "mono") || !strcmp(argv[i+1], "0")) {
+                    p.video_layout = video_layout_mono;
+                } else {
+                    usage(argv[0], argv[i], EXIT_FAILURE);
+                }
             } else {
                 usage(argv[0], argv[i], EXIT_FAILURE);
             }

--- a/goavpipe/structs.go
+++ b/goavpipe/structs.go
@@ -321,6 +321,7 @@ type XcParams struct {
 	ChannelLayout          int       `json:"channel_layout"`                   // Audio channel layout
 	MaxCLL                 string    `json:"max_cll,omitempty"`
 	MasterDisplay          string    `json:"master_display,omitempty"`
+	VideoLayout            int32     `json:"video_layout,omitempty"`
 	BitDepth               int32     `json:"bitdepth,omitempty"`
 	SyncAudioToStreamId    int       `json:"sync_audio_to_stream_id"`
 	ForceEqualFDuration    bool      `json:"force_equal_frame_duration,omitempty"`

--- a/libavpipe.c
+++ b/libavpipe.c
@@ -5,6 +5,7 @@
 #include "libavpipe/src/avpipe_udp_thread.c"
 #include "libavpipe/src/avpipe_utils.c"
 #include "libavpipe/src/avpipe_format.c"
+#include "libavpipe/src/avpipe_codec.c"
 #include "libavpipe/src/avpipe_copy_mpegts.c"
 #include "libavpipe/src/avpipe_xc.c"
 #include "libavpipe/src/scte35.c"

--- a/libavpipe/Makefile
+++ b/libavpipe/Makefile
@@ -2,6 +2,7 @@ TOP_DIR ?= $(shell pwd)
 SRCS=avpipe_xc.c \
     avpipe_utils.c \
     avpipe_format.c \
+    avpipe_codec.c \
     avpipe_filters.c \
     avpipe_io.c \
     avpipe_mux.c \

--- a/libavpipe/include/avpipe_xc.h
+++ b/libavpipe/include/avpipe_xc.h
@@ -452,6 +452,12 @@ typedef enum dif_type {
     dif_bwdif_frame = 2  // Use filter bwdif mode 'send_frame' (one frame per input frame)
 } dif_type;
 
+// Video layout. Values align with ISO/IEC 23001-8 (CICP)
+typedef enum video_layout_t {
+    video_layout_mono = 0, // Monoscopic
+    video_layout_sbs  = 3  // Stereoscopic side-by-side
+} video_layout_t;
+
 #define DRAW_TEXT_SHADOW_OFFSET     0.075
 #define MAX_EXTRACT_IMAGES_SZ       100
 
@@ -521,6 +527,7 @@ typedef struct xcparams_t {
     int         bitdepth;                   // Can be 8, 10, 12
     char        *max_cll;                   // Maximum Content Light Level (HDR only)
     char        *master_display;            // Master display (HDR only)
+    int         video_layout;               // Video layout (eg. stereoscopic SBS)
     int         stream_id;                  // Stream id to trasncode, should be >= 0
     char        *filter_descriptor;         // Filter descriptor if tx-type == audio-merge
     char        *mux_spec;

--- a/libavpipe/include/avpipe_xc.h
+++ b/libavpipe/include/avpipe_xc.h
@@ -584,6 +584,16 @@ typedef struct stream_info_t {
     enum AVFieldOrder   field_order;
     int                 profile;
     int                 level;
+
+    char                color_primaries[16];      // e.g. "bt2020", "bt709"
+    char                color_transfer[24];       // e.g. "smpte2084" (PQ), "arib-std-b67" (HLG)
+    char                color_space[16];          // e.g. "bt2020nc"
+    char                color_range[8];           // "tv" (limited) or "pc" (full)
+
+    char                mastering_display[128];   // AV_PKT_DATA_MASTERING_DISPLAY_METADATA
+    char                max_cll[32];              // AV_PKT_DATA_CONTENT_LIGHT_LEVEL
+    char                stereo3d_type[32];        // AV_PKT_DATA_STEREO3D
+
     side_data_t         side_data;
     AVDictionary        *tags;
 } stream_info_t;

--- a/libavpipe/src/avpipe_codec.c
+++ b/libavpipe/src/avpipe_codec.c
@@ -1,0 +1,156 @@
+/*
+ * avpipe_codec.c
+ *
+ * Codec-specific helpers, factored out of avpipe_xc.c.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "avpipe_codec.h"
+#include "avpipe_xc.h"
+#include "elv_log.h"
+
+/* HEVC SEI mastering_display_colour_volume scaling. */
+#define MD_CHROMA_SCALE  50000
+#define MD_LUMA_SCALE    10000
+
+int
+parse_master_display(
+    const char *s,
+    AVMasteringDisplayMetadata *out)
+{
+    int g_x, g_y, b_x, b_y, r_x, r_y, wp_x, wp_y, l_max, l_min;
+
+    if (s == NULL || out == NULL)
+        return eav_param;
+
+    /* x265 master-display format. AVRational denominators match HEVC SEI scaling */
+    if (sscanf(s, "G(%d,%d)B(%d,%d)R(%d,%d)WP(%d,%d)L(%d,%d)",
+               &g_x, &g_y, &b_x, &b_y, &r_x, &r_y, &wp_x, &wp_y, &l_max, &l_min) != 10) {
+        elv_err("parse_master_display: bad format, s=\"%s\"", s);
+        return eav_param;
+    }
+
+    /* AVMasteringDisplayMetadata uses R, G, B order in display_primaries[]. */
+    out->display_primaries[0][0] = (AVRational){r_x, MD_CHROMA_SCALE};
+    out->display_primaries[0][1] = (AVRational){r_y, MD_CHROMA_SCALE};
+    out->display_primaries[1][0] = (AVRational){g_x, MD_CHROMA_SCALE};
+    out->display_primaries[1][1] = (AVRational){g_y, MD_CHROMA_SCALE};
+    out->display_primaries[2][0] = (AVRational){b_x, MD_CHROMA_SCALE};
+    out->display_primaries[2][1] = (AVRational){b_y, MD_CHROMA_SCALE};
+    out->white_point[0]          = (AVRational){wp_x, MD_CHROMA_SCALE};
+    out->white_point[1]          = (AVRational){wp_y, MD_CHROMA_SCALE};
+    out->min_luminance           = (AVRational){l_min, MD_LUMA_SCALE};
+    out->max_luminance           = (AVRational){l_max, MD_LUMA_SCALE};
+    out->has_primaries = 1;
+    out->has_luminance = 1;
+
+    return eav_success;
+}
+
+int
+format_master_display(
+    char *buf,
+    size_t buf_size,
+    const AVMasteringDisplayMetadata *m)
+{
+    if (buf == NULL || m == NULL)
+        return eav_param;
+
+    /* Inverse of parse_master_display (including scaling) */
+    snprintf(buf, buf_size,
+        "G(%lld,%lld)B(%lld,%lld)R(%lld,%lld)WP(%lld,%lld)L(%lld,%lld)",
+        (long long)av_rescale(m->display_primaries[1][0].num, MD_CHROMA_SCALE, m->display_primaries[1][0].den),
+        (long long)av_rescale(m->display_primaries[1][1].num, MD_CHROMA_SCALE, m->display_primaries[1][1].den),
+        (long long)av_rescale(m->display_primaries[2][0].num, MD_CHROMA_SCALE, m->display_primaries[2][0].den),
+        (long long)av_rescale(m->display_primaries[2][1].num, MD_CHROMA_SCALE, m->display_primaries[2][1].den),
+        (long long)av_rescale(m->display_primaries[0][0].num, MD_CHROMA_SCALE, m->display_primaries[0][0].den),
+        (long long)av_rescale(m->display_primaries[0][1].num, MD_CHROMA_SCALE, m->display_primaries[0][1].den),
+        (long long)av_rescale(m->white_point[0].num,           MD_CHROMA_SCALE, m->white_point[0].den),
+        (long long)av_rescale(m->white_point[1].num,           MD_CHROMA_SCALE, m->white_point[1].den),
+        (long long)av_rescale(m->max_luminance.num,            MD_LUMA_SCALE,   m->max_luminance.den),
+        (long long)av_rescale(m->min_luminance.num,            MD_LUMA_SCALE,   m->min_luminance.den));
+
+    return eav_success;
+}
+
+int
+parse_max_cll(
+    const char *s,
+    AVContentLightMetadata *out)
+{
+    unsigned int max_cll, max_fall;
+
+    if (s == NULL || out == NULL)
+        return eav_param;
+
+    if (sscanf(s, "%u,%u", &max_cll, &max_fall) != 2) {
+        elv_err("parse_max_cll: bad format, s=\"%s\"", s);
+        return eav_param;
+    }
+
+    out->MaxCLL  = max_cll;
+    out->MaxFALL = max_fall;
+
+    return eav_success;
+}
+
+int
+format_max_cll(
+    char *buf,
+    size_t buf_size,
+    const AVContentLightMetadata *c)
+{
+    if (buf == NULL || c == NULL)
+        return eav_param;
+
+    snprintf(buf, buf_size, "%u,%u", c->MaxCLL, c->MaxFALL);
+    return eav_success;
+}
+
+int
+attach_master_display(
+    AVCodecContext *ctx,
+    const char *s)
+{
+    AVMasteringDisplayMetadata m;
+    int rc = parse_master_display(s, &m);
+    if (rc != eav_success)
+        return rc;
+
+    AVPacketSideData *sd = av_packet_side_data_new(
+        &ctx->coded_side_data,
+        &ctx->nb_coded_side_data,
+        AV_PKT_DATA_MASTERING_DISPLAY_METADATA,
+        sizeof(m), 0);
+    if (!sd) {
+        elv_err("attach_master_display: side data allocation failed");
+        return eav_mem_alloc;
+    }
+    memcpy(sd->data, &m, sizeof(m));
+    return eav_success;
+}
+
+int
+attach_max_cll(
+    AVCodecContext *ctx,
+    const char *s)
+{
+    AVContentLightMetadata c;
+    int rc = parse_max_cll(s, &c);
+    if (rc != eav_success)
+        return rc;
+
+    AVPacketSideData *sd = av_packet_side_data_new(
+        &ctx->coded_side_data,
+        &ctx->nb_coded_side_data,
+        AV_PKT_DATA_CONTENT_LIGHT_LEVEL,
+        sizeof(c), 0);
+    if (!sd) {
+        elv_err("attach_max_cll: side data allocation failed");
+        return eav_mem_alloc;
+    }
+    memcpy(sd->data, &c, sizeof(c));
+    return eav_success;
+}

--- a/libavpipe/src/avpipe_codec.h
+++ b/libavpipe/src/avpipe_codec.h
@@ -1,0 +1,79 @@
+/*
+ * avpipe_codec.h
+ *
+ * Codec-specific helpers.
+ */
+
+#include <libavcodec/avcodec.h>
+#include <libavutil/mastering_display_metadata.h>
+
+#include "avpipe_xc.h"
+
+/*
+ * Parse x265 master-display string:
+ * "G(g_x,g_y)B(b_x,b_y)R(r_x,r_y)WP(wp_x,wp_y)L(l_max,l_min)"
+ * (usual chromaticities scaled by 50000, luminance by 10000)
+ *
+ * Returns eav_success and fills *out on success, or eav_param on parse failure
+ */
+int
+parse_master_display(
+    const char *s,
+    AVMasteringDisplayMetadata *out);
+
+/*
+ * Format AVMasteringDisplayMetadata struct into x265 master-display string
+ * Buffer size 128 bytes is sufficient.
+ *
+ * Returns eav_success on success, or eav_param if either pointer is NULL.
+ */
+int
+format_master_display(
+    char *buf,
+    size_t buf_size,
+    const AVMasteringDisplayMetadata *m);
+
+/*
+ * Parse "<MaxCLL>,<MaxFALL>" string.
+ *
+ * Returns eav_success and fills *out on success, or eav_param on parse failure
+ */
+int
+parse_max_cll(
+    const char *s,
+    AVContentLightMetadata *out);
+
+/*
+ * Format AVContentLightMetadata struct into string "<MaxCLL>,<MaxFALL>"
+ * Buffer size 32 bytes is sufficient
+ *
+ * Returns eav_success on success, or eav_param if either pointer is NULL.
+ */
+int
+format_max_cll(
+    char *buf,
+    size_t buf_size,
+    const AVContentLightMetadata *c);
+
+/*
+ * Parse 265 master-display string and attach as
+ * AV_PKT_DATA_MASTERING_DISPLAY_METADATA on ctx->coded_side_data.
+ * Instructs mp4 muxer to write the mdcv box
+ *
+ * Returns eav_success on success, eav_param if the string can't be parsed,
+ * or eav_mem_alloc if side-data allocation fails.
+ */
+int
+attach_master_display(
+    AVCodecContext *ctx,
+    const char *s);
+
+/*
+ * Parse "<MaxCLL>,<MaxFALL>" and attach as AV_PKT_DATA_CONTENT_LIGHT_LEVEL
+ * on ctx->coded_side_data.
+ * Instructs mp4 muxer to write the clli box
+ */
+int
+attach_max_cll(
+    AVCodecContext *ctx,
+    const char *s);

--- a/libavpipe/src/avpipe_format.c
+++ b/libavpipe/src/avpipe_format.c
@@ -1,5 +1,7 @@
 /*
  * avpipe_format.c
+ *
+ * Container-specific helpers.
  */
 
 #include <libavcodec/avcodec.h>

--- a/libavpipe/src/avpipe_format.h
+++ b/libavpipe/src/avpipe_format.h
@@ -1,5 +1,7 @@
 /*
- * avpipe_format.c
+ * avpipe_format.h
+ *
+ * Container-specific helpers.
  */
 
 #include <libavcodec/avcodec.h>

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -14,10 +14,12 @@
 #include <libavutil/imgutils.h>
 #include <libavutil/display.h>
 #include <libavutil/stereo3d.h>
+#include <libavutil/mastering_display_metadata.h>
 
 #include "avpipe_xc.h"
 #include "avpipe_utils.h"
 #include "avpipe_format.h"
+#include "avpipe_codec.h"
 #include "avpipe_io.h"
 #include "avpipe_copy_mpegts.h"
 #include "elv_log.h"
@@ -793,12 +795,20 @@ set_h265_params(
     size_t off = 0;
 
     /* Set max_cll and master_display meta data for HDR content (omit if "0,0") */
-    if (params->max_cll && params->max_cll[0] != '\0' && strcmp(params->max_cll, "0,0") != 0)
+    if (params->max_cll && params->max_cll[0] != '\0' && strcmp(params->max_cll, "0,0") != 0) {
         av_opt_set(encoder_codec_context->priv_data, "max-cll", params->max_cll, 0);
+        /* Also attach as side data - mp4 clli box. */
+        if (attach_max_cll(encoder_codec_context, params->max_cll) != eav_success)
+            elv_warn("set_h265_params: failed to attach max_cll side data, url=%s", params->url);
+    }
     if (params->master_display && params->master_display[0] != '\0') {
         off += snprintf(x265_params + off, sizeof(x265_params) - off,
             "hdr10=1:hdr10-opt=1:repeat-headers=1:colorprim=bt2020:transfer=smpte2084:colormatrix=bt2020nc");
         av_opt_set(encoder_codec_context->priv_data, "master-display", params->master_display, 0);
+
+        /* Attach side data - mp4 muxer mdcv box */
+        if (attach_master_display(encoder_codec_context, params->master_display) != eav_success)
+            elv_warn("set_h265_params: failed to attach master_display side data, url=%s", params->url);
 
         /* Add HDR10 color metadata into AVCodecContext (populates the colr box) */
         encoder_codec_context->color_range     = AVCOL_RANGE_MPEG;       // "tv"
@@ -1009,8 +1019,11 @@ set_nvidia_hevc_params(
     av_opt_set(encoder_codec_context->priv_data, "tune", "hq", 0);   // Valid: hq, ll, ull, lossless, losslesshp
 
     /* HDR - set max_cll and master_display meta data for HDR content (skip if "0,0") */
-    if (params->max_cll && params->max_cll[0] != '\0' && strcmp(params->max_cll, "0,0") != 0)
+    if (params->max_cll && params->max_cll[0] != '\0' && strcmp(params->max_cll, "0,0") != 0) {
         av_opt_set(encoder_codec_context->priv_data, "max_cll", params->max_cll, 0);
+        if (attach_max_cll(encoder_codec_context, params->max_cll) != eav_success)
+            elv_warn("set_nvidia_hevc_params: failed to attach max_cll side data, url=%s", params->url);
+    }
     if (params->master_display && params->master_display[0] != '\0') {
         encoder_codec_context->pix_fmt        = AV_PIX_FMT_P010;                 // 10-bit
         encoder_codec_context->color_range    = AVCOL_RANGE_MPEG;                // "tv"
@@ -1018,6 +1031,10 @@ set_nvidia_hevc_params(
         encoder_codec_context->color_trc      = AVCOL_TRC_SMPTE2084;             // PQ (ST 2084)
         encoder_codec_context->colorspace     = AVCOL_SPC_BT2020_NCL;            // bt2020nc
         av_opt_set(encoder_codec_context->priv_data, "master_display", params->master_display, 0);
+
+        /* Attach side data - mp4 mdcv box */
+        if (attach_master_display(encoder_codec_context, params->master_display) != eav_success)
+            elv_warn("set_nvidia_hevc_params: failed to attach master_display side data, url=%s", params->url);
 
         /* HDR10 requires 10bit and main10 - set if not specified */
         if (params->profile == NULL || strlen(params->profile) == 0) {
@@ -4293,6 +4310,24 @@ avpipe_probe(
         stream_probes_ptr->profile = codec_context->profile;
         stream_probes_ptr->level = codec_context->level;
 
+        /* Color metadata store as 'names' */
+        stream_probes_ptr->color_primaries[0] = '\0';
+        stream_probes_ptr->color_transfer[0]  = '\0';
+        stream_probes_ptr->color_space[0]     = '\0';
+        stream_probes_ptr->color_range[0]     = '\0';
+        const char *cp_name = av_color_primaries_name(s->codecpar->color_primaries);
+        const char *ct_name = av_color_transfer_name(s->codecpar->color_trc);
+        const char *cs_name = av_color_space_name(s->codecpar->color_space);
+        const char *cr_name = av_color_range_name(s->codecpar->color_range);
+        if (cp_name) snprintf(stream_probes_ptr->color_primaries, sizeof(stream_probes_ptr->color_primaries), "%s", cp_name);
+        if (ct_name) snprintf(stream_probes_ptr->color_transfer,  sizeof(stream_probes_ptr->color_transfer),  "%s", ct_name);
+        if (cs_name) snprintf(stream_probes_ptr->color_space,     sizeof(stream_probes_ptr->color_space),     "%s", cs_name);
+        if (cr_name) snprintf(stream_probes_ptr->color_range,     sizeof(stream_probes_ptr->color_range),     "%s", cr_name);
+
+        stream_probes_ptr->mastering_display[0] = '\0';
+        stream_probes_ptr->max_cll[0]           = '\0';
+        stream_probes_ptr->stereo3d_type[0]     = '\0';
+
         // Set container duration if necessary
         if (probe->container_info.duration <
             ((float)stream_probes_ptr->duration_ts)/stream_probes_ptr->time_base.den)
@@ -4304,13 +4339,38 @@ avpipe_probe(
         for (int i = 0; i < s->codecpar->nb_coded_side_data; i++) {
             const AVPacketSideData *sd = &s->codecpar->coded_side_data[i];
             switch (sd->type) {
-                case AV_PKT_DATA_DISPLAYMATRIX:
+                case AV_PKT_DATA_DISPLAYMATRIX: {
                     stream_probes_ptr->side_data.display_matrix.rotation = av_display_rotation_get((int32_t *)sd->data);
                     double rot = stream_probes_ptr->side_data.display_matrix.rotation;
                     // Convert from CCW [-180:180] value to straight CW
                     rot = rot >= 0 ? rot : 360.0 + rot;
                     rot = rot > 0 ? 360 - rot : 0;
                     stream_probes_ptr->side_data.display_matrix.rotation_cw = rot;
+                    break;
+                }
+                case AV_PKT_DATA_MASTERING_DISPLAY_METADATA: {
+                    if (sd->size >= (int)sizeof(AVMasteringDisplayMetadata)) {
+                        format_master_display(stream_probes_ptr->mastering_display,
+                            sizeof(stream_probes_ptr->mastering_display),
+                            (const AVMasteringDisplayMetadata *)sd->data);
+                    }
+                    break;
+                }
+                case AV_PKT_DATA_CONTENT_LIGHT_LEVEL:
+                    if (sd->size >= (int)sizeof(AVContentLightMetadata)) {
+                        format_max_cll(stream_probes_ptr->max_cll,
+                            sizeof(stream_probes_ptr->max_cll),
+                            (const AVContentLightMetadata *)sd->data);
+                    }
+                    break;
+                case AV_PKT_DATA_STEREO3D:
+                    if (sd->size >= (int)sizeof(AVStereo3D)) {
+                        const char *s3d_name = av_stereo3d_type_name(
+                            ((const AVStereo3D *)sd->data)->type);
+                        if (s3d_name)
+                            snprintf(stream_probes_ptr->stereo3d_type,
+                                sizeof(stream_probes_ptr->stereo3d_type), "%s", s3d_name);
+                    }
                     break;
                 default:
                     // Not handled

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -13,6 +13,7 @@
 #include <libswscale/swscale.h>
 #include <libavutil/imgutils.h>
 #include <libavutil/display.h>
+#include <libavutil/stereo3d.h>
 
 #include "avpipe_xc.h"
 #include "avpipe_utils.h"
@@ -752,10 +753,17 @@ set_h264_params(
                                                 encoder_codec_context->height);
     }
 
-    av_opt_set(encoder_codec_context->priv_data, "x264-params", "stitchable=1", 0);
+    {
+        char x264_params[128] = "stitchable=1";
+        if (params->video_layout == video_layout_sbs) {
+            snprintf(x264_params, sizeof(x264_params),
+                "stitchable=1:frame-packing=%d", video_layout_sbs);
+        }
+        av_opt_set(encoder_codec_context->priv_data, "x264-params", x264_params, 0);
+    }
 }
 
-static void
+static int
 set_h265_params(
     coderctx_t *encoder_context,
     coderctx_t *decoder_context,
@@ -780,19 +788,44 @@ set_h265_params(
         av_opt_set(encoder_codec_context->priv_data, "profile", "main12", 0);
     }
 
-    /* Set max_cll and master_display meta data for HDR content */
-    if (params->max_cll && params->max_cll[0] != '\0')
+    /* Build x265-params as a single colon-separated string */
+    char x265_params[512] = {0};
+    size_t off = 0;
+
+    /* Set max_cll and master_display meta data for HDR content (omit if "0,0") */
+    if (params->max_cll && params->max_cll[0] != '\0' && strcmp(params->max_cll, "0,0") != 0)
         av_opt_set(encoder_codec_context->priv_data, "max-cll", params->max_cll, 0);
     if (params->master_display && params->master_display[0] != '\0') {
-        av_opt_set(encoder_codec_context->priv_data, "x265-params",
-            "hdr10=1:hdr10-opt=1:repeat-headers=1:colorprim=bt2020:transfer=smpte2084:colormatrix=bt2020nc", 0);
+        off += snprintf(x265_params + off, sizeof(x265_params) - off,
+            "hdr10=1:hdr10-opt=1:repeat-headers=1:colorprim=bt2020:transfer=smpte2084:colormatrix=bt2020nc");
         av_opt_set(encoder_codec_context->priv_data, "master-display", params->master_display, 0);
 
-        if ((params->profile == NULL || strlen(params->profile) == 0) && params->bitdepth < 10) {
-            /* If not specified or if bitdepth is specified but <10, assume 10 bits */
+        /* Add HDR10 color metadata into AVCodecContext (populates the colr box) */
+        encoder_codec_context->color_range     = AVCOL_RANGE_MPEG;       // "tv"
+        encoder_codec_context->color_primaries = AVCOL_PRI_BT2020;
+        encoder_codec_context->color_trc       = AVCOL_TRC_SMPTE2084;    // PQ (ST 2084)
+        encoder_codec_context->colorspace      = AVCOL_SPC_BT2020_NCL;   // bt2020nc
+
+        /* HDR10 requires 10bit and main10 - set if not specified */
+        if (params->profile == NULL || strlen(params->profile) == 0) {
             av_opt_set(encoder_codec_context->priv_data, "profile", "main10", 0);
+        } else if (strcmp(params->profile, "main10") != 0) {
+            elv_err("HDR (master_display set) requires profile=main10, got profile=%s, url=%s",
+                params->profile, params->url);
+            return eav_param;
         }
+        /* Always force 10-bit */
+        encoder_codec_context->pix_fmt = AV_PIX_FMT_YUV420P10LE;
     }
+
+    /* Stereoscopic frame packing (HEVC SEI: Frame Packing Arrangement SEI) */
+    if (params->video_layout == video_layout_sbs) {
+        off += snprintf(x265_params + off, sizeof(x265_params) - off,
+            "%sframe-packing=%d", off > 0 ? ":" : "", video_layout_sbs);
+    }
+
+    if (off > 0)
+        av_opt_set(encoder_codec_context->priv_data, "x265-params", x265_params, 0);
 
     /* Set the number of bframes to 0 and avoid having bframes */
     av_opt_set_int(encoder_codec_context->priv_data, "bframes", 0, 0);
@@ -803,6 +836,7 @@ set_h265_params(
      * Let X265 encoder picks the level automatically. Setting the level based on
      * resolution and framerate might pick higher level than what is needed.
      */
+    return 0;
 }
 
 static void
@@ -944,7 +978,7 @@ set_nvidia_h264_params(
      */
 }
 
-static void
+static int
 set_nvidia_hevc_params(
     coderctx_t *encoder_context,
     coderctx_t *decoder_context,
@@ -974,8 +1008,8 @@ set_nvidia_hevc_params(
     av_opt_set(encoder_codec_context->priv_data, "preset", "p2", 0); // Valid: p1–p7
     av_opt_set(encoder_codec_context->priv_data, "tune", "hq", 0);   // Valid: hq, ll, ull, lossless, losslesshp
 
-    /* HDR - set max_cll and master_display meta data for HDR content */
-    if (params->max_cll && params->max_cll[0] != '\0')
+    /* HDR - set max_cll and master_display meta data for HDR content (skip if "0,0") */
+    if (params->max_cll && params->max_cll[0] != '\0' && strcmp(params->max_cll, "0,0") != 0)
         av_opt_set(encoder_codec_context->priv_data, "max_cll", params->max_cll, 0);
     if (params->master_display && params->master_display[0] != '\0') {
         encoder_codec_context->pix_fmt        = AV_PIX_FMT_P010;                 // 10-bit
@@ -985,11 +1019,17 @@ set_nvidia_hevc_params(
         encoder_codec_context->colorspace     = AVCOL_SPC_BT2020_NCL;            // bt2020nc
         av_opt_set(encoder_codec_context->priv_data, "master_display", params->master_display, 0);
 
-        if ((params->profile == NULL || strlen(params->profile) == 0) && params->bitdepth < 10) {
-            /* If not specified or if bitdepth is specified but <10, assume 10 bits */
+        /* HDR10 requires 10bit and main10 - set if not specified */
+        if (params->profile == NULL || strlen(params->profile) == 0) {
             av_opt_set(encoder_codec_context->priv_data, "profile", "main10", 0);
+        } else if (strcmp(params->profile, "main10") != 0) {
+            elv_err("HDR (master_display set) requires profile=main10, got profile=%s, url=%s",
+                params->profile, params->url);
+            return eav_param;
         }
     }
+
+    return 0;
 }
 
 static int
@@ -1222,11 +1262,13 @@ prepare_video_encoder(
 
     if (!strcmp(params->ecodec, "h264_nvenc"))
         set_nvidia_h264_params(encoder_context, decoder_context, params);
-    else if (!strcmp(params->ecodec, "hevc_nvenc"))
-        set_nvidia_hevc_params(encoder_context, decoder_context, params);
-    else if (!strcmp(params->ecodec, "libx265"))
-        set_h265_params(encoder_context, decoder_context, params);
-    else if (!strcmp(params->ecodec, "h264_ni_enc") || !strcmp(params->ecodec, "h264_ni_quadra_enc"))
+    else if (!strcmp(params->ecodec, "hevc_nvenc")) {
+        if ((rc = set_nvidia_hevc_params(encoder_context, decoder_context, params)) != eav_success)
+            return rc;
+    } else if (!strcmp(params->ecodec, "libx265")) {
+        if ((rc = set_h265_params(encoder_context, decoder_context, params)) != eav_success)
+            return rc;
+    } else if (!strcmp(params->ecodec, "h264_ni_enc") || !strcmp(params->ecodec, "h264_ni_quadra_enc"))
         set_netint_h264_params(encoder_context, decoder_context, params);
     else if (!strcmp(params->ecodec, "h265_ni_enc"))
         set_netint_h265_params(encoder_context, decoder_context, params);
@@ -1258,6 +1300,23 @@ prepare_video_encoder(
             encoder_context->codec_context[index]) < 0) {
         elv_err("could not copy encoder parameters to output stream");
         return eav_codec_param;
+    }
+
+    /* For stereoscopic video - add AV_PKT_DATA_STEREO3D (stvi box) */
+    if (params->video_layout == video_layout_sbs) {
+        AVPacketSideData *sd = av_packet_side_data_new(
+            &encoder_context->stream[index]->codecpar->coded_side_data,
+            &encoder_context->stream[index]->codecpar->nb_coded_side_data,
+            AV_PKT_DATA_STEREO3D, sizeof(AVStereo3D), 0);
+        if (sd) {
+            AVStereo3D *s3d = (AVStereo3D *)sd->data;
+            memset(s3d, 0, sizeof(*s3d));
+            s3d->type = AV_STEREO3D_SIDEBYSIDE;
+            /* view=PACKED + no flags: left view in left half, right view in right half */
+            s3d->view = AV_STEREO3D_VIEW_PACKED;
+        } else {
+            elv_warn("Failed to attach stereo3d side data to output stream");
+        }
     }
 
     encoder_context->stream[index]->time_base = encoder_codec_context->time_base;
@@ -4540,6 +4599,7 @@ log_params(
         "listen=%d "
         "max_cll=\"%s\" "
         "master_display=\"%s\" "
+        "video_layout=%d "
         "filter_descriptor=\"%s\" "
         "extract_image_interval_ts=%"PRId64" "
         "extract_images_sz=%d "
@@ -4572,6 +4632,7 @@ log_params(
         params->bitdepth, params->listen,
         params->max_cll ? params->max_cll : "",
         params->master_display ? params->master_display : "",
+        params->video_layout,
         params->filter_descriptor,
         params->extract_image_interval_ts, params->extract_images_sz,
         1, params->video_time_base, params->video_frame_duration_ts, params->rotate,


### PR DESCRIPTION
- add parameters for video_layout (SBS - side by side)
- add logic for HDR10 to derive the bit depth and profile main10 correctly (if not specified by xc params)
- enhance HDR10 HEVC to create the proper HEVC bitstream and MP4 container stream and frame level metadata
- add SBS video layout parameters to HEVC bitstream and MP4
- add full mez + HDR test and verify container and HEVC bitstream parameters