### PR TITLE
use Taker interface in ioHandler.OutWriter

### DIFF
--- a/avpipe.go
+++ b/avpipe.go
@@ -468,9 +468,9 @@ func AVPipeWriteOutput(handler C.int64_t, fd C.int64_t, buf *C.uint8_t, sz C.int
 
 // AVPipeWriteOutputGo writes the given buffer to the goavpipe.OutputHandler
 // pointed to by fd in the table of handler.
-// The optional allowTake parameter when true commits the caller to no modification
-// of the buffer thus allowing the callee to take ownership of the buffer.
-func AVPipeWriteOutputGo(handler int64, fd int64, buf []byte, allowTake ...bool) int {
+// The allowTake parameter when true commits the caller to no modification of
+// the buffer thus allowing the callee to take ownership of the buffer.
+func AVPipeWriteOutputGo(handler int64, fd int64, buf []byte, allowTake bool) int {
 	if len(buf) == 0 {
 		return 0
 	}
@@ -491,12 +491,7 @@ func AVPipeWriteOutputGo(handler int64, fd int64, buf []byte, allowTake ...bool)
 		return -1
 	}
 
-	canTake := false
-	if len(allowTake) > 0 {
-		canTake = allowTake[0]
-	}
-
-	n, err := h.OutWriter(C.int64_t(fd), buf, canTake)
+	n, err := h.OutWriter(C.int64_t(fd), buf, allowTake)
 	if err != nil {
 		return -1
 	}

--- a/avpipe.go
+++ b/avpipe.go
@@ -463,10 +463,14 @@ func AVPipeWriteOutput(handler C.int64_t, fd C.int64_t, buf *C.uint8_t, sz C.int
 	gobuf := make([]byte, sz)
 	C.memcpy(unsafe.Pointer(&gobuf[0]), unsafe.Pointer(buf), C.size_t(sz))
 
-	return C.int(AVPipeWriteOutputGo(int64(handler), int64(fd), gobuf))
+	return C.int(AVPipeWriteOutputGo(int64(handler), int64(fd), gobuf, true))
 }
 
-func AVPipeWriteOutputGo(handler int64, fd int64, buf []byte) int {
+// AVPipeWriteOutputGo writes the given buffer to the goavpipe.OutputHandler
+// pointed to by fd in the table of handler.
+// The optional allowTake parameter when true commits the caller to no modification
+// of the buffer thus allowing the callee to take ownership of the buffer.
+func AVPipeWriteOutputGo(handler int64, fd int64, buf []byte, allowTake ...bool) int {
 	if len(buf) == 0 {
 		return 0
 	}
@@ -487,7 +491,12 @@ func AVPipeWriteOutputGo(handler int64, fd int64, buf []byte) int {
 		return -1
 	}
 
-	n, err := h.OutWriter(C.int64_t(fd), buf)
+	canTake := false
+	if len(allowTake) > 0 {
+		canTake = allowTake[0]
+	}
+
+	n, err := h.OutWriter(C.int64_t(fd), buf, canTake)
 	if err != nil {
 		return -1
 	}
@@ -514,9 +523,33 @@ func AVPipeWriteMuxOutput(fd C.int64_t, buf *C.uint8_t, sz C.int) C.int {
 	return C.int(n)
 }
 
-func (h *ioHandler) OutWriter(fd C.int64_t, buf []byte) (int, error) {
+func (h *ioHandler) OutWriter(fd C.int64_t, buf []byte, canTake bool) (int, error) {
+	// Taker is an optional interface of OutputHandler where 'buf' is taken by
+	// the receiver which then assumes the ownership of that buffer (as opposed
+	// to the io.Writer where the caller keeps the ownership of the buffer).
+	// NOTE:
+	// * after calling 'Take' the caller must not modify the passed in buffer.
+	// * the Taker interface is defined and used in avcache-go/cache for page segments
+	type Taker interface {
+		Take(b []byte) error
+	}
+
 	outHandler := h.getOutTable(int64(fd))
-	n, err := outHandler.Write(buf)
+
+	var taker Taker
+	if canTake {
+		taker, _ = outHandler.(Taker)
+	}
+
+	var n int
+	var err error
+	if taker != nil {
+		n = len(buf)
+		err = taker.Take(buf)
+	} else {
+		n, err = outHandler.Write(buf)
+	}
+
 	if traceIo {
 		goavpipe.Log.Debug("OutWriter written", "n", n, "error", err)
 	}

--- a/avpipe_mvhevc.go
+++ b/avpipe_mvhevc.go
@@ -116,6 +116,8 @@ type mvhevcOutputHandler struct {
 	patcher *mvhevcpatch.StreamPatcher
 }
 
+// mvhevcOutputHandler deliberately does not implement the optional Taker
+// interface (it buffers and rewrites)
 func (h *mvhevcOutputHandler) Write(buf []byte) (int, error) {
 	return h.patcher.Write(buf)
 }

--- a/avpipe_seq_writer.go
+++ b/avpipe_seq_writer.go
@@ -67,7 +67,7 @@ func (h *avpipeSequentialOutHandler) Write(p []byte) (n int, err error) {
 		return 0, errOutputClosed
 	}
 
-	n = AVPipeWriteOutputGo(h.inFd, *h.outFd, p)
+	n = AVPipeWriteOutputGo(h.inFd, *h.outFd, p, false)
 	if n < 0 {
 		return 0, fmt.Errorf("failed to write to output fd %d", *h.outFd)
 	}


### PR DESCRIPTION
The Taker interface is defined and used for page segments in avcache-go/cache

This PR is meant to take advantage of changes in [content-fabric#3899](https://github.com/qluvio/content-fabric/pull/3899)