### PR TITLE
Minor fix and updates - video layout and probe info

### DIFF
--- a/elvxc/cmd/transcode.go
+++ b/elvxc/cmd/transcode.go
@@ -273,6 +273,21 @@ func getAudioIndexes(params *goavpipe.XcParams, audioIndexes string) (err error)
 	return nil
 }
 
+func getVideoLayout(layout string) (int32, error) {
+	switch strings.ToLower(strings.TrimSpace(layout)) {
+	case "", "mono", "0":
+		return int32(goavpipe.VideoLayoutMono), nil
+	case "sbs", "side-by-side", "3":
+		return int32(goavpipe.VideoLayoutSbs), nil
+	case "tb", "top-bottom", "4":
+		return int32(goavpipe.VideoLayoutTb), nil
+	case "mvhevc", "mv-hevc", "10":
+		return int32(goavpipe.VideoLayoutMVHEVC), nil
+	default:
+		return 0, fmt.Errorf("Invalid video-layout: %s", layout)
+	}
+}
+
 // parseExtractImagesTs converts the extract-images-ts string parameter, e.g.
 // "0,64000,128000,1152000", to an int64 array in goavpipe.XcParams
 func parseExtractImagesTs(params *goavpipe.XcParams, s string) (err error) {
@@ -338,6 +353,7 @@ func InitTranscode(cmdRoot *cobra.Command) error {
 	cmdTranscode.PersistentFlags().Int32P("enc-width", "", -1, "default -1 means use source width.")
 	cmdTranscode.PersistentFlags().Int32P("video-time-base", "", 0, "Video encoder timebase, must be > 0 (the actual timebase would be 1/video-time-base).")
 	cmdTranscode.PersistentFlags().Int32P("video-frame-duration-ts", "", 0, "Frame duration of the output video in time base.")
+	cmdTranscode.PersistentFlags().String("video-layout", "", "Video layout, can be 'mono'/0, 'sbs'/3, 'tb'/4, or 'mvhevc'/10.")
 	cmdTranscode.PersistentFlags().Int64P("duration-ts", "", -1, "default -1 means entire stream.")
 	cmdTranscode.PersistentFlags().Int64P("audio-seg-duration-ts", "", 0, "(mandatory if format is not 'segment' and transcoding audio) audio segment duration time base (positive integer).")
 	cmdTranscode.PersistentFlags().Int64P("video-seg-duration-ts", "", 0, "(mandatory if format is not 'segment' and transcoding video) video segment duration time base (positive integer).")
@@ -617,6 +633,11 @@ func doTranscode(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("video-frame-duration-ts is not valid")
 	}
 
+	videoLayout, err := getVideoLayout(cmd.Flag("video-layout").Value.String())
+	if err != nil {
+		return err
+	}
+
 	durationTs, err := cmd.Flags().GetInt64("duration-ts")
 	if err != nil {
 		return fmt.Errorf("Duration ts is not valid")
@@ -774,6 +795,7 @@ func doTranscode(cmd *cobra.Command, args []string) error {
 		DebugFrameLevel:        debugFrameLevel,
 		VideoTimeBase:          int(videoTimeBase),
 		VideoFrameDurationTs:   int(videoFrameDurationTs),
+		VideoLayout:            videoLayout,
 		Seekable:               seekable,
 		Rotate:                 int(rotate),
 		Profile:                profile,
@@ -804,10 +826,7 @@ func doTranscode(cmd *cobra.Command, args []string) error {
 
 			goavpipe.InitUrlIOHandlerIfNotPresent(filename, nil, outOpener)
 
-			handle, err := avpipe.XcInit(params)
-			log.Info("XcInit", "handle", handle, "err", err)
-
-			err = avpipe.Xc(params)
+			err := avpipe.Xc(params)
 			if err != nil {
 				done <- fmt.Errorf("failed transcoding %s, err=%v", filename, err)
 			} else {

--- a/exc/elv_xc.c
+++ b/exc/elv_xc.c
@@ -10,6 +10,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <stdio.h>
 #include <libavutil/log.h>
 #include <libavutil/pixdesc.h>
 #include <errno.h>
@@ -1011,6 +1012,27 @@ static int get_extract_images_ts(char *s, xcparams_t *params) {
     return i;
 }
 
+static int
+get_video_layout(
+    const char *s,
+    int *video_layout
+)
+{
+    if (!strcmp(s, "mono") || !strcmp(s, "0")) {
+        *video_layout = video_layout_mono;
+    } else if (!strcmp(s, "sbs") || !strcmp(s, "side-by-side") || !strcmp(s, "3")) {
+        *video_layout = video_layout_sbs;
+    } else if (!strcmp(s, "tb") || !strcmp(s, "top-bottom") || !strcmp(s, "4")) {
+        *video_layout = video_layout_tb;
+    } else if (!strcmp(s, "mvhevc") || !strcmp(s, "mv-hevc") || !strcmp(s, "10")) {
+        *video_layout = video_layout_mvhevc;
+    } else {
+        return -1;
+    }
+
+    return 0;
+}
+
 static void
 usage(
     char *progname,
@@ -1092,6 +1114,7 @@ usage(
         "\t-copy-mpegts :           (optional) Default 0. Create a copy of the MPEGTS input (for MPEGTS, SRT, RTP)\n"
         "\t-video-bitrate :         (optional) Mutually exclusive with crf. Default: -1 (unused)\n"
         "\t-video-frame-duration-ts :  (optional) Frame duration of the output video in time base.\n"
+        "\t-video-layout :          (optional) Video layout, can be \"mono\"/0, \"sbs\"/3, \"tb\"/4, or \"mvhevc\"/10.\n"
         "\t-video-seg-duration-ts : (mandatory If format is not \"segment\" and transcoding video) video segment duration time base (positive integer).\n"
         "\t-video-time-base :       (optional) Video encoder timebase, must be > 0 (the actual timebase would be 1/video-time-base).\n"
         "\t-wm-text :               (optional) Watermark text that will be presented in every video frame if it exist. It has higher priority than overlay watermark.\n"
@@ -1543,12 +1566,7 @@ main(
                 if (p.video_time_base <= 0)
                     usage(argv[0], argv[i], EXIT_FAILURE);
             } else if (!strcmp(argv[i], "-video-layout")) {
-                /* Accept both label and numeric CICP */
-                if (!strcmp(argv[i+1], "sbs") || !strcmp(argv[i+1], "3")) {
-                    p.video_layout = video_layout_sbs;
-                } else if (!strcmp(argv[i+1], "mono") || !strcmp(argv[i+1], "0")) {
-                    p.video_layout = video_layout_mono;
-                } else {
+                if (get_video_layout(argv[i+1], &p.video_layout) < 0) {
                     usage(argv[0], argv[i], EXIT_FAILURE);
                 }
             } else {
@@ -1629,6 +1647,12 @@ main(
 
     elv_logger_open(NULL, "exc", 10, log_size*1024*1024, elv_log_file);
     elv_set_log_level(elv_log_debug);
+
+    if (p.video_layout == video_layout_mvhevc) {
+        fprintf(stderr, "Error: MVHEVC restore output handler is not available\n");
+        elv_err("MVHEVC restore output handler is not available");
+        return EXIT_FAILURE;
+    }
 
     if (!strcmp(command, "probe")) {
         p.xc_type = xc_probe;

--- a/mp4e/codec_info.go
+++ b/mp4e/codec_info.go
@@ -168,7 +168,7 @@ func ExtractCodecInfo(r io.Reader) (infos []*CodecInfo, err error) {
 		} else if ase, ok := se.(*mp4.AudioSampleEntryBox); ok {
 			info, err = parseAudioSampleEntryBox(ase)
 		} else {
-			info = &CodecInfo{CodecTagString: se.Type()}
+			continue
 		}
 
 		if err != nil {

--- a/testdata/avprobe_dolby_atmos.jsonc
+++ b/testdata/avprobe_dolby_atmos.jsonc
@@ -27,10 +27,20 @@
       "duration_ts": 1536000,
       "bit_rate": 640000,
       "nb_frames": 1000,
+      "mp4_info": {
+        "codec_tag_string": "ec-3",
+        "mime_codec_string": "ec-3",
+        "channels": 6,
+        "ec3": {
+          "chan_map": 63489,
+          "chan_map_hex": "F801",
+          "joc": true,
+          "complexity_index": 16
+        }
+      },
       "tags": {
         "handler_name": "Bento4 Sound Handler",
-        "language": "eng",
-        "vendor_id": "[0][0][0][0]"
+        "language": "eng"
       }
     },
     {
@@ -61,11 +71,16 @@
       "duration_ts": 1600000,
       "bit_rate": 302640,
       "nb_frames": 1600,
+      "mp4_info": {
+        "codec_tag_string": "avc1",
+        "mime_codec_string": "avc1.4D4028",
+        "profile_idc": 77,
+        "level": 40
+      },
       "tags": {
         "encoder": "AVC Coding",
         "handler_name": "Bento4 Video Handler",
-        "language": "und",
-        "vendor_id": "[0][0][0][0]"
+        "language": "und"
       }
     }
   ]

--- a/testdata/avprobe_dolby_atmos.jsonc
+++ b/testdata/avprobe_dolby_atmos.jsonc
@@ -27,20 +27,10 @@
       "duration_ts": 1536000,
       "bit_rate": 640000,
       "nb_frames": 1000,
-      "mp4_info": {
-        "codec_tag_string": "ec-3",
-        "mime_codec_string": "ec-3",
-        "channels": 6,
-        "ec3": {
-          "chan_map": 63489,
-          "chan_map_hex": "F801",
-          "joc": true,
-          "complexity_index": 16
-        }
-      },
       "tags": {
         "handler_name": "Bento4 Sound Handler",
-        "language": "eng"
+        "language": "eng",
+        "vendor_id": "[0][0][0][0]"
       }
     },
     {
@@ -71,16 +61,11 @@
       "duration_ts": 1600000,
       "bit_rate": 302640,
       "nb_frames": 1600,
-      "mp4_info": {
-        "codec_tag_string": "avc1",
-        "mime_codec_string": "avc1.4D4028",
-        "profile_idc": 77,
-        "level": 40
-      },
       "tags": {
         "encoder": "AVC Coding",
         "handler_name": "Bento4 Video Handler",
-        "language": "und"
+        "language": "und",
+        "vendor_id": "[0][0][0][0]"
       }
     }
   ]


### PR DESCRIPTION
Fix a bug in probe info when data tracks may be found between audio and video tracks, causing probe streams to have mis-aligned codec info data
- fix code review: https://github.com/eluv-io/avpipe/pull/168#issuecomment-4580874229

Fix Dolby Atmos test after adding mp4_info to probe (expected JSON needed to be updated)

Add video_layout to CLI 'exc'
- fail if MVHEVC because the C code doesn't install the Go MVHEVC output wrapper and doesn't fix ffmpeg output

Add video_layout to CLI elvxc - this works correctly with the MVHEVC output wrapper