### PR TITLE
Fix Dolby Vision processing for profile > 10 using dvwC

### DIFF
--- a/avpipe_test.go
+++ b/avpipe_test.go
@@ -2049,6 +2049,7 @@ type mvhevcCase struct {
 	width, height        uint16 // per-view resolution
 	expectBaseProfileIDC int    // hvcC base layer: 1=Main (SDR), 2=Main 10 (HDR)
 	expectLevelIDC       int    // expected HEVC level_idc (150=L5.1, 156=L5.2, ...)
+	expectDOVIProfile    int    // expected Dolby Vision profile
 	expectHDR10          bool
 	expectMdcv           bool
 	expectClli           bool
@@ -2087,6 +2088,18 @@ func TestMVHEVC_MezAndABRBypass(t *testing.T) {
 	}
 }
 
+// TestDOVI20_MVHEVC_MezAndABRBypass verifies Dolby Vision MV-HEVC bypass.
+func TestDOVI20_MVHEVC_MezAndABRBypass(t *testing.T) {
+	runMVHEVCMezAndABRBypass(t, mvhevcCase{
+		src:                  "./media/3d_test_reel_2024_dovi_mvhevc.mp4",
+		width:                3840,
+		height:               2160,
+		expectBaseProfileIDC: 2, // Main 10
+		expectLevelIDC:       183,
+		expectDOVIProfile:    avdesc.DOVIProfileMVHEVC,
+	})
+}
+
 func runMVHEVCMezAndABRBypass(t *testing.T, c mvhevcCase) {
 	f := fn() + "/" + t.Name()
 	checkFileExists(t, c.src)
@@ -2102,6 +2115,9 @@ func runMVHEVCMezAndABRBypass(t *testing.T, c mvhevcCase) {
 	assert.True(t, srcIns.HasOinfSgpd, "source missing oinf")
 	assert.True(t, srcIns.HasLinfSgpd, "source missing linf")
 	assert.True(t, srcIns.HasTrgrCstg, "source missing trgr/cstg")
+	if c.expectDOVIProfile > 0 {
+		assertDOVIMVHEVCProfile(t, c.src, c.expectDOVIProfile)
+	}
 
 	// Stage 1: source → mez (bypass repackage to fmp4-segment).
 	// Ecodec must be a real encoder libavformat can find even in bypass —
@@ -2183,6 +2199,9 @@ func assertMVHEVCStructure(t *testing.T, mp4Path string, c mvhevcCase) {
 		if assert.NoError(t, err, "ExtractCodecInfo on %s", mp4Path) && len(infos) > 0 {
 			assert.Equal(t, c.expectBaseProfileIDC, infos[0].ProfileIDC, "base profile_idc in %s", mp4Path)
 			assert.Equal(t, c.expectLevelIDC, infos[0].Level, "level_idc in %s", mp4Path)
+			if c.expectDOVIProfile > 0 {
+				assertDOVIMVHEVCCodecInfo(t, infos[0], c.expectDOVIProfile, mp4Path)
+			}
 		}
 	}
 
@@ -2200,6 +2219,31 @@ func assertMVHEVCStructure(t *testing.T, mp4Path string, c mvhevcCase) {
 	if c.expectClli {
 		assert.True(t, ins.HasClli, "missing clli (content light level) in %s", mp4Path)
 	}
+}
+
+func assertDOVIMVHEVCProfile(t *testing.T, mp4Path string, expectProfile int) {
+	t.Helper()
+	f, err := os.Open(mp4Path)
+	require.NoError(t, err)
+	defer func() { _ = f.Close() }()
+
+	infos, err := mp4e.ExtractCodecInfo(f)
+	require.NoError(t, err)
+	require.NotEmpty(t, infos, "no codec info in %s", mp4Path)
+	assertDOVIMVHEVCCodecInfo(t, infos[0], expectProfile, mp4Path)
+}
+
+func assertDOVIMVHEVCCodecInfo(t *testing.T, info *mp4e.CodecInfo, expectProfile int, mp4Path string) {
+	t.Helper()
+	require.NotNil(t, info, "nil codec info for %s", mp4Path)
+	assert.Equal(t, "hvc1", info.CodecTagString, "codec tag in %s", mp4Path)
+	assert.Equal(t, mp4e.Mp4VideoLayoutMVHEVC, info.VideoLayout, "video layout in %s", mp4Path)
+	assert.Equal(t, 6, info.EnhancementProfileIDC, "MV-HEVC enhancement profile_idc in %s", mp4Path)
+	require.NotNil(t, info.DOVI, "Dolby Vision configuration missing from %s", mp4Path)
+	assert.Equal(t, expectProfile, info.DOVI.Profile, "DOVI profile in %s", mp4Path)
+	assert.Equal(t, "dvh1", info.DOVI.FourCC, "DOVI fourcc in %s", mp4Path)
+	assert.True(t, info.DOVI.RPUPresent, "DOVI RPU flag in %s", mp4Path)
+	assert.True(t, info.DOVI.BLPresent, "DOVI BL flag in %s", mp4Path)
 }
 
 // TestHEVC_HDR10_MezAndABR creates a mez from source and ABR rungs from mez,

--- a/goavpipe/avdesc/dolby.go
+++ b/goavpipe/avdesc/dolby.go
@@ -2,7 +2,11 @@ package avdesc
 
 import "fmt"
 
-// DOVIInfo holds the Dolby Vision configuration from a dvcC/dvvC box or probe
+const (
+	DOVIProfileMVHEVC = 20 // Required for MV-HEVC
+)
+
+// DOVIInfo holds the Dolby Vision configuration from a dvcC/dvvC/dvwC box or probe
 // side data (AV_PKT_DATA_DOVI_CONF).
 type DOVIInfo struct {
 	// VersionMajor is the major version of the Dolby Vision specification used

--- a/mp4e/codec_info.go
+++ b/mp4e/codec_info.go
@@ -56,8 +56,9 @@ type CodecInfo struct {
 	EC3 *EC3Info `json:"ec3,omitempty"`
 
 	// DOVI is set only when the codec entry contains a Dolby Vision configuration
-	// box (dvcC or dvvC). Common cases:
-	//   hvc1/hev1 with dvvC child — Profile 8.x (cross-compatible) or Profile 20 (MV-HEVC)
+	// box (dvcC, dvvC, or dvwC). Common cases:
+	//   hvc1/hev1 with dvvC child — Profile 8.x (cross-compatible)
+	//   hvc1/hev1 with dvwC child — Dolby Vision Profile 20 (required for MV-HEVC)
 	//   dvh1/dvhe as the sample entry type — Profile 5 or Profile 20 (strict DV container)
 	// Note: dvh1/dvhe sample entry types require mp4ff support to be parsed here;
 	// until that is added, those entries fall through to the default CodecInfo path.
@@ -257,7 +258,7 @@ func parseMP4ACodecInfo(se *mp4.AudioSampleEntryBox) (*CodecInfo, error) {
 	}, nil
 }
 
-// parseDOVIBox parses the payload of a dvcC or dvvC box and returns a DOVIInfo.
+// parseDOVIBox parses the payload of a dvcC, dvvC, or dvwC box and returns a DOVIInfo.
 // Layout (from FFmpeg dovi_isom.c):
 //
 //	byte 0:   dv_version_major
@@ -272,7 +273,7 @@ func parseMP4ACodecInfo(se *mp4.AudioSampleEntryBox) (*CodecInfo, error) {
 //	  bits 7-4: dv_bl_signal_compatibility_id (4 bits)
 func parseDOVIBox(payload []byte) (*avdesc.DOVIInfo, error) {
 	if len(payload) < 5 {
-		return nil, errors.E("dvcC/dvvC payload too short", "len", len(payload))
+		return nil, errors.E("dvcC/dvvC/dvwC payload too short", "len", len(payload))
 	}
 	word := uint16(payload[2])<<8 | uint16(payload[3])
 	return &avdesc.DOVIInfo{
@@ -302,6 +303,10 @@ func doviFourCC(codecTag string) string {
 		return "dvhe"
 	}
 	return "dvh1"
+}
+
+func isDOVIBoxType(boxType string) bool {
+	return boxType == "dvvC" || boxType == "dvcC" || boxType == "dvwC"
 }
 
 func parseVisualSampleEntryBox(se *mp4.VisualSampleEntryBox) (*CodecInfo, error) {
@@ -337,10 +342,10 @@ func parseVisualSampleEntryBox(se *mp4.VisualSampleEntryBox) (*CodecInfo, error)
 			VideoLayout:     Mp4VideoLayoutMono,
 		}
 
-		// Look for Dolby Vision configuration box (dvvC or dvcC) in children
+		// Look for Dolby Vision configuration box (dvvC, dvcC, or dvwC) in children.
 		for _, child := range se.Children {
 			boxType := child.Type()
-			if boxType == "dvvC" || boxType == "dvcC" {
+			if isDOVIBoxType(boxType) {
 				if ub, ok := child.(*mp4.UnknownBox); ok {
 					dovi, doviErr := parseDOVIBox(ub.Payload())
 					if doviErr != nil {

--- a/mp4e/codec_info_test.go
+++ b/mp4e/codec_info_test.go
@@ -51,6 +51,32 @@ func TestDOVICodecString(t *testing.T) {
 	assert.Equal(t, "dvh1.05.13", d3.CodecString())
 }
 
+func TestIsDOVIBoxType(t *testing.T) {
+	assert.True(t, isDOVIBoxType("dvcC"))
+	assert.True(t, isDOVIBoxType("dvvC"))
+	assert.True(t, isDOVIBoxType("dvwC"))
+	assert.False(t, isDOVIBoxType("hvcC"))
+}
+
+func TestParseDOVIBoxProfile20(t *testing.T) {
+	// Profile 20 uses the dvwC box name in FFmpeg, but the payload layout is
+	// the same Dolby Vision decoder configuration record as dvcC/dvvC.
+	word := uint16(avdesc.DOVIProfileMVHEVC)<<9 | uint16(13)<<3 | 0b101
+	payload := []byte{1, 0, byte(word >> 8), byte(word), 0x00}
+
+	info, err := parseDOVIBox(payload)
+	require.NoError(t, err)
+	require.NotNil(t, info)
+	assert.Equal(t, 1, info.VersionMajor)
+	assert.Equal(t, 0, info.VersionMinor)
+	assert.Equal(t, avdesc.DOVIProfileMVHEVC, info.Profile)
+	assert.Equal(t, 13, info.Level)
+	assert.True(t, info.RPUPresent)
+	assert.False(t, info.ELPresent)
+	assert.True(t, info.BLPresent)
+	assert.Equal(t, 0, info.BLSignalCompatibilityID)
+}
+
 func TestExtractCodecInfo_DOVI81(t *testing.T) {
 	f, err := os.Open("testdata/dv81-hvc1-init.mp4")
 	require.NoError(t, err)


### PR DESCRIPTION
The failure case is:
- our source file is Dolby Vision p20 using dvvC box
- however ffmpeg parses dvvC into its packet data but recreates a dvwC box when profile > 10

Code in `movenc.c`
```
if (dovi->dv_profile > 10)
    ffio_wfourcc(pb, "dvwC");
else if (dovi->dv_profile > 7)
    ffio_wfourcc(pb, "dvvC");
else
    ffio_wfourcc(pb, "dvcC");
```

Added a new test file `./media/3d_test_reel_2024_dovi_mvhevc.mp4`