### PR TITLE
Fix frame color when decoded as "reserved" (0)

### DIFF
--- a/avpipe_test.go
+++ b/avpipe_test.go
@@ -166,6 +166,53 @@ func TestVideoSeg(t *testing.T) {
 
 }
 
+func TestProResBT709BadFrameColor(t *testing.T) {
+	url := "./media/prores_bt709_bad_frame_color.mov"
+	checkFileExists(t, url)
+
+	outputDir := path.Join(baseOutPath, fn())
+	params := &goavpipe.XcParams{
+		BypassTranscoding:      false,
+		Format:                 "fmp4-segment",
+		AudioBitrate:           128000,
+		AudioSegDurationTs:     -1,
+		BitDepth:               8,
+		CrfStr:                 "23",
+		DurationTs:             -1,
+		Ecodec:                 h264Codec,
+		EncHeight:              -1,
+		EncWidth:               -1,
+		ExtractImageIntervalTs: -1,
+		GPUIndex:               -1,
+		SampleRate:             -1,
+		SegDuration:            "30",
+		StartFragmentIndex:     1,
+		StartSegmentStr:        "1",
+		StreamId:               -1,
+		SyncAudioToStreamId:    -1,
+		VideoBitrate:           -1,
+		VideoSegDurationTs:     -1,
+		ForceKeyInt:            48,
+		XcType:                 goavpipe.XcVideo,
+		Url:                    url,
+		DebugFrameLevel:        debugFrameLevel,
+	}
+	setFastEncodeParams(params, true)
+
+	xcTestResult := &XcTestResult{
+		mezFile:  []string{fmt.Sprintf("%s/vsegment-1.mp4", outputDir)},
+		pixelFmt: "yuv420p",
+	}
+	xcTest(t, outputDir, params, xcTestResult, true)
+
+	probeInfo, err := avpipe.Probe(&goavpipe.XcParams{
+		Url:      xcTestResult.mezFile[0],
+		Seekable: true,
+	})
+	failNowOnError(t, err)
+	requireVideoStreamColor(t, probeInfo, "bt709", "bt709", "bt709")
+}
+
 func TestVideoSegWithRotate(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping slow transcoding test in short mode")
@@ -3006,6 +3053,30 @@ type expectedHDR10 struct {
 	Width, Height    int    // 0 = don't check
 	MasteringDisplay string // x265 format "G(...)B(...)R(...)WP(...)L(...)"; "*" = require non-empty
 	MaxCLL           string // "<MaxCLL>,<MaxFALL>"; "*" = require non-empty.
+}
+
+func requireVideoStreamColor(
+	t *testing.T,
+	probe *goavpipe.ProbeInfo,
+	colorPrimaries,
+	colorTransfer,
+	colorSpace string) {
+	t.Helper()
+
+	var si *goavpipe.StreamInfo
+	for i := range probe.StreamInfo {
+		if probe.StreamInfo[i].CodecType == "video" {
+			si = &probe.StreamInfo[i]
+			break
+		}
+	}
+	if !assert.NotNil(t, si, "no video stream in probe result") {
+		return
+	}
+
+	assert.Equal(t, colorPrimaries, si.ColorPrimaries)
+	assert.Equal(t, colorTransfer, si.ColorTransfer)
+	assert.Equal(t, colorSpace, si.ColorSpace)
 }
 
 // assertHDR10 probes and asserts the mp4 video stream matches the expected.

--- a/libavpipe/include/avpipe_xc.h
+++ b/libavpipe/include/avpipe_xc.h
@@ -372,6 +372,12 @@ typedef struct coderctx_t {
 
     int64_t audio_output_pts;                           /* Used to set PTS directly when using audio FIFO */
 
+    /* Video color metadata reconciled values - used for fixing frame color metadata */
+    enum AVColorPrimaries              video_color_primaries;
+    enum AVColorTransferCharacteristic video_color_trc;
+    enum AVColorSpace                  video_colorspace;
+    enum AVColorRange                  video_color_range;
+
     /* Video filter */
     AVFilterContext *video_buffersink_ctx;
     AVFilterContext *video_buffersrc_ctx;

--- a/libavpipe/src/avpipe_filters.c
+++ b/libavpipe/src/avpipe_filters.c
@@ -3,6 +3,7 @@
  */
 
 #include "avpipe_xc.h"
+#include "avpipe_format.h"
 #include "elv_log.h"
 #include "libavutil/pixdesc.h"
 
@@ -52,7 +53,7 @@ init_video_filters(
         dec_codec_ctx->width, dec_codec_ctx->height, dec_codec_ctx->pix_fmt,
         time_base.num, time_base.den,
         dec_codec_ctx->sample_aspect_ratio.num, dec_codec_ctx->sample_aspect_ratio.den,
-        dec_codec_ctx->colorspace, dec_codec_ctx->color_range);
+        decoder_context->video_colorspace, decoder_context->video_color_range);
     elv_dbg("init_video_filters, video srcfilter args=%s", args);
 
     /* video_stream_index should be the same in both encoder and decoder context */

--- a/libavpipe/src/avpipe_format.c
+++ b/libavpipe/src/avpipe_format.c
@@ -528,6 +528,149 @@ copy_source_color_to_output(
         dst->color_range = src->color_range;
 }
 
+static int
+known_color_primaries(
+    enum AVColorPrimaries value)
+{
+    return value > AVCOL_PRI_RESERVED0 &&
+        value != AVCOL_PRI_UNSPECIFIED &&
+        value != AVCOL_PRI_RESERVED &&
+        value < AVCOL_PRI_NB;
+}
+
+static int
+known_color_trc(
+    enum AVColorTransferCharacteristic value)
+{
+    return value > AVCOL_TRC_RESERVED0 &&
+        value != AVCOL_TRC_UNSPECIFIED &&
+        value != AVCOL_TRC_RESERVED &&
+        value < AVCOL_TRC_NB;
+}
+
+static int
+known_color_space(
+    enum AVColorSpace value,
+    enum AVPixelFormat pix_fmt)
+{
+    if (value == AVCOL_SPC_UNSPECIFIED || value < 0 || value >= AVCOL_SPC_NB)
+        return 0;
+    /* AVCOL_SPC_RGB is value 0 (unset) - valid for RGB but not for YUV */
+    if (value == AVCOL_SPC_RGB) {
+        const AVPixFmtDescriptor *desc = av_pix_fmt_desc_get(pix_fmt);
+        if (!desc || !(desc->flags & AV_PIX_FMT_FLAG_RGB))
+            return 0;
+    }
+    return 1;
+}
+
+static int
+known_color_range(
+    enum AVColorRange value)
+{
+    return value > AVCOL_RANGE_UNSPECIFIED &&
+        value < AVCOL_RANGE_NB;
+}
+
+/*
+ * Resolve video stream color info when preparing the decoder.
+ * These values are used for both:
+ * - video input filter
+ * - fix frame color meta when primaries/trc are decoded as "reserved" (0)
+ * Fixes filter error:
+ * "Unsupported input (Operation not supported): fmt:yuv422p10le csp:gbr prim:reserved trc:reserved -> fmt:yuv420p csp:bt709 prim:reserved trc:reserved"
+ */
+void
+reconcile_decoder_video_color(
+    coderctx_t *decoder_context,
+    int stream_index,
+    const char *url)
+{
+    AVCodecContext *codec_context;
+    AVCodecParameters *codecpar;
+    enum AVPixelFormat pix_fmt;
+
+    decoder_context->video_color_primaries = AVCOL_PRI_UNSPECIFIED;
+    decoder_context->video_color_trc       = AVCOL_TRC_UNSPECIFIED;
+    decoder_context->video_colorspace      = AVCOL_SPC_UNSPECIFIED;
+    decoder_context->video_color_range     = AVCOL_RANGE_UNSPECIFIED;
+
+    if (stream_index < 0 ||
+        !decoder_context->codec_context[stream_index] ||
+        !decoder_context->stream[stream_index] ||
+        !decoder_context->stream[stream_index]->codecpar)
+        return;
+
+    codec_context = decoder_context->codec_context[stream_index];
+    codecpar = decoder_context->stream[stream_index]->codecpar;
+    pix_fmt = codec_context->pix_fmt;
+
+    if (known_color_primaries(codec_context->color_primaries)) {
+        decoder_context->video_color_primaries = codec_context->color_primaries;
+        if (known_color_primaries(codecpar->color_primaries) &&
+            codecpar->color_primaries != codec_context->color_primaries)
+            elv_warn("reconcile_decoder_video_color: primaries differ, decoder=%s codecpar=%s, url=%s",
+                av_color_primaries_name(codec_context->color_primaries),
+                av_color_primaries_name(codecpar->color_primaries), url);
+    } else if (known_color_primaries(codecpar->color_primaries)) {
+        decoder_context->video_color_primaries = codecpar->color_primaries;
+    }
+
+    if (known_color_trc(codec_context->color_trc)) {
+        decoder_context->video_color_trc = codec_context->color_trc;
+        if (known_color_trc(codecpar->color_trc) &&
+            codecpar->color_trc != codec_context->color_trc)
+            elv_warn("reconcile_decoder_video_color: transfer differ, decoder=%s codecpar=%s, url=%s",
+                av_color_transfer_name(codec_context->color_trc),
+                av_color_transfer_name(codecpar->color_trc), url);
+    } else if (known_color_trc(codecpar->color_trc)) {
+        decoder_context->video_color_trc = codecpar->color_trc;
+    }
+
+    if (known_color_space(codec_context->colorspace, pix_fmt)) {
+        decoder_context->video_colorspace = codec_context->colorspace;
+        if (known_color_space(codecpar->color_space, pix_fmt) &&
+            codecpar->color_space != codec_context->colorspace)
+            elv_warn("reconcile_decoder_video_color: matrix differ, decoder=%s codecpar=%s, url=%s",
+                av_color_space_name(codec_context->colorspace),
+                av_color_space_name(codecpar->color_space), url);
+    } else if (known_color_space(codecpar->color_space, pix_fmt)) {
+        decoder_context->video_colorspace = codecpar->color_space;
+    }
+
+    if (known_color_range(codec_context->color_range)) {
+        decoder_context->video_color_range = codec_context->color_range;
+        if (known_color_range(codecpar->color_range) &&
+            codecpar->color_range != codec_context->color_range)
+            elv_warn("reconcile_decoder_video_color: range differ, decoder=%s codecpar=%s, url=%s",
+                av_color_range_name(codec_context->color_range),
+                av_color_range_name(codecpar->color_range), url);
+    } else if (known_color_range(codecpar->color_range)) {
+        decoder_context->video_color_range = codecpar->color_range;
+    }
+}
+
+/*
+ * Fix frame color metadata for frames that are decoded as "reserved" (0)
+ */
+void
+fix_video_frame_color(
+    coderctx_t *decoder_context,
+    AVFrame *frame)
+{
+    if (!frame)
+        return;
+
+    if (!known_color_primaries(frame->color_primaries))
+        frame->color_primaries = decoder_context->video_color_primaries;
+    if (!known_color_trc(frame->color_trc))
+        frame->color_trc = decoder_context->video_color_trc;
+    if (!known_color_space(frame->colorspace, frame->format))
+        frame->colorspace = decoder_context->video_colorspace;
+    if (!known_color_range(frame->color_range))
+        frame->color_range = decoder_context->video_color_range;
+}
+
 /* Broad category for a primaries value: 0=unknown, 1=BT.709, 2=BT.601, 3=HDR */
 static int
 color_pri_cat(enum AVColorPrimaries p)

--- a/libavpipe/src/avpipe_format.h
+++ b/libavpipe/src/avpipe_format.h
@@ -107,6 +107,17 @@ copy_source_color_to_output(
     coderctx_t *decoder_context);
 
 void
+reconcile_decoder_video_color(
+    coderctx_t *decoder_context,
+    int stream_index,
+    const char *url);
+
+void
+fix_video_frame_color(
+    coderctx_t *decoder_context,
+    AVFrame *frame);
+
+void
 dash_synthesize_color_defaults(
     xcparams_t *params,
     AVCodecParameters *codecpar);

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -595,6 +595,10 @@ prepare_decoder(
         /* PENDING(RM) Do we need this for audio? Because audio is based on resampling, it doesn't work like video. */
     }
 
+    /* Reconcile video stream color metadata here - used for video buffer source filter and fixing frame color */
+    if (decoder_context->video_stream_index >= 0)
+        reconcile_decoder_video_color(decoder_context, decoder_context->video_stream_index, url);
+
     return 0;
 }
 
@@ -2792,6 +2796,7 @@ transcode_video(
             frame->pkt_dts = frame->pts;
         }
 
+        fix_video_frame_color(decoder_context, frame);
         dump_frame(0, stream_index, "IN ", codec_context->frame_num, frame, debug_frame_level);
 
         ret = check_pts_wrapped(&decoder_context->audio_last_input_pts[stream_index], frame, stream_index);
@@ -3074,6 +3079,10 @@ flush_decoder(
         if (response == AVERROR_EOF) {
             elv_log("GOT EOF url=%s, xc_type=%d, format=%s", p->url, p->xc_type, p->format);
             continue; // PENDING(SSS) why continue and not break?
+        }
+
+        if (codec_context->codec_type == AVMEDIA_TYPE_VIDEO) {
+            fix_video_frame_color(decoder_context, frame);
         }
 
         dump_frame(i >= 0, stream_index,


### PR DESCRIPTION
Fixes filter error:
```
 Unsupported input (Operation not supported): fmt:yuv422p10le csp:gbr prim:reserved trc:reserved -> fmt:yuv420p csp:bt709 prim:reserved trc:reserved
```

Resolve the proper color metadata in prep decoder
- this is done in case metadata is signaled inconsistently in SPS/VUI and container meta

Use proper color meta in video buffer source filter 

Use proper color meta to fix frames when decoded as "reserved" (0).

Example log showing frame inconsistency in real life prores file:

```
2026-04-28 19:28:15.274 LOG PI COLOR decode-frame/raw frame=61393 pts=61392000 dts=61392000 stream=0 primaries=bt709(1) transfer=bt709(1) matrix=bt709(1) range=tv(1), url=/Users/serban/ELV/TNT/sony/goodo1_sn01_ep0106_tv-2386803_pic-hd-178_fr-fr_txt_fr-fr_sid210622f12b190095aa_crid44582901-44582918-44582935.mov
2026-04-28 19:28:15.277 LOG PI COLOR decode-frame/raw frame=61394 pts=61393000 dts=61393000 stream=0 primaries=bt709(1) transfer=bt709(1) matrix=bt709(1) range=tv(1), url=/Users/serban/ELV/TNT/sony/goodo1_sn01_ep0106_tv-2386803_pic-hd-178_fr-fr_txt_fr-fr_sid210622f12b190095aa_crid44582901-44582918-44582935.mov
2026-04-28 19:28:15.289 LOG PI COLOR decode-frame/raw frame=61395 pts=61394000 dts=61394000 stream=0 primaries=bt709(1) transfer=bt709(1) matrix=bt709(1) range=tv(1), url=/Users/serban/ELV/TNT/sony/goodo1_sn01_ep0106_tv-2386803_pic-hd-178_fr-fr_txt_fr-fr_sid210622f12b190095aa_crid44582901-44582918-44582935.mov
2026-04-28 19:28:15.291 LOG PI COLOR decode-frame/raw frame=61396 pts=61395000 dts=61395000 stream=0 primaries=bt709(1) transfer=bt709(1) matrix=bt709(1) range=tv(1), url=/Users/serban/ELV/TNT/sony/goodo1_sn01_ep0106_tv-2386803_pic-hd-178_fr-fr_txt_fr-fr_sid210622f12b190095aa_crid44582901-44582918-44582935.mov
2026-04-28 19:28:15.297 LOG PI COLOR decode-frame/raw frame=61397 pts=61396000 dts=61396000 stream=0 primaries=bt709(1) transfer=bt709(1) matrix=bt709(1) range=tv(1), url=/Users/serban/ELV/TNT/sony/goodo1_sn01_ep0106_tv-2386803_pic-hd-178_fr-fr_txt_fr-fr_sid210622f12b190095aa_crid44582901-44582918-44582935.mov
2026-04-28 19:28:15.329 LOG PI COLOR decode-frame/raw frame=61398 pts=61397000 dts=61397000 stream=0 primaries=reserved(0) transfer=reserved(0) matrix=bt709(1) range=tv(1), url=/Users/serban/ELV/TNT/sony/goodo1_sn01_ep0106_tv-2386803_pic-hd-178_fr-fr_txt_fr-fr_sid210622f12b190095aa_crid44582901-44582918-44582935.mov
2026-04-28 19:28:15.347 LOG PI COLOR decode-frame/raw frame=61399 pts=61398000 dts=61398000 stream=0 primaries=reserved(0) transfer=reserved(0) matrix=bt709(1) range=tv(1), url=/Users/serban/ELV/TNT/sony/goodo1_sn01_ep0106_tv-2386803_pic-hd-178_fr-fr_txt_fr-fr_sid210622f12b190095aa_crid44582901-44582918-44582935.mov
2026-04-28 19:28:15.353 LOG PI COLOR decode-frame/raw frame=61400 pts=61399000 dts=61399000 stream=0 primaries=reserved(0) transfer=reserved(0) matrix=bt709(1) range=tv(1), url=/Users/serban/ELV/TNT/sony/goodo1_sn01_ep0106_tv-2386803_pic-hd-178_fr-fr_txt_fr-fr_sid210622f12b190095aa_crid44582901-44582918-44582935.mov
2026-04-28 19:28:15.399 LOG PI COLOR decode-frame/raw frame=61401 pts=61400000 dts=61400000 stream=0 primaries=reserved(0) transfer=reserved(0) matrix=bt709(1) range=tv(1), url=/Users/serban/ELV/TNT/sony/goodo1_sn01_ep0106_tv-2386803_pic-hd-178_fr-fr_txt_fr-fr_sid210622f12b190095aa_crid44582901-44582918-44582935.mov
2026-04-28 19:28:15.400 LOG PI COLOR decode-frame/raw frame=61402 pts=61401000 dts=61401000 stream=0 primaries=reserved(0) transfer=reserved(0) matrix=bt709(1) range=tv(1), url=/Users/serban/ELV/TNT/sony/goodo1_sn01_ep0106_tv-2386803_pic-hd-178_fr-fr_txt_fr-fr_sid210622f12b190095aa_crid44582901-44582918-44582935.mov
2026-04-28 19:28:15.403 LOG PI COLOR decode-frame/raw frame=61403 pts=61402000 dts=61402000 stream=0 primaries=reserved(0) transfer=reserved(0) matrix=bt709(1) range=tv(1), url=/Users/serban/ELV/TNT/sony/goodo1_sn01_ep0106_tv-2386803_pic-hd-178_fr-fr_txt_fr-fr_sid210622f12b190095aa_crid44582901-44582918-44582935.mov
```