### PR TITLE
fix mpegts segmentation for multi-program streams or faulty PCRs

### DIFF
--- a/broadcastproto/mpegts/av_input.go
+++ b/broadcastproto/mpegts/av_input.go
@@ -251,6 +251,6 @@ func (mih *mpegtsInputHandler) ReaderLoop(ch chan []byte, packetsDropped *atomic
 			goavpipe.Log.Trace("Processed packets", "count", nPackets, "chan size", len(ch), "chan cap", cap(ch))
 		}
 
-		ts.ProcessDatagram(buf)
+		ts.ProcessDatagram(time.Now(), buf)
 	}
 }

--- a/broadcastproto/mpegts/custom.go
+++ b/broadcastproto/mpegts/custom.go
@@ -214,7 +214,7 @@ func (f *MpegTsConsumer) ReaderLoop() {
 				"chan cap", cap(f.pktChan))
 		}
 
-		f.pp.ProcessDatagram(pkt.Data)
+		f.pp.ProcessDatagram(time.Now(), pkt.Data)
 		pkt.Release()
 	}
 }

--- a/broadcastproto/mpegts/mpegts.go
+++ b/broadcastproto/mpegts/mpegts.go
@@ -21,6 +21,25 @@ const (
 	PcrMax uint64 = ((1 << 33) * 300) + (1 << 9)
 )
 
+// pcrStaleSegmentDivisor sets the PCR staleness window: a pinned PID is considered stale after no PCR for
+// (segment length / pcrStaleSegmentDivisor). PCRs normally arrive at least once per second (every 100ms per spec),
+// so this is far longer than any healthy gap while still detecting a dead PCR well within a single segment.
+const pcrStaleSegmentDivisor = 2
+
+// minSegmentWallClockDivisor sets the minimum wall-clock interval between PCR-driven rotations to
+// (segment length / minSegmentWallClockDivisor). It caps the segment creation rate if the source PCR advances much
+// faster than real time, so segments are never produced more than this factor faster than nominal.
+const minSegmentWallClockDivisor = 4
+
+type rotationReason int
+
+const (
+	rotationNone rotationReason = iota
+	rotationPCR
+	rotationPCRWrap
+	rotationWallClock
+)
+
 // StripTsPadding indicates whether the payload of TS padding packets in RTP-TS streams should be stripped. For now
 // this is not configurable per stream, since it has low performance impact and potentially saves bandwidth.
 var StripTsPadding = atomic.NewBool(false)
@@ -54,7 +73,12 @@ type MpegtsPacketProcessor struct {
 
 	continuityMap map[int]uint8 // Map of PID to last continuity counter
 	pcr           uint64        // Last seen PCR value
-	outBuf        []byte        // Preallocated byte buffer
+	// pcrPid is the PID of the stream we extracted the PCR from. Pinning to a single PID provides a stable PCR for
+	// multi-program streams with independent PCRs. PID 0 is reserved for the PAT (which cannot carry PCRs), so it is
+	// safe to use 0 as the "not set" value.
+	pcrPid        int
+	pcrLastSeenAt time.Time // Last time we saw a PCR from the selected PID.
+	outBuf        []byte    // Preallocated byte buffer
 	closeCh       chan struct{}
 
 	startLogged bool // ensure logging TS processing route once
@@ -149,7 +173,7 @@ func NewTSStats() *TSStats {
 	}
 }
 
-func (mpp *MpegtsPacketProcessor) ProcessDatagram(datagram []byte) {
+func (mpp *MpegtsPacketProcessor) ProcessDatagram(now time.Time, datagram []byte) {
 	if !mpp.startLogged {
 		mpp.startLogged = true
 		mpegtslog.Info("mpegts processing first datagram",
@@ -179,7 +203,7 @@ func (mpp *MpegtsPacketProcessor) ProcessDatagram(datagram []byte) {
 		}
 		swapped := mpp.rtpStats.FirstTimestamp.CompareAndSwap(0, dgHeader.Timestamp)
 		if swapped {
-			mpp.rtpStats.RefTime = time.Now()
+			mpp.rtpStats.RefTime = now
 			mpp.rtpStats.FirstSeqNum.Store(uint32(dgHeader.SequenceNumber))
 			defer mpp.PushStats() // defer so that ts stats are included in the stats
 		}
@@ -197,7 +221,7 @@ func (mpp *MpegtsPacketProcessor) ProcessDatagram(datagram []byte) {
 	hasPadding := false
 	for offset := mpegtsOffset; offset+188 <= len(datagram); offset += 188 {
 		pkt := toTSPacket(datagram[offset : offset+188])
-		err := mpp.HandleMpegtsPacket(pkt)
+		err := mpp.HandleMpegtsPacket(now, pkt)
 		if err != nil {
 			badPackets++
 		} else if mpp.cfg.Packaging == transport.RtpTs {
@@ -216,15 +240,10 @@ func (mpp *MpegtsPacketProcessor) ProcessDatagram(datagram []byte) {
 		}
 	}
 
-	if mpp.pcr == 0 {
-		// Wait for at least one packet with PCR before writing
-		return
-	}
-
-	mpp.writeDatagram(datagram, badPackets == 0 && hasPadding && StripTsPadding.Load(), mpegtsOffset)
+	mpp.writeDatagram(now, datagram, badPackets == 0 && hasPadding && StripTsPadding.Load(), mpegtsOffset)
 }
 
-func (mpp *MpegtsPacketProcessor) HandleMpegtsPacket(pkt packet.Packet) error {
+func (mpp *MpegtsPacketProcessor) HandleMpegtsPacket(now time.Time, pkt packet.Packet) error {
 	mpp.stats.PacketsReceived.Inc()
 	mpp.stats.BytesReceived.Add(uint64(len(pkt)))
 
@@ -234,7 +253,7 @@ func (mpp *MpegtsPacketProcessor) HandleMpegtsPacket(pkt packet.Packet) error {
 	}
 
 	mpp.checkContinuityCounter(pkt)
-	mpp.updatePCR(pkt)
+	mpp.updatePCR(now, pkt)
 
 	if mpp.cfg.AnalyzeData || mpp.cfg.AnalyzeVideo {
 		// TODO(Nate): Copy over some of the logic analyzing this stuff
@@ -332,7 +351,7 @@ func (mpp *MpegtsPacketProcessor) checkContinuityCounter(pkt packet.Packet) {
 	}
 }
 
-func (mpp *MpegtsPacketProcessor) updatePCR(pkt packet.Packet) {
+func (mpp *MpegtsPacketProcessor) updatePCR(now time.Time, pkt packet.Packet) {
 	if !pkt.HasAdaptationField() {
 		return
 	}
@@ -348,45 +367,107 @@ func (mpp *MpegtsPacketProcessor) updatePCR(pkt packet.Packet) {
 		return
 	}
 
+	pid := pkt.PID()
+	if mpp.pcrPid != 0 && pid != mpp.pcrPid {
+		// We have already pinned a PCR PID and this packet is from a different program: ignore it.
+		return
+	}
+
 	pcr, err := a.PCR()
 	if err != nil {
 		mpp.stats.ErrorsAdapationField.Inc()
 		return
 	}
+
+	// pinningPcrPid is true when no PCR PID is currently pinned (at startup or after a wall-clock rotation unpinned
+	// it), so this PCR (re)pins the PID and is always accepted.
+	pinningPcrPid := mpp.pcrPid == 0
+	// A healthy PCR strictly advances, except for the rare counter wrap (a large backward jump). If it stagnates or
+	// moves backward without wrapping, the source clock is unhealthy: leave mpp.pcr / mpp.pcrLastSeenAt untouched so
+	// that rotationDecision falls back to wall-clock segmentation once the PCR goes stale.
+	pcrWrapped := pcr < mpp.pcr && mpp.pcr-pcr > PcrMax/2
+	if !pinningPcrPid && pcr <= mpp.pcr && !pcrWrapped {
+		return
+	}
+
 	mpp.pcr = pcr
+	mpp.pcrPid = pid
+	mpp.pcrLastSeenAt = now
+	if pinningPcrPid && mpp.currentWc != nil {
+		mpp.segStartPcr = pcr
+	}
 
 	mpp.stats.FirstPCR.CompareAndSwap(0, mpp.pcr)
 	mpp.stats.LastPCR.Store(mpp.pcr)
 }
 
-func (mpp *MpegtsPacketProcessor) writeDatagram(datagram []byte, removePadding bool, rtpPayloadOffset int) {
+func (mpp *MpegtsPacketProcessor) pcrIsStale(now time.Time) bool {
+	segmentLength := time.Duration(mpp.cfg.SegmentLengthSec) * time.Second
+	return segmentLength > 0 &&
+		!mpp.pcrLastSeenAt.IsZero() &&
+		now.Sub(mpp.pcrLastSeenAt) > segmentLength/pcrStaleSegmentDivisor
+}
+
+func (mpp *MpegtsPacketProcessor) checkRotation(now time.Time) rotationReason {
+	segmentLength := time.Duration(mpp.cfg.SegmentLengthSec) * time.Second
+	if mpp.currentWc == nil || segmentLength == 0 {
+		return rotationNone
+	}
+
+	// No usable PCR - either none seen yet, or the pinned PID went silent: fall back to wall-clock segmentation.
+	if mpp.pcrPid == 0 || mpp.pcrIsStale(now) {
+		if now.Sub(mpp.segStartTime) > segmentLength {
+			return rotationWallClock
+		}
+		return rotationNone
+	}
+
+	// Enforce a minimum wall-clock interval between PCR-driven rotations, guarding against creating segments far too
+	// frequently when the source PCR runs much faster than real time (e.g. a broken encoder clock) or a large burst
+	// of buffered data is flushed at once.
+	if now.Sub(mpp.segStartTime) < segmentLength/minSegmentWallClockDivisor {
+		return rotationNone
+	}
+
+	if mpp.pcr < mpp.segStartPcr && mpp.segStartPcr-mpp.pcr > PcrMax/2 {
+		return rotationPCRWrap
+	}
+	if mpp.pcr > mpp.segStartPcr && mpp.pcr-mpp.segStartPcr > mpp.cfg.SegmentLengthSec*PcrTs {
+		return rotationPCR
+	}
+	return rotationNone
+}
+
+func (mpp *MpegtsPacketProcessor) writeDatagram(now time.Time, datagram []byte, removePadding bool, rtpPayloadOffset int) {
 	if mpp.currentWc == nil {
 		if mpp.stats.ErrorsOpeningOutput.Load() > 50 {
 			return
 		}
 
-		err := mpp.openNextOutput()
+		err := mpp.openNextOutput(now)
 		if err != nil {
 			return
 		}
 	}
 
-	curCloseToZero := PcrTs*30 > mpp.pcr
-	prevCloseToMax := PcrMax-(PcrTs*60) < mpp.segStartPcr
-	pcrWrapped := prevCloseToMax && curCloseToZero
-	pcrPastSegmentBounds := mpp.pcr > mpp.segStartPcr && mpp.pcr-mpp.segStartPcr > mpp.cfg.SegmentLengthSec*PcrTs
-	segTimeFarTooLong := time.Since(mpp.segStartTime) > time.Duration(mpp.cfg.SegmentLengthSec)*time.Second*2
-	if pcrWrapped || pcrPastSegmentBounds || segTimeFarTooLong {
-		mpegtslog.Debug("opening next output", "pcrWrapped", pcrWrapped, "pcrPastSegmentBounds", pcrPastSegmentBounds, "pcr", mpp.pcr, "segStartPcr", mpp.segStartPcr)
-		if pcrWrapped {
+	if res := mpp.checkRotation(now); res != rotationNone {
+		switch res {
+		case rotationPCRWrap:
 			mpp.stats.NumWraps.Inc()
-		}
-		if segTimeFarTooLong {
+			mpegtslog.Debug("opening next output", "reason", "pcr_wrap", "pcr", mpp.pcr, "segStartPcr", mpp.segStartPcr)
+		case rotationPCR:
+			mpegtslog.Debug("opening next output", "reason", "pcr", "pcr", mpp.pcr, "segStartPcr", mpp.segStartPcr)
+		case rotationWallClock:
 			mpp.stats.NumTimedRotate.Inc()
+			mpegtslog.Debug("opening next output", "reason", "wallclock",
+				"last_seg_start_time", mpp.segStartTime, "time_since_start", now.Sub(mpp.segStartTime))
 		}
-		err := mpp.openNextOutput()
-		if err != nil {
+		if err := mpp.openNextOutput(now); err != nil {
 			return
+		}
+		if res == rotationWallClock {
+			// Unpin the PCR PID so a fresh PID can be selected for the new segment.
+			mpp.pcrPid = 0
 		}
 	}
 
@@ -433,7 +514,7 @@ func (mpp *MpegtsPacketProcessor) writeDatagram(datagram []byte, removePadding b
 	mpp.stats.BytesWritten.Add(uint64(n))
 }
 
-func (mpp *MpegtsPacketProcessor) openNextOutput() error {
+func (mpp *MpegtsPacketProcessor) openNextOutput(now time.Time) error {
 	startTime := time.Now()
 	var closeDone time.Time
 	defer func() {
@@ -461,7 +542,7 @@ func (mpp *MpegtsPacketProcessor) openNextOutput() error {
 	mpp.stats.NumSegments.Inc()
 	mpp.currentWc = wc
 	mpp.segStartPcr = mpp.pcr
-	mpp.segStartTime = time.Now()
+	mpp.segStartTime = now
 	return nil
 }
 

--- a/broadcastproto/mpegts/mpegts_test.go
+++ b/broadcastproto/mpegts/mpegts_test.go
@@ -1,0 +1,338 @@
+package mpegts
+
+import (
+	"io"
+	"testing"
+	"time"
+
+	"github.com/Comcast/gots/v2/packet"
+	"github.com/stretchr/testify/require"
+
+	"github.com/eluv-io/avpipe/broadcastproto/transport"
+)
+
+func TestMpegtsPacketProcessorPCRRotationFallback(t *testing.T) {
+	// base is the logical "now" for the first datagram of each subtest. Later datagrams pass base.Add(...) to
+	// advance time deterministically, instead of mutating the processor's internal timestamps.
+	base := time.Unix(1000, 0)
+
+	// laterThanSegment is comfortably beyond both the segment length and the staleness window (half the segment
+	// length) configured by newTestMpegtsPacketProcessor.
+	laterThanSegment := base.Add(3 * time.Second)
+
+	t.Run("startup writes without pcr", func(t *testing.T) {
+		opener := &recordingSequentialOpener{}
+		pp := newTestMpegtsPacketProcessor(opener)
+
+		first := mustPacketWithoutPCR(t, 100)
+		pp.ProcessDatagram(base, first[:])
+
+		require.Equal(t, 1, opener.opens)
+		require.Equal(t, 0, pp.pcrPid)
+		require.EqualValues(t, 1, pp.stats.NumSegments.Load())
+		require.EqualValues(t, 1, pp.stats.PacketsWritten.Load())
+	})
+
+	t.Run("no pcr rotates by wall clock", func(t *testing.T) {
+		opener := &recordingSequentialOpener{}
+		pp := newTestMpegtsPacketProcessor(opener)
+
+		first := mustPacketWithoutPCR(t, 100)
+		pp.ProcessDatagram(base, first[:])
+
+		require.Equal(t, 1, opener.opens)
+		require.EqualValues(t, 1, pp.stats.NumSegments.Load())
+		require.EqualValues(t, 0, pp.stats.NumTimedRotate.Load())
+
+		second := mustPacketWithoutPCR(t, 100)
+		pp.ProcessDatagram(laterThanSegment, second[:])
+
+		require.Equal(t, 2, opener.opens)
+		require.Equal(t, 0, pp.pcrPid)
+		require.EqualValues(t, 2, pp.stats.NumSegments.Load())
+		require.EqualValues(t, 1, pp.stats.NumTimedRotate.Load())
+	})
+
+	t.Run("zero pcr initializes processor", func(t *testing.T) {
+		opener := &recordingSequentialOpener{}
+		pp := newTestMpegtsPacketProcessor(opener)
+
+		first := mustPacketWithPCR(t, 100, 0)
+		pp.ProcessDatagram(base, first[:])
+
+		require.Equal(t, 1, opener.opens)
+		require.Equal(t, 100, pp.pcrPid)
+		require.EqualValues(t, 0, pp.pcr)
+		require.EqualValues(t, 1, pp.stats.NumSegments.Load())
+		require.EqualValues(t, 1, pp.stats.PacketsWritten.Load())
+	})
+
+	t.Run("first pcr switches from wall clock without immediate rotation", func(t *testing.T) {
+		opener := &recordingSequentialOpener{}
+		pp := newTestMpegtsPacketProcessor(opener)
+
+		first := mustPacketWithoutPCR(t, 100)
+		pp.ProcessDatagram(base, first[:])
+
+		require.Equal(t, 1, opener.opens)
+		require.Equal(t, 0, pp.pcrPid)
+
+		second := mustPacketWithPCR(t, 100, PcrTs*100)
+		pp.ProcessDatagram(base, second[:])
+
+		require.Equal(t, 1, opener.opens)
+		require.Equal(t, 100, pp.pcrPid)
+		require.EqualValues(t, PcrTs*100, pp.pcr)
+		require.EqualValues(t, PcrTs*100, pp.segStartPcr)
+		require.EqualValues(t, 0, pp.stats.NumTimedRotate.Load())
+	})
+
+	t.Run("pcr advancement rotates", func(t *testing.T) {
+		opener := &recordingSequentialOpener{}
+		pp := newTestMpegtsPacketProcessor(opener)
+
+		first := mustPacketWithPCR(t, 100, 1)
+		pp.ProcessDatagram(base, first[:])
+
+		require.Equal(t, 1, opener.opens)
+		require.EqualValues(t, 1, pp.stats.NumSegments.Load())
+		require.EqualValues(t, 0, pp.stats.NumTimedRotate.Load())
+
+		// PCR advances past the segment bounds once the minimum wall-clock margin has elapsed: rotation is media
+		// driven, not a timed fallback.
+		second := mustPacketWithPCR(t, 100, PcrTs*2)
+		pp.ProcessDatagram(base.Add(500*time.Millisecond), second[:])
+
+		require.Equal(t, 2, opener.opens)
+		require.EqualValues(t, 2, pp.stats.NumSegments.Load())
+		require.EqualValues(t, 0, pp.stats.NumTimedRotate.Load())
+	})
+
+	t.Run("pcr advancement respects minimum wall clock margin", func(t *testing.T) {
+		opener := &recordingSequentialOpener{}
+		pp := newTestMpegtsPacketProcessor(opener)
+
+		first := mustPacketWithPCR(t, 100, 1)
+		pp.ProcessDatagram(base, first[:])
+
+		require.Equal(t, 1, opener.opens)
+
+		// PCR has advanced a full segment, but barely any wall-clock time has passed (well under the segmentLength/4
+		// floor): the rotation is suppressed to avoid producing segments too frequently.
+		second := mustPacketWithPCR(t, 100, PcrTs*2)
+		pp.ProcessDatagram(base.Add(100*time.Millisecond), second[:])
+
+		require.Equal(t, 1, opener.opens)
+		require.EqualValues(t, 0, pp.stats.NumTimedRotate.Load())
+
+		// Once the minimum margin has elapsed, the pending PCR advancement triggers the rotation.
+		third := mustPacketWithPCR(t, 100, PcrTs*3)
+		pp.ProcessDatagram(base.Add(300*time.Millisecond), third[:])
+
+		require.Equal(t, 2, opener.opens)
+		require.EqualValues(t, 0, pp.stats.NumTimedRotate.Load())
+	})
+
+	t.Run("primary rotation stays media driven", func(t *testing.T) {
+		opener := &recordingSequentialOpener{}
+		pp := newTestMpegtsPacketProcessor(opener)
+
+		first := mustPacketWithPCR(t, 100, 1)
+		pp.ProcessDatagram(base, first[:])
+
+		require.Equal(t, 1, opener.opens)
+		require.EqualValues(t, 1, pp.stats.NumSegments.Load())
+		require.EqualValues(t, 0, pp.stats.NumTimedRotate.Load())
+
+		// Well past the segment length, but a fresh PCR that has barely advanced keeps rotation media driven: no
+		// wall-clock fallback fires.
+		second := mustPacketWithPCR(t, 100, 2)
+		pp.ProcessDatagram(laterThanSegment, second[:])
+
+		require.Equal(t, 1, opener.opens)
+		require.EqualValues(t, 0, pp.stats.NumTimedRotate.Load())
+	})
+
+	t.Run("pcr pid stays pinned", func(t *testing.T) {
+		opener := &recordingSequentialOpener{}
+		pp := newTestMpegtsPacketProcessor(opener)
+
+		first := mustPacketWithPCR(t, 100, 1)
+		pp.ProcessDatagram(base, first[:])
+
+		require.Equal(t, 1, opener.opens)
+		require.Equal(t, 100, pp.pcrPid)
+		require.EqualValues(t, 1, pp.pcr)
+
+		// A PCR from a different program must not be adopted while the original PID is still fresh.
+		second := mustPacketWithPCR(t, 200, PcrTs*2)
+		pp.ProcessDatagram(base, second[:])
+
+		require.Equal(t, 1, opener.opens)
+		require.Equal(t, 100, pp.pcrPid)
+		require.EqualValues(t, 1, pp.pcr)
+		require.EqualValues(t, 0, pp.stats.NumTimedRotate.Load())
+	})
+
+	t.Run("stale pcr pid clears on fallback rotation", func(t *testing.T) {
+		opener := &recordingSequentialOpener{}
+		pp := newTestMpegtsPacketProcessor(opener)
+
+		first := mustPacketWithPCR(t, 100, 1)
+		pp.ProcessDatagram(base, first[:])
+
+		require.Equal(t, 1, opener.opens)
+		require.Equal(t, 100, pp.pcrPid)
+		require.EqualValues(t, 1, pp.pcr)
+
+		// The pinned PID has gone silent; a PCR from a different program arrives after the staleness window. It is
+		// ignored for PCR, so the processor falls back to wall clock and unpins the PID.
+		second := mustPacketWithPCR(t, 200, 2)
+		pp.ProcessDatagram(laterThanSegment, second[:])
+
+		require.Equal(t, 2, opener.opens)
+		require.Equal(t, 0, pp.pcrPid)
+		require.EqualValues(t, 1, pp.pcr)
+		require.EqualValues(t, 1, pp.stats.NumTimedRotate.Load())
+
+		// With the PID unpinned, the next PCR re-pins onto the new program.
+		third := mustPacketWithPCR(t, 200, 2)
+		pp.ProcessDatagram(laterThanSegment, third[:])
+
+		require.Equal(t, 2, opener.opens)
+		require.Equal(t, 200, pp.pcrPid)
+		require.EqualValues(t, 2, pp.pcr)
+		require.EqualValues(t, 1, pp.stats.NumTimedRotate.Load())
+	})
+
+	t.Run("stagnant pcr falls back to wall clock", func(t *testing.T) {
+		opener := &recordingSequentialOpener{}
+		pp := newTestMpegtsPacketProcessor(opener)
+
+		first := mustPacketWithPCR(t, 100, PcrTs)
+		pp.ProcessDatagram(base, first[:])
+
+		require.Equal(t, 1, opener.opens)
+		require.Equal(t, 100, pp.pcrPid)
+
+		// Simulate a frozen source clock: the pinned PID keeps emitting the same PCR value. The repeated value must
+		// not refresh pcrLastSeenAt, so staleness triggers a wall-clock rotation.
+		second := mustPacketWithPCR(t, 100, PcrTs)
+		pp.ProcessDatagram(laterThanSegment, second[:])
+
+		require.Equal(t, 2, opener.opens)
+		require.Equal(t, 0, pp.pcrPid)
+		require.EqualValues(t, PcrTs, pp.pcr)
+		require.EqualValues(t, 1, pp.stats.NumTimedRotate.Load())
+	})
+
+	t.Run("backward pcr is ignored", func(t *testing.T) {
+		opener := &recordingSequentialOpener{}
+		pp := newTestMpegtsPacketProcessor(opener)
+
+		first := mustPacketWithPCR(t, 100, PcrTs*100)
+		pp.ProcessDatagram(base, first[:])
+		require.EqualValues(t, PcrTs*100, pp.pcr)
+
+		// A small backward step (not a wrap) is treated as an unhealthy clock and ignored.
+		second := mustPacketWithPCR(t, 100, PcrTs*50)
+		pp.ProcessDatagram(base, second[:])
+		require.EqualValues(t, PcrTs*100, pp.pcr)
+	})
+
+	t.Run("pcr wrap is accepted", func(t *testing.T) {
+		opener := &recordingSequentialOpener{}
+		pp := newTestMpegtsPacketProcessor(opener)
+
+		first := mustPacketWithPCR(t, 100, (PcrMax/4)*3)
+		pp.ProcessDatagram(base, first[:])
+		require.EqualValues(t, (PcrMax/4)*3, pp.pcr)
+
+		// A large backward jump is a genuine counter wrap and must be accepted as the new media time.
+		second := mustPacketWithPCR(t, 100, PcrTs)
+		pp.ProcessDatagram(base, second[:])
+		require.EqualValues(t, PcrTs, pp.pcr)
+	})
+
+	t.Run("stale pid uses wall clock fallback", func(t *testing.T) {
+		opener := &recordingSequentialOpener{}
+		pp := newTestMpegtsPacketProcessor(opener)
+
+		first := mustPacketWithPCR(t, 100, 1)
+		pp.ProcessDatagram(base, first[:])
+
+		require.Equal(t, 1, opener.opens)
+		require.EqualValues(t, 1, pp.stats.NumSegments.Load())
+		require.EqualValues(t, 0, pp.stats.NumTimedRotate.Load())
+
+		// The pinned PID has gone silent and a PCR-less datagram arrives after the staleness window: wall clock takes
+		// over segmentation.
+		second := mustPacketWithoutPCR(t, 100)
+		pp.ProcessDatagram(laterThanSegment, second[:])
+
+		require.Equal(t, 2, opener.opens)
+		require.EqualValues(t, 2, pp.stats.NumSegments.Load())
+		require.EqualValues(t, 1, pp.stats.NumTimedRotate.Load())
+	})
+}
+
+func newTestMpegtsPacketProcessor(opener SequentialOpener) *MpegtsPacketProcessor {
+	return NewMpegtsPacketProcessor(
+		TsConfig{
+			SegmentLengthSec: 1,
+			Packaging:        transport.RawTs,
+		},
+		opener,
+		1,
+	)
+}
+
+func mustPacketWithPCR(t *testing.T, pid int, pcr uint64) packet.Packet {
+	t.Helper()
+
+	pkt := packet.New()
+	pkt.SetPID(pid)
+	require.NoError(t, pkt.SetAdaptationFieldControl(packet.AdaptationFieldFlag))
+	af, err := pkt.AdaptationField()
+	require.NoError(t, err)
+	require.NoError(t, af.SetHasPCR(true))
+	require.NoError(t, af.SetPCR(pcr))
+
+	return *pkt
+}
+
+func mustPacketWithoutPCR(t *testing.T, pid int) packet.Packet {
+	t.Helper()
+
+	pkt := packet.New()
+	pkt.SetPID(pid)
+	require.NoError(t, pkt.SetAdaptationFieldControl(packet.AdaptationFieldFlag))
+	return *pkt
+}
+
+type recordingSequentialOpener struct {
+	opens int
+}
+
+func (o *recordingSequentialOpener) OpenNext() (io.WriteCloser, error) {
+	o.opens++
+	return &recordingWriteCloser{}, nil
+}
+
+func (o *recordingSequentialOpener) Stat(args any) error {
+	return nil
+}
+
+func (o *recordingSequentialOpener) ReportStart() error {
+	return nil
+}
+
+type recordingWriteCloser struct{}
+
+func (w *recordingWriteCloser) Write(p []byte) (int, error) {
+	return len(p), nil
+}
+
+func (w *recordingWriteCloser) Close() error {
+	return nil
+}


### PR DESCRIPTION
Multi-program MPEGTS streams carry independent PCRs for each program. The segmenter previously tracked the PCR from any PID, so interleaved PCRs from different programs produced an unstable timeline and erratic segment rotation.

Pin the PCR to the first PID that yields a valid PCR and ignore PCRs from other PIDs. The segment-start PCR is captured from that PID's first PCR, and wrap detection now triggers on any large backward jump (> PcrMax/2) rather than the old close-to-zero / close-to-max heuristic.

Reject unhealthy PCRs: a value that stagnates or moves backward without wrapping no longer advances mpp.pcr / pcrLastSeenAt. Combined with a new staleness check (no PCR from the pinned PID for longer than half the segment length), the pinned PID then goes stale and segmentation falls back to wall-clock time, after which the PID is unpinned and re-selected. This replaces the old "segment far too long" backstop and keeps mpp.pcr coherent across bad input.

Enforce a minimum wall-clock interval between PCR-driven rotations (segment length / 4) so a broken encoder clock running much faster than real time, or a large flushed buffer, cannot spawn many tiny segments.

Other changes:
- Extract rotation logic into checkRotation(), returning a single rotationReason (rotationPCR / rotationPCRWrap / rotationWallClock / rotationNone).
- Drop the "wait for first PCR before writing" gate so PCR-less streams are segmented purely on wall-clock time.
- Thread an explicit "now" through ProcessDatagram -> HandleMpegtsPacket -> updatePCR and writeDatagram -> openNextOutput so a single timestamp is used per datagram and time can be injected in tests. I/O-latency probes keep using real wall-clock time.
- netreader: treat io.EOF as non-recoverable so the read loop stops instead of reconnecting forever on a closed stream.
- Add table of unit tests covering PID pinning, stale/stagnant/backward/wrap PCR handling, and wall-clock fallback.