### PR TITLE
Fix fmp4-validate cmd

### DIFF
--- a/mp4e/dovi/info.go
+++ b/mp4e/dovi/info.go
@@ -78,9 +78,12 @@ func Info(inputPath string, opts InfoOptions) (map[string]any, error) {
 	}
 	defer func() { _ = ifd.Close() }()
 
-	parsedMP4, err := mp4.DecodeFile(ifd, mp4.WithDecodeMode(mp4.DecModeLazyMdat))
-	if err != nil {
-		return nil, fmt.Errorf("could not decode MP4: %w", err)
+	// Non-fatal decode errors: some files have unknown/proprietary top-level
+	// boxes after mdat that mp4ff cannot parse. As long as moov was decoded we
+	// have everything we need.
+	parsedMP4, decodeErr := mp4.DecodeFile(ifd, mp4.WithDecodeMode(mp4.DecModeLazyMdat))
+	if parsedMP4 == nil {
+		return nil, fmt.Errorf("could not decode MP4: %w", decodeErr)
 	}
 
 	if parsedMP4.Moov == nil {
@@ -191,6 +194,9 @@ func Info(inputPath string, opts InfoOptions) (map[string]any, error) {
 	}
 
 	results["File-level QC"] = fileLevelDVQC(parsedMP4, dvTrackIDs)
+	if decodeErr != nil {
+		results["parse_warning"] = decodeErr.Error()
+	}
 	return results, nil
 }
 

--- a/mp4e/mvhevc/info.go
+++ b/mp4e/mvhevc/info.go
@@ -20,9 +20,12 @@ func Info(inputPath string, opts InfoOptions) (map[string]any, error) {
 	}
 	defer func() { _ = ifd.Close() }()
 
-	parsedMP4, err := mp4.DecodeFile(ifd, mp4.WithDecodeMode(mp4.DecModeLazyMdat))
-	if err != nil {
-		return nil, fmt.Errorf("could not decode MP4: %w", err)
+	// Non-fatal decode errors: some files have unknown/proprietary top-level
+	// boxes after mdat that mp4ff cannot parse. As long as moov was decoded we
+	// have everything we need.
+	parsedMP4, decodeErr := mp4.DecodeFile(ifd, mp4.WithDecodeMode(mp4.DecModeLazyMdat))
+	if parsedMP4 == nil {
+		return nil, fmt.Errorf("could not decode MP4: %w", decodeErr)
 	}
 
 	if parsedMP4.Moov == nil {
@@ -93,6 +96,9 @@ func Info(inputPath string, opts InfoOptions) (map[string]any, error) {
 		results[key] = track
 	}
 
+	if decodeErr != nil {
+		results["parse_warning"] = decodeErr.Error()
+	}
 	return results, nil
 }
 


### PR DESCRIPTION
From Robot:

**Change:** Non-fatal decode error handling in mp4e/dovi/info.go

**Problem:**
The 8 GB DV file has unknown proprietary boxes appended at the very end (past the 7 GB mark). When mp4.DecodeFile encountered them, it returned an error. The original code treated any decode error as fatal and returned immediately — so the whole --dovi command failed with "could not decode MP4", even though the important part (moov, which has all the track and DV metadata) had already been fully read.

**Fix:**
Two small changes:

Changed if err != nil → return nil to if parsedMP4 == nil → return nil
— Only abort if mp4ff returned nothing at all. If parsedMP4 exists, moov was decoded and we have everything we need.

Added results["parse_warning"] = decodeErr.Error()
— Instead of silently ignoring the error, surface it as a warning field in the JSON output so the caller is still aware something unusual was encountered.

**Why this is safe:**
The file is a progressive MP4 — moov comes before mdat. By the time mp4ff hits the unknown trailing boxes, it has already decoded all the metadata. The trailing boxes are non-standard and don't affect the DV validation at all.

