### PR TITLE
Add format MPEGTS - single continuous output

### DIFF
--- a/elvxc/cmd/transcode.go
+++ b/elvxc/cmd/transcode.go
@@ -332,7 +332,7 @@ func InitTranscode(cmdRoot *cobra.Command) error {
 	cmdTranscode.PersistentFlags().StringP("audio-encoder", "", "aac", "audio encoder, default is 'aac', can be: 'aac', 'ac3', 'mp2', 'mp3'.")
 	cmdTranscode.PersistentFlags().StringP("decoder", "d", "", "video decoder, default is 'h264', can be: 'h264', 'h264_cuvid', 'jpeg2000', 'hevc'.")
 	cmdTranscode.PersistentFlags().StringP("audio-decoder", "", "", "audio decoder, default is '' and will be automatically chosen.")
-	cmdTranscode.PersistentFlags().StringP("format", "", "dash", "package format, can be 'dash', 'hls', 'mp4', 'fmp4', 'segment', 'fmp4-segment', or 'image2'.")
+	cmdTranscode.PersistentFlags().StringP("format", "", "dash", "package format, can be 'dash', 'hls', 'mp4', 'fmp4', 'segment', 'fmp4-segment', 'mpegts', or 'image2'.")
 	cmdTranscode.PersistentFlags().StringP("filter-descriptor", "", "", " Audio filter descriptor the same as ffmpeg format")
 	cmdTranscode.PersistentFlags().Int32P("force-keyint", "", 0, "force IDR key frame in this interval.")
 	cmdTranscode.PersistentFlags().BoolP("equal-fduration", "", false, "force equal frame duration. Must be 0 or 1 and only valid for 'fmp4-segment' format.")
@@ -474,8 +474,8 @@ func doTranscode(cmd *cobra.Command, args []string) error {
 	audioDecoder := cmd.Flag("audio-decoder").Value.String()
 
 	format := cmd.Flag("format").Value.String()
-	if format != "dash" && format != "hls" && format != "mp4" && format != "fmp4" && format != "segment" && format != "fmp4-segment" && format != "image2" {
-		return fmt.Errorf("Package format is not valid, can be 'dash', 'hls', 'mp4', 'fmp4', 'segment', 'fmp4-segment', or 'image2'")
+	if format != "dash" && format != "hls" && format != "mp4" && format != "fmp4" && format != "segment" && format != "fmp4-segment" && format != "mpegts" && format != "image2" {
+		return fmt.Errorf("Package format is not valid, can be 'dash', 'hls', 'mp4', 'fmp4', 'segment', 'fmp4-segment', 'mpegts', or 'image2'")
 	}
 
 	filterDescriptor := cmd.Flag("filter-descriptor").Value.String()
@@ -645,7 +645,7 @@ func doTranscode(cmd *cobra.Command, args []string) error {
 
 	audioSegDurationTs, err := cmd.Flags().GetInt64("audio-seg-duration-ts")
 	if err != nil ||
-		(format != "segment" && format != "fmp4-segment" &&
+		(format != "segment" && format != "fmp4-segment" && format != "mpegts" &&
 			audioSegDurationTs == 0 &&
 			(xcType == goavpipe.XcAll || xcType == goavpipe.XcAudio ||
 				xcType == goavpipe.XcAudioJoin || xcType == goavpipe.XcAudioMerge)) {
@@ -653,7 +653,7 @@ func doTranscode(cmd *cobra.Command, args []string) error {
 	}
 
 	videoSegDurationTs, err := cmd.Flags().GetInt64("video-seg-duration-ts")
-	if err != nil || (format != "segment" && format != "fmp4-segment" && format != "mp4" &&
+	if err != nil || (format != "segment" && format != "fmp4-segment" && format != "mp4" && format != "mpegts" &&
 		videoSegDurationTs == 0 && (xcType == goavpipe.XcAll || xcType == goavpipe.XcVideo)) {
 		return fmt.Errorf("Video seg duration ts is not valid")
 	}

--- a/exc/elv_xc.c
+++ b/exc/elv_xc.c
@@ -1074,9 +1074,10 @@ usage(
         "\t                                    Output goes to directory ./O\n"
         "\t-filter-descriptor :     (mandatory if xc-type is audio-pan). Audio filter descriptor the same as ffmpeg format.\n"
         "\t                                    For example: -filter-descriptor [0:1]pan=stereo|c0<c1+0.707*c2|c1<c2+0.707*c1[aout]\n"
-        "\t-format :                (optional) Package format. Default is \"dash\", can be: \"dash\", \"hls\", \"mp4\", \"fmp4\", \"segment\", \"fmp4-segment\", or \"image2\"\n"
+        "\t-format :                (optional) Package format. Default is \"dash\", can be: \"dash\", \"hls\", \"mp4\", \"fmp4\", \"segment\", \"fmp4-segment\", \"mpegts\", or \"image2\"\n"
         "\t                                    Using \"segment\" format produces self contained mp4 segments with start pts from 0 for each segment\n"
         "\t                                    Using \"fmp4-segment\" format produces self contained mp4 segments with continious pts.\n"
+        "\t                                    Using \"mpegts\" format produces a single continuous MPEGTS stream.\n"
         "\t                                    Using \"fmp4-segment\" generates segments that are appropriate for live streaming.\n"
         "\t-force-keyint :          (optional) Force IDR key frame in this interval.\n"
         "\t-gpu-index :             (optional) Use the GPU with specified index for transcoding (export CUDA_DEVICE_ORDER=PCI_BUS_ID would use smi index).\n"
@@ -1393,6 +1394,8 @@ main(
                     p.format = strdup("segment");
                 } else if (strcmp(argv[i+1], "fmp4-segment") == 0) {
                     p.format = strdup("fmp4-segment");
+                } else if (strcmp(argv[i+1], "mpegts") == 0) {
+                    p.format = strdup("mpegts");
                 } else if (strcmp(argv[i+1], "image2") == 0) {
                     p.format = strdup("image2");
                 } else {
@@ -1668,6 +1671,7 @@ main(
     if (strcmp(p.format, "segment") &&
         strcmp(p.format, "fmp4-segment") &&
         strcmp(p.format, "mp4") &&
+        strcmp(p.format, "mpegts") &&
         p.seg_duration == NULL &&
         p.audio_seg_duration_ts <= 0 && p.xc_type & xc_audio) {
         usage(argv[0], "audio_seg_duration_ts or seg_duration", EXIT_FAILURE);
@@ -1675,6 +1679,7 @@ main(
     if (strcmp(p.format, "segment") &&
         strcmp(p.format, "fmp4-segment") &&
         strcmp(p.format, "mp4") &&
+        strcmp(p.format, "mpegts") &&
         p.seg_duration == NULL &&
         p.video_seg_duration_ts <= 0 &&
         p.xc_type & xc_video &&

--- a/libavpipe/src/avpipe_io.c
+++ b/libavpipe/src/avpipe_io.c
@@ -134,6 +134,10 @@ elv_io_open(
                 outctx->type = avpipe_aes_128_key;
                 outctx->seg_index = -2;
             }
+            else if (strstr(url, "mpegts-stream")) {
+                /* Continuous MPEGTS stream, single output (format="mpegts") */
+                outctx->type = avpipe_mpegts_segment;
+            }
             else if (!strncmp(url, "mp4", 3)) {
                 outctx->type = avpipe_mp4_stream;
             } else if (strstr(url, "fsegment")) {

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -1748,6 +1748,9 @@ prepare_encoder(
             filename2 = "fsegment-audio-%05d.mp4";
     } else if (!strcmp(params->format, "image2")) {
         filename = "%d.jpeg";
+    } else if (!strcmp(params->format, "mpegts")) {
+        /* Continuous MPEGTS stream, single output (ffmpeg mpegts muxer) */
+        filename = "mpegts-stream.ts";
     }
 
     /*
@@ -2471,6 +2474,14 @@ encode_frame(
             outctx->frames_written++;
             out_handlers->avpipe_stater(outctx, stream_index, out_stat_frame_written);
         }
+
+        /*
+         * Video duration is computed as a PTS delta above - this is incorrect when there
+         * are B-frames as it can go negative (or a larger positive). Don't pass a
+         * negative duration to the muxer (ffmpeg logs warnings and sets it to 0 anyway).
+         */
+        if (output_packet->duration < 0)
+            output_packet->duration = 0;
 
         /* mux encoded frame */
         ret = av_interleaved_write_frame(format_context, output_packet);
@@ -3721,6 +3732,23 @@ avpipe_xc(
         goto xc_done;
     }
 
+    /*
+     * Format 'mpegts' - call io_open() explicitly.
+     * Background: segment.c and dashenc.c are designed to call io_open() because
+     * they have multiple outputs. For the avpipe 'mux' job we modified movenc.c to call
+     * io_open() so we can follow the same callback convention in avpipe.
+     * (we could remove the movenc.c change in the future and just have avpipe mux call)
+     */
+    if ((params->xc_type & xc_video) && !strcmp(params->format, "mpegts") &&
+        !encoder_context->format_context->pb) {
+        AVFormatContext *fc = encoder_context->format_context;
+        if (fc->io_open(fc, &fc->pb, fc->url, AVIO_FLAG_WRITE, NULL) < 0) {
+            elv_err("Failed to open mpegts output pb, url=%s", params->url);
+            rc = eav_write_header;
+            goto xc_done;
+        }
+    }
+
     if ((params->xc_type & xc_video) &&
         avformat_write_header(encoder_context->format_context, NULL) != eav_success) {
         elv_err("Failed to write video output file header, url=%s", params->url);
@@ -4096,6 +4124,14 @@ xc_done:
 
     if ((params->xc_type & xc_video) && rc == eav_success)
         av_write_trailer(encoder_context->format_context);
+
+    /* Format "mpegts" - we called io_open() explicitly so close explicitly */
+    if ((params->xc_type & xc_video) && !strcmp(params->format, "mpegts") &&
+        encoder_context->format_context->pb) {
+        AVFormatContext *fc = encoder_context->format_context;
+        fc->io_close2(fc, fc->pb);
+        fc->pb = NULL;
+    }
     if ((params->xc_type & xc_audio) && rc == eav_success) {
         for (int i=0; i<encoder_context->n_audio_output; i++)
             av_write_trailer(encoder_context->format_context2[i]);
@@ -4632,8 +4668,9 @@ check_params(
          strcmp(params->format, "mp4") &&
          strcmp(params->format, "fmp4") &&
          strcmp(params->format, "segment") &&
-         strcmp(params->format, "fmp4-segment"))) {
-        elv_err("Output format can be only \"dash\", \"hls\", \"image2\", \"mp4\", \"fmp4\", \"segment\", or \"fmp4-segment\", url=%s", params->url);
+         strcmp(params->format, "fmp4-segment") &&
+         strcmp(params->format, "mpegts"))) {
+        elv_err("Output format can be only \"dash\", \"hls\", \"image2\", \"mp4\", \"fmp4\", \"segment\", \"fmp4-segment\", or \"mpegts\", url=%s", params->url);
         return eav_param;
     }
 


### PR DESCRIPTION
Add output format MPEGTS.
- Produces one continuous MPEGTS output.
- Also add exc and elvxc CLI support for format 'mpegts'

One important difference in the code flow is that mpegtsenc.c does not call its own io_open().   We have modified movenc.c to do so but it's not really needed since we can call that ourselves.  (I think we should remove the movenc.c patch in the future which is what we use for 'mux' jobs).

