### PR TITLE
Fix HDR/SDR colors in mp4 and HEVC/AVC

### DIFF
--- a/avpipe_test.go
+++ b/avpipe_test.go
@@ -39,6 +39,9 @@ const (
 	hdr10MaxCLL         = "1000,400"
 )
 
+// enableNvenc enables tests on NVIDIA GPU
+const enableNvenc = false
+
 type XcTestResult struct {
 	mezFile           []string
 	timeScale         int
@@ -1815,9 +1818,13 @@ func TestHEVC_H265ABRTranscode(t *testing.T) {
 
 }
 
-// TestHEVC_HDR10_MezAndABR creates a mez from source and ABR rungs from mez
-// Validates: pix_fmt, profile, and colr/mdcv/clli
-func TestHEVC_HDR10_MezAndABR(t *testing.T) {
+// runHEVCHDR10MezAndABR is the test body for HDR10 mez + ABR with configurable encoder
+// Validates: pix_fmt, profile, and colr/mdcv/clli through:
+//
+//	source -> mez (HEVC, full-res)
+//	mez    -> ABR bypass (no re-encode)
+//	mez    -> ABR re-encode (720p)
+func runHEVCHDR10MezAndABR(t *testing.T, ecodec string) {
 	f := fn()
 	if testing.Short() {
 		t.Skip("SKIPPING " + f + " (fast mode)")
@@ -1840,7 +1847,7 @@ func TestHEVC_HDR10_MezAndABR(t *testing.T) {
 		DurationTs:        hdr10TestDurationTs,
 		StartSegmentStr:   "1",
 		SegDuration:       "30",
-		Ecodec:            "libx265",
+		Ecodec:            ecodec,
 		Dcodec:            "hevc",
 		EncHeight:         -1, // preserve 2160
 		EncWidth:          -1, // preserve 3840
@@ -1865,6 +1872,10 @@ func TestHEVC_HDR10_MezAndABR(t *testing.T) {
 		Height:           2160,
 		MasteringDisplay: hdr10MasterDisplay, // round-trips bit-exact through x265 → mp4 → probe
 		MaxCLL:           hdr10MaxCLL,
+	}
+	if ecodec == "hevc_nvenc" {
+		// nvenc uses P010 (semi-planar 10-bit) instead of YUV420P10LE.
+		mezExpected.PixFmt = "p010le"
 	}
 	assertHDR10(t, path.Join(mezDir, "vsegment-1.mp4"), mezExpected)
 	assertHDR10(t, path.Join(mezDir, "vsegment-2.mp4"), mezExpected)
@@ -1911,6 +1922,22 @@ func TestHEVC_HDR10_MezAndABR(t *testing.T) {
 
 		assertHDR10(t, dashVideoInit(t, abrDir), scaledExpected)
 	}
+}
+
+// TestHEVC_HDR10_MezAndABR creates a mez from source and ABR rungs from mez,
+// using libx265 (CPU). Validates: pix_fmt, profile, and colr/mdcv/clli.
+func TestHEVC_HDR10_MezAndABR(t *testing.T) {
+	runHEVCHDR10MezAndABR(t, "libx265")
+}
+
+// TestHEVC_HDR10_MezAndABR_Nvenc creates a mez from souce and ABR rungs from mez,
+// sing nvenc (GPU).
+// Requires enableNvenc
+func TestHEVC_HDR10_MezAndABR_Nvenc(t *testing.T) {
+	if !enableNvenc {
+		t.Skip("enableNvenc=false; skipping hevc_nvenc HDR10 test")
+	}
+	runHEVCHDR10MezAndABR(t, "hevc_nvenc")
 }
 
 func TestAVPipeStats(t *testing.T) {

--- a/avpipe_test.go
+++ b/avpipe_test.go
@@ -1870,12 +1870,8 @@ func runHEVCHDR10MezAndABR(t *testing.T, ecodec string) {
 		ColorRange:       "tv",
 		Width:            3840,
 		Height:           2160,
-		MasteringDisplay: hdr10MasterDisplay, // round-trips bit-exact through x265 → mp4 → probe
+		MasteringDisplay: hdr10MasterDisplay,
 		MaxCLL:           hdr10MaxCLL,
-	}
-	if ecodec == "hevc_nvenc" {
-		// nvenc uses P010 (semi-planar 10-bit) instead of YUV420P10LE.
-		mezExpected.PixFmt = "p010le"
 	}
 	assertHDR10(t, path.Join(mezDir, "vsegment-1.mp4"), mezExpected)
 	assertHDR10(t, path.Join(mezDir, "vsegment-2.mp4"), mezExpected)

--- a/elvxc/cmd/probe.go
+++ b/elvxc/cmd/probe.go
@@ -98,6 +98,29 @@ func doProbe(cmd *cobra.Command, args []string) error {
 		fmt.Printf("\tsample_aspect_ratio: %d:%d\n", info.SampleAspectRatio.Num(), info.SampleAspectRatio.Denom())
 		fmt.Printf("\tdisplay_aspect_ratio: %d:%d\n", info.DisplayAspectRatio.Num(), info.DisplayAspectRatio.Denom())
 		fmt.Printf("\tfield_order: %s\n", info.FieldOrder)
+		if info.CodecType == "video" {
+			if info.ColorPrimaries != "" {
+				fmt.Printf("\tcolor_primaries: %s\n", info.ColorPrimaries)
+			}
+			if info.ColorTransfer != "" {
+				fmt.Printf("\tcolor_transfer: %s\n", info.ColorTransfer)
+			}
+			if info.ColorSpace != "" {
+				fmt.Printf("\tcolor_space: %s\n", info.ColorSpace)
+			}
+			if info.ColorRange != "" {
+				fmt.Printf("\tcolor_range: %s\n", info.ColorRange)
+			}
+			if info.MasteringDisplay != "" {
+				fmt.Printf("\tmastering_display: %s\n", info.MasteringDisplay)
+			}
+			if info.MaxCLL != "" {
+				fmt.Printf("\tmax_cll: %s\n", info.MaxCLL)
+			}
+			if info.Stereo3DType != "" {
+				fmt.Printf("\tstereo3d_type: %s\n", info.Stereo3DType)
+			}
+		}
 		/* TODO: Make this a switch based on different SideData */
 		if info.SideData != nil && len(info.SideData) > 0 {
 			displayMatrix, ok := info.SideData[0].(avpipe.SideDataDisplayMatrix)

--- a/libavpipe/include/avpipe_utils.h
+++ b/libavpipe/include/avpipe_utils.h
@@ -50,6 +50,19 @@ void
 dump_stream(
     AVStream *s);
 
+/*
+ * Log color metadata (decode or encode)
+ */
+void
+log_color_metadata(
+    const char *stage,
+    int stream_index,
+    enum AVColorPrimaries pri,
+    enum AVColorTransferCharacteristic trc,
+    enum AVColorSpace spc,
+    enum AVColorRange rng,
+    const char *url);
+
 void
 save_gray_frame(
     unsigned char *buf,

--- a/libavpipe/src/avpipe_codec.c
+++ b/libavpipe/src/avpipe_codec.c
@@ -109,6 +109,14 @@ format_max_cll(
     return eav_success;
 }
 
+/*
+ * Emit the MDCV atom - parse x265 master-display string and write to coded_side_data.
+ * Used by both libx265 and nvenc.
+ * Must be called before avcodec_open2().
+ *
+ * Returns eav_success on success, eav_param if the string can't be parsed,
+ * or eav_mem_alloc if side-data allocation fails.
+ */
 int
 attach_master_display(
     AVCodecContext *ctx,
@@ -119,14 +127,11 @@ attach_master_display(
     if (rc != eav_success)
         return rc;
 
-    /* Set HDR metadata (CLL / MDCV) - applies to both libx265 and nvenc wrapper.
-     * Must be set before the encoder is opened (avcodec_open2). */
-    AVFrameSideData *sd = av_frame_side_data_new(
-        &ctx->decoded_side_data,
-        &ctx->nb_decoded_side_data,
-        AV_FRAME_DATA_MASTERING_DISPLAY_METADATA,
-        sizeof(m),
-        AV_FRAME_SIDE_DATA_FLAG_UNIQUE);
+    AVPacketSideData *sd = av_packet_side_data_new(
+        &ctx->coded_side_data,
+        &ctx->nb_coded_side_data,
+        AV_PKT_DATA_MASTERING_DISPLAY_METADATA,
+        sizeof(m), 0);
     if (!sd) {
         elv_err("attach_master_display: side data allocation failed");
         return eav_mem_alloc;
@@ -135,8 +140,69 @@ attach_master_display(
     return eav_success;
 }
 
+/*
+ * Emit CLLI atom - parse "<MaxCLL>,<MaxFALL>" and write to coded_side-data.
+ * Used by both libx265 and nvenc.
+ * Must be called before avcodec_open2().
+ */
 int
 attach_max_cll(
+    AVCodecContext *ctx,
+    const char *s)
+{
+    AVContentLightMetadata c;
+    int rc = parse_max_cll(s, &c);
+    if (rc != eav_success)
+        return rc;
+
+    AVPacketSideData *sd = av_packet_side_data_new(
+        &ctx->coded_side_data,
+        &ctx->nb_coded_side_data,
+        AV_PKT_DATA_CONTENT_LIGHT_LEVEL,
+        sizeof(c), 0);
+    if (!sd) {
+        elv_err("attach_max_cll: side data allocation failed");
+        return eav_mem_alloc;
+    }
+    memcpy(sd->data, &c, sizeof(c));
+    return eav_success;
+}
+
+/*
+ * nvenc-only attach mastering display metadata as AV_FRAME_DATA_MASTERING_DISPLAY_METADATA
+ * on ctx->decoded_side_data so nvenc wrapper enables SEI 137 emission.
+ * Must be called before avcodec_open2().
+ */
+int
+attach_master_display_nvenc(
+    AVCodecContext *ctx,
+    const char *s)
+{
+    AVMasteringDisplayMetadata m;
+    int rc = parse_master_display(s, &m);
+    if (rc != eav_success)
+        return rc;
+
+    AVFrameSideData *sd = av_frame_side_data_new(
+        &ctx->decoded_side_data,
+        &ctx->nb_decoded_side_data,
+        AV_FRAME_DATA_MASTERING_DISPLAY_METADATA,
+        sizeof(m), 0);
+    if (!sd) {
+        elv_err("attach_master_display_nvenc: side data allocation failed");
+        return eav_mem_alloc;
+    }
+    memcpy(sd->data, &m, sizeof(m));
+    return eav_success;
+}
+
+/*
+ * nvenc-only attach max_cll as AV_FRAME_DATA_CONTENT_LIGHT_LEVEL
+ * on decoded_side_data so nvenc wrapper emits the clli SEI.
+ * Must be called before avcodec_open2().
+ */
+int
+attach_max_cll_nvenc(
     AVCodecContext *ctx,
     const char *s)
 {
@@ -149,10 +215,9 @@ attach_max_cll(
         &ctx->decoded_side_data,
         &ctx->nb_decoded_side_data,
         AV_FRAME_DATA_CONTENT_LIGHT_LEVEL,
-        sizeof(c),
-        AV_FRAME_SIDE_DATA_FLAG_UNIQUE);
+        sizeof(c), 0);
     if (!sd) {
-        elv_err("attach_max_cll: side data allocation failed");
+        elv_err("attach_max_cll_nvenc: side data allocation failed");
         return eav_mem_alloc;
     }
     memcpy(sd->data, &c, sizeof(c));

--- a/libavpipe/src/avpipe_codec.c
+++ b/libavpipe/src/avpipe_codec.c
@@ -170,7 +170,7 @@ attach_max_cll(
 
 /*
  * nvenc-only attach mastering display metadata as AV_FRAME_DATA_MASTERING_DISPLAY_METADATA
- * on ctx->decoded_side_data so nvenc wrapper enables SEI 137 emission.
+ * on decoded_side_data so nvenc wrapper adds SEI mdcv
  * Must be called before avcodec_open2().
  */
 int
@@ -198,7 +198,7 @@ attach_master_display_nvenc(
 
 /*
  * nvenc-only attach max_cll as AV_FRAME_DATA_CONTENT_LIGHT_LEVEL
- * on decoded_side_data so nvenc wrapper emits the clli SEI.
+ * on decoded_side_data so nvenc wrapper adds SEI clli
  * Must be called before avcodec_open2().
  */
 int

--- a/libavpipe/src/avpipe_codec.c
+++ b/libavpipe/src/avpipe_codec.c
@@ -119,11 +119,14 @@ attach_master_display(
     if (rc != eav_success)
         return rc;
 
-    AVPacketSideData *sd = av_packet_side_data_new(
-        &ctx->coded_side_data,
-        &ctx->nb_coded_side_data,
-        AV_PKT_DATA_MASTERING_DISPLAY_METADATA,
-        sizeof(m), 0);
+    /* Set HDR metadata (CLL / MDCV) - applies to both libx265 and nvenc wrapper.
+     * Must be set before the encoder is opened (avcodec_open2). */
+    AVFrameSideData *sd = av_frame_side_data_new(
+        &ctx->decoded_side_data,
+        &ctx->nb_decoded_side_data,
+        AV_FRAME_DATA_MASTERING_DISPLAY_METADATA,
+        sizeof(m),
+        AV_FRAME_SIDE_DATA_FLAG_UNIQUE);
     if (!sd) {
         elv_err("attach_master_display: side data allocation failed");
         return eav_mem_alloc;
@@ -142,11 +145,12 @@ attach_max_cll(
     if (rc != eav_success)
         return rc;
 
-    AVPacketSideData *sd = av_packet_side_data_new(
-        &ctx->coded_side_data,
-        &ctx->nb_coded_side_data,
-        AV_PKT_DATA_CONTENT_LIGHT_LEVEL,
-        sizeof(c), 0);
+    AVFrameSideData *sd = av_frame_side_data_new(
+        &ctx->decoded_side_data,
+        &ctx->nb_decoded_side_data,
+        AV_FRAME_DATA_CONTENT_LIGHT_LEVEL,
+        sizeof(c),
+        AV_FRAME_SIDE_DATA_FLAG_UNIQUE);
     if (!sd) {
         elv_err("attach_max_cll: side data allocation failed");
         return eav_mem_alloc;

--- a/libavpipe/src/avpipe_codec.h
+++ b/libavpipe/src/avpipe_codec.h
@@ -56,9 +56,10 @@ format_max_cll(
     const AVContentLightMetadata *c);
 
 /*
- * Parse 265 master-display string and attach as
- * AV_PKT_DATA_MASTERING_DISPLAY_METADATA on ctx->coded_side_data.
- * Instructs mp4 muxer to write the mdcv box
+ * Parse x265 master-display string and attach as
+ * AV_FRAME_DATA_MASTERING_DISPLAY_METADATA on ctx->decoded_side_data.
+ * Applies to both libx265 and nvenc wrapper
+ * Must be called before avcodec_open2().
  *
  * Returns eav_success on success, eav_param if the string can't be parsed,
  * or eav_mem_alloc if side-data allocation fails.
@@ -69,9 +70,10 @@ attach_master_display(
     const char *s);
 
 /*
- * Parse "<MaxCLL>,<MaxFALL>" and attach as AV_PKT_DATA_CONTENT_LIGHT_LEVEL
- * on ctx->coded_side_data.
- * Instructs mp4 muxer to write the clli box
+ * Parse "<MaxCLL>,<MaxFALL>" and attach as AV_FRAME_DATA_CONTENT_LIGHT_LEVEL
+ * on ctx->decoded_side_data.
+ * Applies to both libx265 and nvenc wrapper
+ * Must be called before avcodec_open2().
  */
 int
 attach_max_cll(

--- a/libavpipe/src/avpipe_codec.h
+++ b/libavpipe/src/avpipe_codec.h
@@ -55,27 +55,22 @@ format_max_cll(
     size_t buf_size,
     const AVContentLightMetadata *c);
 
-/*
- * Parse x265 master-display string and attach as
- * AV_FRAME_DATA_MASTERING_DISPLAY_METADATA on ctx->decoded_side_data.
- * Applies to both libx265 and nvenc wrapper
- * Must be called before avcodec_open2().
- *
- * Returns eav_success on success, eav_param if the string can't be parsed,
- * or eav_mem_alloc if side-data allocation fails.
- */
 int
 attach_master_display(
     AVCodecContext *ctx,
     const char *s);
 
-/*
- * Parse "<MaxCLL>,<MaxFALL>" and attach as AV_FRAME_DATA_CONTENT_LIGHT_LEVEL
- * on ctx->decoded_side_data.
- * Applies to both libx265 and nvenc wrapper
- * Must be called before avcodec_open2().
- */
 int
 attach_max_cll(
+    AVCodecContext *ctx,
+    const char *s);
+
+int
+attach_master_display_nvenc(
+    AVCodecContext *ctx,
+    const char *s);
+
+int
+attach_max_cll_nvenc(
     AVCodecContext *ctx,
     const char *s);

--- a/libavpipe/src/avpipe_format.c
+++ b/libavpipe/src/avpipe_format.c
@@ -500,12 +500,11 @@ verify_hdr_source_color(
 }
 
 /*
- * Copy source color metadata from decoder stream codecpar to encoder stream codecpar.
- * Only fields that are specified in the source are copied; UNSPECIFIED fields are left alone.
- * Caller must invoke this AFTER avcodec_parameters_from_context() so that codecpar values
- * are not overwritten by the encoder context defaults. Because the encoder context fields
- * are left UNSPECIFIED, the elementary stream VUI signals nothing - only the mp4 'colr' atom
- * carries the source values.
+ * Copy source color metadata into encoder codec context if specified
+ * Must be called before avcodec_open2().
+ *
+ * Setting both VUI and colr is required for HEVC (HEVC decoder overrides codecpar->color*
+ * with the SPS VUI values).
  */
 void
 copy_source_color_to_output(
@@ -515,16 +514,16 @@ copy_source_color_to_output(
     int idx = decoder_context->video_stream_index;
     if (idx < 0 || !decoder_context->stream[idx] || !decoder_context->stream[idx]->codecpar)
         return;
-    if (!encoder_context->stream[idx] || !encoder_context->stream[idx]->codecpar)
+    if (!encoder_context->codec_context[idx])
         return;
     AVCodecParameters *src = decoder_context->stream[idx]->codecpar;
-    AVCodecParameters *dst = encoder_context->stream[idx]->codecpar;
+    AVCodecContext    *dst = encoder_context->codec_context[idx];
     if (src->color_primaries != AVCOL_PRI_UNSPECIFIED)
         dst->color_primaries = src->color_primaries;
     if (src->color_trc != AVCOL_TRC_UNSPECIFIED)
         dst->color_trc = src->color_trc;
     if (src->color_space != AVCOL_SPC_UNSPECIFIED)
-        dst->color_space = src->color_space;
+        dst->colorspace = src->color_space;
     if (src->color_range != AVCOL_RANGE_UNSPECIFIED)
         dst->color_range = src->color_range;
 }

--- a/libavpipe/src/avpipe_format.c
+++ b/libavpipe/src/avpipe_format.c
@@ -462,3 +462,69 @@ is_dolby_atmos(
 
     return 0;
 }
+
+/*
+ * Verify the source video color metadata matches expected HDR overrides.
+ */
+void
+verify_hdr_source_color(
+    coderctx_t *decoder_context,
+    xcparams_t *params)
+{
+    int idx = decoder_context->video_stream_index;
+    if (idx < 0 || !decoder_context->stream[idx] || !decoder_context->stream[idx]->codecpar)
+        return;
+    AVCodecParameters *src = decoder_context->stream[idx]->codecpar;
+    const char *url = params ? params->url : "";
+
+    if (src->color_primaries != AVCOL_PRI_BT2020) {
+        const char *n = av_color_primaries_name(src->color_primaries);
+        elv_warn("HDR source color_primaries mismatch: expected bt2020(%d), source=%s(%d), url=%s",
+            (int)AVCOL_PRI_BT2020, n ? n : "?", (int)src->color_primaries, url);
+    }
+    if (src->color_trc != AVCOL_TRC_SMPTE2084) {
+        const char *n = av_color_transfer_name(src->color_trc);
+        elv_warn("HDR source transfer mismatch: expected smpte2084(%d), source=%s(%d), url=%s",
+            (int)AVCOL_TRC_SMPTE2084, n ? n : "?", (int)src->color_trc, url);
+    }
+    if (src->color_space != AVCOL_SPC_BT2020_NCL) {
+        const char *n = av_color_space_name(src->color_space);
+        elv_warn("HDR source matrix mismatch: expected bt2020nc(%d), source=%s(%d), url=%s",
+            (int)AVCOL_SPC_BT2020_NCL, n ? n : "?", (int)src->color_space, url);
+    }
+    if (src->color_range != AVCOL_RANGE_MPEG) {
+        const char *n = av_color_range_name(src->color_range);
+        elv_warn("HDR source range mismatch: expected tv/MPEG(%d), source=%s(%d), url=%s",
+            (int)AVCOL_RANGE_MPEG, n ? n : "?", (int)src->color_range, url);
+    }
+}
+
+/*
+ * Copy source color metadata from decoder stream codecpar to encoder stream codecpar.
+ * Only fields that are specified in the source are copied; UNSPECIFIED fields are left alone.
+ * Caller must invoke this AFTER avcodec_parameters_from_context() so that codecpar values
+ * are not overwritten by the encoder context defaults. Because the encoder context fields
+ * are left UNSPECIFIED, the elementary stream VUI signals nothing - only the mp4 'colr' atom
+ * carries the source values.
+ */
+void
+copy_source_color_to_output(
+    coderctx_t *encoder_context,
+    coderctx_t *decoder_context)
+{
+    int idx = decoder_context->video_stream_index;
+    if (idx < 0 || !decoder_context->stream[idx] || !decoder_context->stream[idx]->codecpar)
+        return;
+    if (!encoder_context->stream[idx] || !encoder_context->stream[idx]->codecpar)
+        return;
+    AVCodecParameters *src = decoder_context->stream[idx]->codecpar;
+    AVCodecParameters *dst = encoder_context->stream[idx]->codecpar;
+    if (src->color_primaries != AVCOL_PRI_UNSPECIFIED)
+        dst->color_primaries = src->color_primaries;
+    if (src->color_trc != AVCOL_TRC_UNSPECIFIED)
+        dst->color_trc = src->color_trc;
+    if (src->color_space != AVCOL_SPC_UNSPECIFIED)
+        dst->color_space = src->color_space;
+    if (src->color_range != AVCOL_RANGE_UNSPECIFIED)
+        dst->color_range = src->color_range;
+}

--- a/libavpipe/src/avpipe_format.h
+++ b/libavpipe/src/avpipe_format.h
@@ -96,20 +96,11 @@ int
 is_dolby_atmos(
     const AVStream *stream);
 
-/*
- * Verify the source video color metadata matches expected HDR overrides.
- */
 void
 verify_hdr_source_color(
     coderctx_t *decoder_context,
     xcparams_t *params);
 
-/*
- * Copy source video color metadata (primaries, transfer, matrix, range) from the decoder
- * stream codecpar onto the encoder stream codecpar so the mp4 'colr' atom carries them.
- * Only fields specified in the source are copied; UNSPECIFIED fields are left alone.
- * Must be called AFTER avcodec_parameters_from_context().
- */
 void
 copy_source_color_to_output(
     coderctx_t *encoder_context,

--- a/libavpipe/src/avpipe_format.h
+++ b/libavpipe/src/avpipe_format.h
@@ -95,3 +95,22 @@ is_mvhevc(
 int
 is_dolby_atmos(
     const AVStream *stream);
+
+/*
+ * Verify the source video color metadata matches expected HDR overrides.
+ */
+void
+verify_hdr_source_color(
+    coderctx_t *decoder_context,
+    xcparams_t *params);
+
+/*
+ * Copy source video color metadata (primaries, transfer, matrix, range) from the decoder
+ * stream codecpar onto the encoder stream codecpar so the mp4 'colr' atom carries them.
+ * Only fields specified in the source are copied; UNSPECIFIED fields are left alone.
+ * Must be called AFTER avcodec_parameters_from_context().
+ */
+void
+copy_source_color_to_output(
+    coderctx_t *encoder_context,
+    coderctx_t *decoder_context);

--- a/libavpipe/src/avpipe_utils.c
+++ b/libavpipe/src/avpipe_utils.c
@@ -223,6 +223,29 @@ dump_stream(
 }
 
 void
+log_color_metadata(
+    const char *stage,
+    int stream_index,
+    enum AVColorPrimaries pri,
+    enum AVColorTransferCharacteristic trc,
+    enum AVColorSpace spc,
+    enum AVColorRange rng,
+    const char *url)
+{
+    const char *pri_name = av_color_primaries_name(pri);
+    const char *trc_name = av_color_transfer_name(trc);
+    const char *spc_name = av_color_space_name(spc);
+    const char *rng_name = av_color_range_name(rng);
+    elv_log("COLOR %s stream=%d primaries=%s(%d) transfer=%s(%d) matrix=%s(%d) range=%s(%d), url=%s",
+        stage, stream_index,
+        pri_name ? pri_name : "?", (int)pri,
+        trc_name ? trc_name : "?", (int)trc,
+        spc_name ? spc_name : "?", (int)spc,
+        rng_name ? rng_name : "?", (int)rng,
+        url ? url : "");
+}
+
+void
 save_gray_frame(
     unsigned char *buf,
     int wrap,

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -1032,17 +1032,27 @@ set_nvidia_hevc_params(
     av_opt_set(encoder_codec_context->priv_data, "preset", "p2", 0); // Valid: p1–p7
     av_opt_set(encoder_codec_context->priv_data, "tune", "hq", 0);   // Valid: hq, ll, ull, lossless, losslesshp
 
-    /* HDR for nvenc requires both side-data paths:
-     *   - coded_side_data: read by the mp4 muxer to emit the 'mdcv'/'clli' atoms
-     *   - decoded_side_data: read by ffmpeg's nvenc wrapper at avcodec_open2() to
-     *     emit the in-stream SEI 137 (mdcv) and SEI 144 (clli) messages
-     * (nvenc has no master_display/max_cll AVOption)
-     */
+    /* HDR for nvenc:
+     *   - mp4 'mdcv'/'clli' atoms via coded_side_data: safe and necessary so the
+     *     container carries HDR metadata (mediainfo and HDR-aware demuxers read it).
+     *   - in-stream SEI 137/144 emission via decoded_side_data: DISABLED (#if 0).
+     *     Setting pMasteringDisplay/pMaxCll on NV_ENC_PIC_PARAMS triggers an
+     *     invalid-pointer free inside libnvidia-encode.so during nvEncEncodePicture
+     *     (tcmalloc abort, stack: nvenc.c:3244 -> libnvidia-encode -> tcmalloc -> abort).
+     *     Confirmed via core-dump backtrace 2026-05-05; reproducible per frame
+     *     when pMasteringDisplay is non-NULL. Flip NVENC_HDR_SEI to 1 to re-enable
+     *     once the NVENC driver/SDK ships a fix.
+     * nvenc has no master_display/max_cll AVOption; until the NVIDIA bug is
+     * resolved, downstream HDR signaling for nvenc output relies on the mp4
+     * atoms (and the colr/VUI fields set on the encoder context below). */
+#define NVENC_HDR_SEI 0   /* re-enable once NVIDIA fixes libnvidia-encode.so HDR pic_params handling */
     if (params->max_cll && params->max_cll[0] != '\0' && strcmp(params->max_cll, "0,0") != 0) {
         if (attach_max_cll(encoder_codec_context, params->max_cll) != eav_success)
-            elv_warn("set_nvidia_hevc_params: failed to attach max_cll coded side data, url=%s", params->url);
+            elv_warn("set_nvidia_hevc_params: failed to attach max_cll side data, url=%s", params->url);
+#if NVENC_HDR_SEI
         if (attach_max_cll_nvenc(encoder_codec_context, params->max_cll) != eav_success)
             elv_warn("set_nvidia_hevc_params: failed to attach max_cll decoded side data, url=%s", params->url);
+#endif
     }
     if (params->master_display && params->master_display[0] != '\0') {
         /* HDR override: verify source color matches BT2020/PQ/BT2020nc/MPEG and warn for any mismatch.
@@ -1057,10 +1067,12 @@ set_nvidia_hevc_params(
 
         /* mp4 'mdcv' atom side data */
         if (attach_master_display(encoder_codec_context, params->master_display) != eav_success)
-            elv_warn("set_nvidia_hevc_params: failed to attach master_display coded side data, url=%s", params->url);
-        /* SEI 137 emission (nvenc-specific path) */
+            elv_warn("set_nvidia_hevc_params: failed to attach master_display side data, url=%s", params->url);
+#if NVENC_HDR_SEI
+        /* SEI 137 emission (nvenc-specific path) - disabled, see NVENC_HDR_SEI above */
         if (attach_master_display_nvenc(encoder_codec_context, params->master_display) != eav_success)
             elv_warn("set_nvidia_hevc_params: failed to attach master_display decoded side data, url=%s", params->url);
+#endif
 
         /* HDR10 requires 10bit and main10 - set if not specified */
         if (params->profile == NULL || strlen(params->profile) == 0) {

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -1035,7 +1035,7 @@ set_nvidia_hevc_params(
     /* HDR for nvenc:
      *   - mp4 'mdcv'/'clli' atoms via coded_side_data: safe and necessary so the
      *     container carries HDR metadata (mediainfo and HDR-aware demuxers read it).
-     *   - in-stream SEI 137/144 emission via decoded_side_data: DISABLED (#if 0).
+     *   - in-stream SEI 137/144 emission via decoded_side_data: currently disabled (NVENC_HDR_SEI)
      *     Setting pMasteringDisplay/pMaxCll on NV_ENC_PIC_PARAMS triggers an
      *     invalid-pointer free inside libnvidia-encode.so during nvEncEncodePicture
      *     (tcmalloc abort, stack: nvenc.c:3244 -> libnvidia-encode -> tcmalloc -> abort).
@@ -1045,7 +1045,6 @@ set_nvidia_hevc_params(
      * nvenc has no master_display/max_cll AVOption; until the NVIDIA bug is
      * resolved, downstream HDR signaling for nvenc output relies on the mp4
      * atoms (and the colr/VUI fields set on the encoder context below). */
-#define NVENC_HDR_SEI 0   /* re-enable once NVIDIA fixes libnvidia-encode.so HDR pic_params handling */
     if (params->max_cll && params->max_cll[0] != '\0' && strcmp(params->max_cll, "0,0") != 0) {
         if (attach_max_cll(encoder_codec_context, params->max_cll) != eav_success)
             elv_warn("set_nvidia_hevc_params: failed to attach max_cll side data, url=%s", params->url);
@@ -1340,8 +1339,14 @@ prepare_video_encoder(
     else
         set_h264_params(encoder_context, decoder_context, params);
 
-    /* Preserve source color metadata for non-HDR */
-    if (!(params->master_display && params->master_display[0] != '\0')) {
+    /* Preserve source color metadata for non-HDR in SPS VUI.
+     *
+     * Do NOT copy source color onto encoder_codec_context for nvenc encoders due to a bug/crash
+     * observed with version 595/13.2
+     */
+    if (!(params->master_display && params->master_display[0] != '\0') &&
+        strcmp(params->ecodec, "hevc_nvenc") != 0 &&
+        strcmp(params->ecodec, "h264_nvenc") != 0) {
         copy_source_color_to_output(encoder_context, decoder_context);
     }
 

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -1319,6 +1319,11 @@ prepare_video_encoder(
     else
         set_h264_params(encoder_context, decoder_context, params);
 
+    /* Preserve source color metadata for non-HDR */
+    if (!(params->master_display && params->master_display[0] != '\0')) {
+        copy_source_color_to_output(encoder_context, decoder_context);
+    }
+
     elv_log("Output pixel_format=%s, profile=%d, level=%d",
         av_get_pix_fmt_name(encoder_codec_context->pix_fmt),
         encoder_codec_context->profile,
@@ -1344,21 +1349,6 @@ prepare_video_encoder(
             encoder_context->codec_context[index]) < 0) {
         elv_err("could not copy encoder parameters to output stream");
         return eav_codec_param;
-    }
-
-    /*
-     * Preserve source color metadata in the mp4 'colr' atom.
-     *
-     * For non-HDR encodes, encoder_codec_context->color_* are left UNSPECIFIED (the default),
-     * so the elementary stream VUI signals nothing. After avcodec_parameters_from_context()
-     * has copied the (UNSPECIFIED) values to the output codecpar, override them with the
-     * source values so the mp4 muxer writes the source color metadata into the 'colr' atom.
-     *
-     * For HDR (master_display set), the HDR override has already been applied to the encoder
-     * context (BT2020/PQ/BT2020nc/MPEG); skip the source-based override and keep those values.
-     */
-    if (!(params->master_display && params->master_display[0] != '\0')) {
-        copy_source_color_to_output(encoder_context, decoder_context);
     }
 
     log_color_metadata("encode", index,

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -1344,16 +1344,18 @@ prepare_video_encoder(
      * Do NOT copy source color onto encoder_codec_context for nvenc encoders due to a bug/crash
      * observed with version 595/13.2
      */
-    if (!(params->master_display && params->master_display[0] != '\0') &&
-        strcmp(params->ecodec, "hevc_nvenc") != 0 &&
-        strcmp(params->ecodec, "h264_nvenc") != 0) {
+    int source_color_copied = 0;
+    if (!(params->master_display && params->master_display[0] != '\0')) {
         copy_source_color_to_output(encoder_context, decoder_context);
+        source_color_copied = 1;
     }
 
-    elv_log("Output pixel_format=%s, profile=%d, level=%d",
+    elv_log("Output pixel_format=%s, codec=%s, profile=%d, level=%d, color_copied=%d",
         av_get_pix_fmt_name(encoder_codec_context->pix_fmt),
+        params->ecodec,
         encoder_codec_context->profile,
-        encoder_codec_context->level);
+        encoder_codec_context->level,
+        source_color_copied);
 
     /* Set encoder options after setting all codec context parameters */
     rc = set_encoder_options(encoder_context, decoder_context, params, decoder_context->video_stream_index,

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -802,10 +802,13 @@ set_h265_params(
     char x265_params[512] = {0};
     size_t off = 0;
 
-    /* Set max_cll and master_display meta data for HDR content (omit if "0,0") */
+    /* HDR for libx265:
+     *   - SEI 137/144 emission: handled by libx265's "master-display"/"max-cll" AVOptions.
+     *   - mp4 'mdcv'/'clli' atoms: attach_master_display / attach_max_cll write to
+     *     coded_side_data
+     */
     if (params->max_cll && params->max_cll[0] != '\0' && strcmp(params->max_cll, "0,0") != 0) {
         av_opt_set(encoder_codec_context->priv_data, "max-cll", params->max_cll, 0);
-        /* Also attach as side data - mp4 clli box. */
         if (attach_max_cll(encoder_codec_context, params->max_cll) != eav_success)
             elv_warn("set_h265_params: failed to attach max_cll side data, url=%s", params->url);
     }
@@ -818,7 +821,6 @@ set_h265_params(
             "hdr10=1:hdr10-opt=1:repeat-headers=1:colorprim=bt2020:transfer=smpte2084:colormatrix=bt2020nc");
         av_opt_set(encoder_codec_context->priv_data, "master-display", params->master_display, 0);
 
-        /* Attach side data - mp4 muxer mdcv box */
         if (attach_master_display(encoder_codec_context, params->master_display) != eav_success)
             elv_warn("set_h265_params: failed to attach master_display side data, url=%s", params->url);
 
@@ -1030,12 +1032,17 @@ set_nvidia_hevc_params(
     av_opt_set(encoder_codec_context->priv_data, "preset", "p2", 0); // Valid: p1–p7
     av_opt_set(encoder_codec_context->priv_data, "tune", "hq", 0);   // Valid: hq, ll, ull, lossless, losslesshp
 
-    /* HDR - set max_cll and master_display meta data for HDR content (skip if "0,0").
-     * nvenc has no master_display/max_cll AVOption; the data is delivered via
-     * AVCodecContext::decoded_side_data (see attach_max_cll / attach_master_display). */
+    /* HDR for nvenc requires both side-data paths:
+     *   - coded_side_data: read by the mp4 muxer to emit the 'mdcv'/'clli' atoms
+     *   - decoded_side_data: read by ffmpeg's nvenc wrapper at avcodec_open2() to
+     *     emit the in-stream SEI 137 (mdcv) and SEI 144 (clli) messages
+     * (nvenc has no master_display/max_cll AVOption)
+     */
     if (params->max_cll && params->max_cll[0] != '\0' && strcmp(params->max_cll, "0,0") != 0) {
         if (attach_max_cll(encoder_codec_context, params->max_cll) != eav_success)
-            elv_warn("set_nvidia_hevc_params: failed to attach max_cll side data, url=%s", params->url);
+            elv_warn("set_nvidia_hevc_params: failed to attach max_cll coded side data, url=%s", params->url);
+        if (attach_max_cll_nvenc(encoder_codec_context, params->max_cll) != eav_success)
+            elv_warn("set_nvidia_hevc_params: failed to attach max_cll decoded side data, url=%s", params->url);
     }
     if (params->master_display && params->master_display[0] != '\0') {
         /* HDR override: verify source color matches BT2020/PQ/BT2020nc/MPEG and warn for any mismatch.
@@ -1048,10 +1055,12 @@ set_nvidia_hevc_params(
         encoder_codec_context->color_trc      = AVCOL_TRC_SMPTE2084;             // PQ (ST 2084)
         encoder_codec_context->colorspace     = AVCOL_SPC_BT2020_NCL;            // bt2020nc
 
-        /* Side data on decoded_side_data - nvenc reads it at avcodec_open2(), then
-         * pic_params reference it per frame to emit SEI 137 + mp4 mdcv box. */
+        /* mp4 'mdcv' atom side data */
         if (attach_master_display(encoder_codec_context, params->master_display) != eav_success)
-            elv_warn("set_nvidia_hevc_params: failed to attach master_display side data, url=%s", params->url);
+            elv_warn("set_nvidia_hevc_params: failed to attach master_display coded side data, url=%s", params->url);
+        /* SEI 137 emission (nvenc-specific path) */
+        if (attach_master_display_nvenc(encoder_codec_context, params->master_display) != eav_success)
+            elv_warn("set_nvidia_hevc_params: failed to attach master_display decoded side data, url=%s", params->url);
 
         /* HDR10 requires 10bit and main10 - set if not specified */
         if (params->profile == NULL || strlen(params->profile) == 0) {

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -515,6 +515,14 @@ prepare_decoder(
         dump_stream(decoder_context->stream[i]);
         dump_codec_parameters(decoder_context->codec_parameters[i]);
         dump_codec_context(decoder_context->codec_context[i]);
+
+        /* Log source color metadata for video streams (taken from the demuxer codecpar
+         * which reflects mp4 'colr' atom or bitstream VUI as applicable). */
+        if (decoder_context->codec_parameters[i]->codec_type == AVMEDIA_TYPE_VIDEO) {
+            AVCodecParameters *cp = decoder_context->codec_parameters[i];
+            log_color_metadata("decode", i,
+                cp->color_primaries, cp->color_trc, cp->color_space, cp->color_range, url);
+        }
     }
 
     /* If it couldn't find identified stream with params->stream_id, then return an error */
@@ -802,6 +810,10 @@ set_h265_params(
             elv_warn("set_h265_params: failed to attach max_cll side data, url=%s", params->url);
     }
     if (params->master_display && params->master_display[0] != '\0') {
+        /* HDR override: verify source color matches BT2020/PQ/BT2020nc/MPEG and warn for any mismatch.
+         * The HDR override values below are still applied unconditionally. */
+        verify_hdr_source_color(decoder_context, params);
+
         off += snprintf(x265_params + off, sizeof(x265_params) - off,
             "hdr10=1:hdr10-opt=1:repeat-headers=1:colorprim=bt2020:transfer=smpte2084:colormatrix=bt2020nc");
         av_opt_set(encoder_codec_context->priv_data, "master-display", params->master_display, 0);
@@ -810,7 +822,7 @@ set_h265_params(
         if (attach_master_display(encoder_codec_context, params->master_display) != eav_success)
             elv_warn("set_h265_params: failed to attach master_display side data, url=%s", params->url);
 
-        /* Add HDR10 color metadata into AVCodecContext (populates the colr box) */
+        /* Add HDR10 color metadata into AVCodecContext (populates the colr box and elementary stream VUI) */
         encoder_codec_context->color_range     = AVCOL_RANGE_MPEG;       // "tv"
         encoder_codec_context->color_primaries = AVCOL_PRI_BT2020;
         encoder_codec_context->color_trc       = AVCOL_TRC_SMPTE2084;    // PQ (ST 2084)
@@ -1018,21 +1030,26 @@ set_nvidia_hevc_params(
     av_opt_set(encoder_codec_context->priv_data, "preset", "p2", 0); // Valid: p1–p7
     av_opt_set(encoder_codec_context->priv_data, "tune", "hq", 0);   // Valid: hq, ll, ull, lossless, losslesshp
 
-    /* HDR - set max_cll and master_display meta data for HDR content (skip if "0,0") */
+    /* HDR - set max_cll and master_display meta data for HDR content (skip if "0,0").
+     * nvenc has no master_display/max_cll AVOption; the data is delivered via
+     * AVCodecContext::decoded_side_data (see attach_max_cll / attach_master_display). */
     if (params->max_cll && params->max_cll[0] != '\0' && strcmp(params->max_cll, "0,0") != 0) {
-        av_opt_set(encoder_codec_context->priv_data, "max_cll", params->max_cll, 0);
         if (attach_max_cll(encoder_codec_context, params->max_cll) != eav_success)
             elv_warn("set_nvidia_hevc_params: failed to attach max_cll side data, url=%s", params->url);
     }
     if (params->master_display && params->master_display[0] != '\0') {
+        /* HDR override: verify source color matches BT2020/PQ/BT2020nc/MPEG and warn for any mismatch.
+         * The HDR override values below are still applied unconditionally. */
+        verify_hdr_source_color(decoder_context, params);
+
         encoder_codec_context->pix_fmt        = AV_PIX_FMT_P010;                 // 10-bit
         encoder_codec_context->color_range    = AVCOL_RANGE_MPEG;                // "tv"
         encoder_codec_context->color_primaries= AVCOL_PRI_BT2020;
         encoder_codec_context->color_trc      = AVCOL_TRC_SMPTE2084;             // PQ (ST 2084)
         encoder_codec_context->colorspace     = AVCOL_SPC_BT2020_NCL;            // bt2020nc
-        av_opt_set(encoder_codec_context->priv_data, "master_display", params->master_display, 0);
 
-        /* Attach side data - mp4 mdcv box */
+        /* Side data on decoded_side_data - nvenc reads it at avcodec_open2(), then
+         * pic_params reference it per frame to emit SEI 137 + mp4 mdcv box. */
         if (attach_master_display(encoder_codec_context, params->master_display) != eav_success)
             elv_warn("set_nvidia_hevc_params: failed to attach master_display side data, url=%s", params->url);
 
@@ -1173,6 +1190,16 @@ prepare_video_encoder(
             elv_err("Failed to set video encoder options with bypass, url=%s", params->url);
             return rc;
         }
+
+        /* Bypass: codec params (including color metadata) were copied from the source stream
+         * via avcodec_parameters_copy above, so the mp4 'colr' atom and any elementary stream
+         * VUI signaling are passed through unchanged. */
+        log_color_metadata("encode/bypass", index,
+            out_stream->codecpar->color_primaries,
+            out_stream->codecpar->color_trc,
+            out_stream->codecpar->color_space,
+            out_stream->codecpar->color_range,
+            params->url);
         return 0;
     }
 
@@ -1318,6 +1345,28 @@ prepare_video_encoder(
         elv_err("could not copy encoder parameters to output stream");
         return eav_codec_param;
     }
+
+    /*
+     * Preserve source color metadata in the mp4 'colr' atom.
+     *
+     * For non-HDR encodes, encoder_codec_context->color_* are left UNSPECIFIED (the default),
+     * so the elementary stream VUI signals nothing. After avcodec_parameters_from_context()
+     * has copied the (UNSPECIFIED) values to the output codecpar, override them with the
+     * source values so the mp4 muxer writes the source color metadata into the 'colr' atom.
+     *
+     * For HDR (master_display set), the HDR override has already been applied to the encoder
+     * context (BT2020/PQ/BT2020nc/MPEG); skip the source-based override and keep those values.
+     */
+    if (!(params->master_display && params->master_display[0] != '\0')) {
+        copy_source_color_to_output(encoder_context, decoder_context);
+    }
+
+    log_color_metadata("encode", index,
+        encoder_context->stream[index]->codecpar->color_primaries,
+        encoder_context->stream[index]->codecpar->color_trc,
+        encoder_context->stream[index]->codecpar->color_space,
+        encoder_context->stream[index]->codecpar->color_range,
+        params->url);
 
     /* For stereoscopic video - add AV_PKT_DATA_STEREO3D (stvi box) */
     if (params->video_layout == video_layout_sbs) {

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -1035,16 +1035,11 @@ set_nvidia_hevc_params(
     /* HDR for nvenc:
      *   - mp4 'mdcv'/'clli' atoms via coded_side_data: safe and necessary so the
      *     container carries HDR metadata (mediainfo and HDR-aware demuxers read it).
-     *   - in-stream SEI 137/144 emission via decoded_side_data: currently disabled (NVENC_HDR_SEI)
+     *   - in-stream SEI 137/144 via decoded_side_data currently disabled (ifdef NVENC_HDR_SEI)
      *     Setting pMasteringDisplay/pMaxCll on NV_ENC_PIC_PARAMS triggers an
-     *     invalid-pointer free inside libnvidia-encode.so during nvEncEncodePicture
-     *     (tcmalloc abort, stack: nvenc.c:3244 -> libnvidia-encode -> tcmalloc -> abort).
-     *     Confirmed via core-dump backtrace 2026-05-05; reproducible per frame
-     *     when pMasteringDisplay is non-NULL. Flip NVENC_HDR_SEI to 1 to re-enable
-     *     once the NVENC driver/SDK ships a fix.
-     * nvenc has no master_display/max_cll AVOption; until the NVIDIA bug is
-     * resolved, downstream HDR signaling for nvenc output relies on the mp4
-     * atoms (and the colr/VUI fields set on the encoder context below). */
+     *     invalid-pointer free in nvEncEncodePicture (nvenc.c:3244)
+     * (nvenc has no master_display/max_cll AVOption)
+     */
     if (params->max_cll && params->max_cll[0] != '\0' && strcmp(params->max_cll, "0,0") != 0) {
         if (attach_max_cll(encoder_codec_context, params->max_cll) != eav_success)
             elv_warn("set_nvidia_hevc_params: failed to attach max_cll side data, url=%s", params->url);

--- a/xc/mez_e2e_test.go
+++ b/xc/mez_e2e_test.go
@@ -85,10 +85,6 @@ var mezTestSources = []mezTestSource{
 	{"Sintel_30s_5_1_pcm_s24le_60000Hz.mov", "24/1", 48, false, ""},
 	{"ELD2_FHD_4_60s_CCBYblendercloud.mov", "24000/1001", 48, false, ""},
 	{"BBB0_HD_8_XDCAM_120s_CCBYblendercloud.mxf", "60000/1001", 120, false, ""},
-	// libx265 variant of BBB0 - locks color-metadata pass-through for the HEVC
-	// encode path. ffmpeg's HEVC decoder unconditionally overrides codecpar with
-	// the SPS VUI on demux, so a colr-only output gets clobbered on the next
-	// roundtrip; this test catches that regression.
 	{"BBB0_HD_8_XDCAM_120s_CCBYblendercloud.mxf", "60000/1001", 120, false, "libx265"},
 	{"SIN6_4K_MOS_HEVC_60s.mp4", "24000/1001", 48, true, ""},
 	{"video-960.mp4", "30/1", 60, false, ""},

--- a/xc/mez_e2e_test.go
+++ b/xc/mez_e2e_test.go
@@ -54,6 +54,9 @@ const keepMezOutput = true
 // keepSegsOutput prevents cleanup of ABR segment output
 const keepSegsOutput = true
 
+// enableNvenc enables tests on NVIDIA GPU
+const enableNvenc = false
+
 // e2eMode is set to true when tests run inside TestEndToEnd.
 // PENDING(SS) simplify and remove this global so tests can run correctly in parallel
 var e2eMode bool
@@ -110,6 +113,17 @@ func mezTestSourceID(src mezTestSource) string {
 		id += "_" + src.Ecodec
 	}
 	return id
+}
+
+// Append nvenc-encoded variants when enableNvenc is set
+func init() {
+	if !enableNvenc {
+		return
+	}
+	mezTestSources = append(mezTestSources,
+		// SDR HEVC mez via nvenc - sister to the libx265 BBB0 entry above.
+		mezTestSource{"BBB0_HD_8_XDCAM_120s_CCBYblendercloud.mxf", "60000/1001", 120, false, "hevc_nvenc"},
+	)
 }
 
 // ---------------------------------------------------------------------------

--- a/xc/mez_e2e_test.go
+++ b/xc/mez_e2e_test.go
@@ -65,34 +65,51 @@ type mezTestSource struct {
 	FrameRate   string // frame rate as "num/den" (e.g. "30000/1001")
 	ForceKeyInt int32  // key frame interval in frames (e.g. 48)
 	Watermark   bool   // if true, also run watermarked ABR variants
+	Ecodec      string // video encoder name; default "libx264" when empty
 }
 
 // mezTestSources is the list of source files used by TestMezCreate.
-// Format:  file, frame rate, key interval, watermark
+// Format:  file, frame rate, key interval, watermark, ecodec ("" → libx264)
 var mezTestSources = []mezTestSource{
-	{"bbb_1080p_30fps_10sec.mp4", "30/1", 60, false},
-	{"bbb_1080p_30fps_60sec.mp4", "30/1", 60, true},
-	{"bbb_sunflower_2160p_30fps_normal_2min.mp4", "30/1", 60, false},
-	{"bbb_sunflower_2160p_30fps_normal_2min.ts", "30/1", 60, false},
-	{"caminandes_llamigos_1080p_4audios.mp4", "24/1", 48, false},
-	{"03_caminandes_llamigos_1080p.mp4", "24/1", 48, true},
-	{"03_caminandes_llamigos_h265_1080p.mp4", "24/1", 48, false},
-	{"Rigify-2min.mp4", "24/1", 48, false},
-	{"Sintel_30s_5_1_pcm_s24le_60000Hz.mov", "24/1", 48, false},
-	{"ELD2_FHD_4_60s_CCBYblendercloud.mov", "24000/1001", 48, false},
-	{"BBB0_HD_8_XDCAM_120s_CCBYblendercloud.mxf", "60000/1001", 120, false},
-	{"SIN6_4K_MOS_HEVC_60s.mp4", "24000/1001", 48, true},
-	{"video-960.mp4", "30/1", 60, false},
-	{"TOS0_FHD_2_H264_60s_CCBYblendercloud.mp4", "24/1", 48, false},
-	{"TOS8_FHD_51-2_PRHQ_60s_CCBYblendercloud.mov", "24000/1001", 48, false},
+	{"bbb_1080p_30fps_10sec.mp4", "30/1", 60, false, ""},
+	{"bbb_1080p_30fps_60sec.mp4", "30/1", 60, true, ""},
+	{"bbb_sunflower_2160p_30fps_normal_2min.mp4", "30/1", 60, false, ""},
+	{"bbb_sunflower_2160p_30fps_normal_2min.ts", "30/1", 60, false, ""},
+	{"caminandes_llamigos_1080p_4audios.mp4", "24/1", 48, false, ""},
+	{"03_caminandes_llamigos_1080p.mp4", "24/1", 48, true, ""},
+	{"03_caminandes_llamigos_h265_1080p.mp4", "24/1", 48, false, ""},
+	{"Rigify-2min.mp4", "24/1", 48, false, ""},
+	{"Sintel_30s_5_1_pcm_s24le_60000Hz.mov", "24/1", 48, false, ""},
+	{"ELD2_FHD_4_60s_CCBYblendercloud.mov", "24000/1001", 48, false, ""},
+	{"BBB0_HD_8_XDCAM_120s_CCBYblendercloud.mxf", "60000/1001", 120, false, ""},
+	// libx265 variant of BBB0 - locks color-metadata pass-through for the HEVC
+	// encode path. ffmpeg's HEVC decoder unconditionally overrides codecpar with
+	// the SPS VUI on demux, so a colr-only output gets clobbered on the next
+	// roundtrip; this test catches that regression.
+	{"BBB0_HD_8_XDCAM_120s_CCBYblendercloud.mxf", "60000/1001", 120, false, "libx265"},
+	{"SIN6_4K_MOS_HEVC_60s.mp4", "24000/1001", 48, true, ""},
+	{"video-960.mp4", "30/1", 60, false, ""},
+	{"TOS0_FHD_2_H264_60s_CCBYblendercloud.mp4", "24/1", 48, false, ""},
+	{"TOS8_FHD_51-2_PRHQ_60s_CCBYblendercloud.mov", "24000/1001", 48, false, ""},
 
 	// Currently these files don't work
-	//{"bbb_sunflower_1080p_29_97_fps_normal.mp4", "30000/1001", 60, false}, // Broken - file actually 30/1 fps
-	//{"prores_example.mov",                       "30000/1001", 60, false}, // Broken
-	//{"Rigify-2min-10000ts.mp4", "24/1", 48, false},                        // Broken - duration expected 416, got 417
-	//{"BBB4_HD_51_AVC_120s_CCBYblendercloud.ts", "60/1", 120, false},  // Broken - improper key frame int
-	//{"SIN5_4K_MOS_J2K_60s_CCBYblendercloud.mxf", "24000/1001", 48, false},  // Broken - avg_framerate and timebase
+	//{"bbb_sunflower_1080p_29_97_fps_normal.mp4", "30000/1001", 60, false, ""}, // Broken - file actually 30/1 fps
+	//{"prores_example.mov",                       "30000/1001", 60, false, ""}, // Broken
+	//{"Rigify-2min-10000ts.mp4", "24/1", 48, false, ""},                        // Broken - duration expected 416, got 417
+	//{"BBB4_HD_51_AVC_120s_CCBYblendercloud.ts", "60/1", 120, false, ""},  // Broken - improper key frame int
+	//{"SIN5_4K_MOS_J2K_60s_CCBYblendercloud.mxf", "24000/1001", 48, false, ""},  // Broken - avg_framerate and timebase
 
+}
+
+// mezTestSourceID returns a unique identifier for a source entry that disambiguates
+// duplicates with the same Path (e.g. when the same file is encoded with different codecs).
+// Used as the test subtest name and as the output directory name.
+func mezTestSourceID(src mezTestSource) string {
+	id := strings.TrimSuffix(src.Path, path.Ext(src.Path))
+	if src.Ecodec != "" && src.Ecodec != "libx264" {
+		id += "_" + src.Ecodec
+	}
+	return id
 }
 
 // ---------------------------------------------------------------------------
@@ -133,7 +150,10 @@ func mezProfileForSource(src mezTestSource) *mezTestProfile {
 	params := goavpipe.NewXcParams()
 	params.Format = "fmp4-segment"
 	params.Url = path.Join(mezSourceDir, src.Path)
-	params.Ecodec = "libx264"
+	params.Ecodec = src.Ecodec
+	if params.Ecodec == "" {
+		params.Ecodec = "libx264"
+	}
 	params.EncHeight = 720
 	params.EncWidth = 1280
 	params.VideoBitrate = 2560000
@@ -325,7 +345,7 @@ func TestMezCreate(t *testing.T) {
 		t.Skip("Use TestEndToEnd or comment out this skip")
 	}
 	for _, src := range mezTestSources {
-		t.Run(src.Path, func(t *testing.T) {
+		t.Run(mezTestSourceID(src), func(t *testing.T) {
 			url := path.Join(mezSourceDir, src.Path)
 			log.Info("STARTING TestMezCreate", "source", url)
 
@@ -347,7 +367,7 @@ func TestMezCreate(t *testing.T) {
 			profile := mezProfileForSource(src)
 
 			// Output directory per source file.
-			baseName := strings.TrimSuffix(src.Path, path.Ext(src.Path))
+			baseName := mezTestSourceID(src)
 			videoMezDir := path.Join(mezOutputDir, baseName)
 			err := os.MkdirAll(videoMezDir, 0755)
 			require.NoError(t, err)
@@ -470,7 +490,7 @@ func TestABRCreate(t *testing.T) {
 		t.Skip("Use TestEndToEnd or comment out this skip")
 	}
 	for _, src := range mezTestSources {
-		t.Run(src.Path, func(t *testing.T) {
+		t.Run(mezTestSourceID(src), func(t *testing.T) {
 			url := path.Join(mezSourceDir, src.Path)
 			if fileMissing(url) {
 				t.Skipf("source file missing: %s", url)
@@ -478,7 +498,7 @@ func TestABRCreate(t *testing.T) {
 			}
 
 			profile := mezProfileForSource(src)
-			baseName := strings.TrimSuffix(src.Path, path.Ext(src.Path))
+			baseName := mezTestSourceID(src)
 			videoMezDir := path.Join(mezOutputDir, baseName)
 
 			// Ensure mez parts exist (create if needed)

--- a/xc/mez_e2e_test.go
+++ b/xc/mez_e2e_test.go
@@ -302,7 +302,8 @@ func fileMissing(url string) bool {
 	return info.IsDir()
 }
 
-// videoColor groups the mp4 'colr' atom fields for the first video stream of a file.
+// videoColor groups general video color metadata for the first video stream of a file,
+// as signaled by the container and/or encoded bitstream.
 type videoColor struct {
 	Primaries string
 	Transfer  string

--- a/xc/mez_e2e_test.go
+++ b/xc/mez_e2e_test.go
@@ -268,6 +268,48 @@ func fileMissing(url string) bool {
 	return info.IsDir()
 }
 
+// videoColor groups the mp4 'colr' atom fields for the first video stream of a file.
+type videoColor struct {
+	Primaries string
+	Transfer  string
+	Space     string
+	Range     string
+}
+
+// probeVideoColor returns the color metadata of the first video stream of url.
+// Empty fields are returned for color values that are unspecified in the source.
+func probeVideoColor(t *testing.T, url string) videoColor {
+	t.Helper()
+	goavpipe.InitIOHandler(
+		&xc.FileInputOpener{URL: url},
+		&xc.FileOutputOpener{Dir: filepath.Dir(url)},
+	)
+	probeParams := goavpipe.NewXcParams()
+	probeParams.Url = url
+	info, err := avpipe.Probe(probeParams)
+	require.NoError(t, err, "probe failed for %s", url)
+	for _, si := range info.StreamInfo {
+		if si.CodecType == "video" {
+			return videoColor{
+				Primaries: si.ColorPrimaries,
+				Transfer:  si.ColorTransfer,
+				Space:     si.ColorSpace,
+				Range:     si.ColorRange,
+			}
+		}
+	}
+	return videoColor{}
+}
+
+// assertColorMatches compares two videoColor sets with field-level error messages.
+func assertColorMatches(t *testing.T, want, got videoColor, label, url string) {
+	t.Helper()
+	assert.Equal(t, want.Primaries, got.Primaries, "color_primaries pass-through (%s) in %s", label, url)
+	assert.Equal(t, want.Transfer, got.Transfer, "color_transfer pass-through (%s) in %s", label, url)
+	assert.Equal(t, want.Space, got.Space, "color_space pass-through (%s) in %s", label, url)
+	assert.Equal(t, want.Range, got.Range, "color_range pass-through (%s) in %s", label, url)
+}
+
 // ---------------------------------------------------------------------------
 // Test
 // ---------------------------------------------------------------------------
@@ -291,6 +333,16 @@ func TestMezCreate(t *testing.T) {
 				t.Skipf("source file missing: %s", url)
 				return
 			}
+
+			// Capture source color metadata so we can verify mez parts pass it through
+			// to the mp4 'colr' atom (UNSPECIFIED fields are passed through unchanged).
+			srcColor := probeVideoColor(t, url)
+			log.Info("Source color metadata",
+				"source", url,
+				"primaries", srcColor.Primaries,
+				"transfer", srcColor.Transfer,
+				"space", srcColor.Space,
+				"range", srcColor.Range)
 
 			profile := mezProfileForSource(src)
 
@@ -377,7 +429,19 @@ func TestMezCreate(t *testing.T) {
 								"codec", si.CodecName,
 								"profile", si.Profile,
 								"level", si.Level,
-								"timescale", si.TimeBase)
+								"timescale", si.TimeBase,
+								"primaries", si.ColorPrimaries,
+								"transfer", si.ColorTransfer,
+								"space", si.ColorSpace,
+								"range", si.ColorRange)
+							// Color metadata must round-trip from source to mez 'colr' atom.
+							mezColor := videoColor{
+								Primaries: si.ColorPrimaries,
+								Transfer:  si.ColorTransfer,
+								Space:     si.ColorSpace,
+								Range:     si.ColorRange,
+							}
+							assertColorMatches(t, srcColor, mezColor, "mez", partFile)
 						}
 					}
 				})
@@ -421,6 +485,15 @@ func TestABRCreate(t *testing.T) {
 			partFiles := ensureMezParts(t, src, profile, videoMezDir)
 			require.NotEmpty(t, partFiles, "no mez parts for %s", src.Path)
 
+			// Capture source color metadata so we can verify ABR init segments pass it through.
+			srcColor := probeVideoColor(t, url)
+			log.Info("Source color metadata",
+				"source", url,
+				"primaries", srcColor.Primaries,
+				"transfer", srcColor.Transfer,
+				"space", srcColor.Space,
+				"range", srcColor.Range)
+
 			for _, v := range abrVariants {
 				// Skip watermark variants for sources that don't have watermarking enabled
 				if v.NeedsWM && !src.Watermark {
@@ -462,6 +535,9 @@ func TestABRCreate(t *testing.T) {
 							initFile := filepath.Join(initDir, "vinit-stream0.m4s")
 							initInfo, iErr := xc.ValidateInitSegment(initFile)
 							require.NoError(t, iErr, "ValidateInitSegment failed for %s", initFile)
+
+							// Color metadata must round-trip from source through mez to ABR 'colr' atom.
+							assertColorMatches(t, srcColor, probeVideoColor(t, initFile), "abr-init", initFile)
 
 							if partIdx == 0 {
 								refInitInfo = initInfo


### PR DESCRIPTION
Primary objective is to preserve color metadata from source to mez (and mez to ABR) for both HDR and SDR.

- HDR still overwrites color meta but verifies that source is correct as well (warning if not).

Emit SEI MDCV and CLII for HDR - currently only libx265 because nvenc runs into a double free in nvenc.c.  This is currently disabled with #ifdef and can be worked on later.

Add nvenc tests - use a constant to enable manually in both avpipe_test.go and xc/ end to end tests