### PR TITLE
Fix Probe out of memory due to non-suitable file formats

### DIFF
--- a/avpipe.go
+++ b/avpipe.go
@@ -1030,7 +1030,7 @@ func GetProfileName(codecId int, profile int) string {
 	return ""
 }
 
-// Probe runs the C libavformat probe and optionally enhances the output with mp4 specific condec info
+// Probe runs the C libavformat probe and optionally enhances the output with mp4 specific codec info
 // PENDING(SS) Should move this function to avpipe_probe.go
 func Probe(params *goavpipe.XcParams) (*goavpipe.ProbeInfo, error) {
 	const op = "avpipe.Probe"
@@ -1053,8 +1053,15 @@ func Probe(params *goavpipe.XcParams) (*goavpipe.ProbeInfo, error) {
 	// extractCodecInfoForProbe would fail to re-open. The handle is kept open so that C.probe can
 	// open the same resource concurrently; it is closed via defer when Probe returns.
 	//
-	// Non-MP4 inputs fail here gracefully. Unfortunately, the container format is unknown until
-	// probing, so we cannot skip this step altogether.
+	// This sequence is designed to work in the Content Fabric context:
+	// - we have one req context per URL and one part reader
+	// - we create two 'input contexts' pointing to the same reader
+	//
+	// In order to make this work we implement this sequence:
+	// - open the handler for the MP4 extraction first (don't close)
+	// - seek back to 0
+	// - invoke the C.Probe which opens its own handle the closes its own handle via callbacks
+	// - finally close the MP4 extraction handle
 	var codecInfos []*mp4e.CodecInfo
 	if params.Seekable {
 		inputOpener := goavpipe.GetInputOpener(params.Url)
@@ -1198,6 +1205,7 @@ func Probe(params *goavpipe.XcParams) (*goavpipe.ProbeInfo, error) {
 
 	probeInfo.Format.FormatName = C.GoString((*C.char)(unsafe.Pointer(cprobe.container_info.format_name)))
 	probeInfo.Format.Duration = float64(cprobe.container_info.duration)
+
 	if codecInfos != nil {
 		enhanceStreamInfo(probeInfo.Streams, codecInfos)
 	}

--- a/avpipe.go
+++ b/avpipe.go
@@ -1060,7 +1060,7 @@ func Probe(params *goavpipe.XcParams) (*goavpipe.ProbeInfo, error) {
 	// In order to make this work we implement this sequence:
 	// - open the handler for the MP4 extraction first (don't close)
 	// - seek back to 0
-	// - invoke the C.Probe which opens its own handle the closes its own handle via callbacks
+	// - invoke the C.Probe which opens its own handle then closes its own handle via callbacks
 	// - finally close the MP4 extraction handle
 	var codecInfos []*mp4e.CodecInfo
 	if params.Seekable {

--- a/mp4e/codec_info.go
+++ b/mp4e/codec_info.go
@@ -118,18 +118,20 @@ func ExtractCodecInfoLazy(r io.ReadSeeker) (infos []*CodecInfo, err error) {
 
 	// Light detection of MP4/MOV (ISOBMFF) using header sniff.
 	// The decoder may crash or run out of memory for an incorrect format.
-	looksMP4 := HasISOBMFFHeader(r)
+	looksMP4, hdr := HasISOBMFFHeader(r)
 	if _, err = r.Seek(0, io.SeekStart); err != nil {
 		return nil, e("reason", "seek to start after header sniff", "error", err)
 	}
 	if !looksMP4 {
-		return nil, e("reason", "not an ISOBMFF/MP4 container")
+		return nil, e("reason", "not an ISOBMFF/MP4 container", "header", fmt.Sprintf("%x", hdr))
 	}
 
 	// Cap the total bytes read into memory during the lazy parse. This is critical to avoid
 	// out-of-memory situations with unexpected file formats.
 	lr := newLimitedReadSeeker(r, maxLazyReadBytes)
 
+	// PENDING(SS) We could make a SafeDecodeFile() wrapper that engages the bytes cap and
+	// suitable ISOBMFF checks.
 	mp4Data, err := mp4.DecodeFile(lr, mp4.WithDecodeMode(mp4.DecModeLazyMdat))
 	if err != nil {
 		return nil, e("reason", "failed to parse MP4", "cause", sanitizeString(err.Error()))
@@ -152,7 +154,7 @@ func newLimitedReadSeeker(r io.ReadSeeker, limit int64) *limitedReadSeeker {
 
 func (l *limitedReadSeeker) Read(p []byte) (int, error) {
 	if l.remaining <= 0 {
-		return 0, errors.E("mp4 codec info", "reason", "read limit exceeded", "bytes", maxLazyReadBytes)
+		return 0, errors.E("mp4 codec info", "reason", "read limit exceeded", "limit", maxLazyReadBytes)
 	}
 	if int64(len(p)) > l.remaining {
 		p = p[:l.remaining]

--- a/mp4e/codec_info.go
+++ b/mp4e/codec_info.go
@@ -116,11 +116,54 @@ func ExtractCodecInfoLazy(r io.ReadSeeker) (infos []*CodecInfo, err error) {
 	const op = "mp4e.ExtractCodecInfoLazy"
 	e := errors.T(op, errors.K.Invalid.Default())
 
-	mp4Data, err := mp4.DecodeFile(r, mp4.WithDecodeMode(mp4.DecModeLazyMdat))
+	// Light detection of MP4/MOV (ISOBMFF) using header sniff.
+	// The decoder may crash or run out of memory for an incorrect format.
+	looksMP4 := HasISOBMFFHeader(r)
+	if _, err = r.Seek(0, io.SeekStart); err != nil {
+		return nil, e("reason", "seek to start after header sniff", "error", err)
+	}
+	if !looksMP4 {
+		return nil, e("reason", "not an ISOBMFF/MP4 container")
+	}
+
+	// Cap the total bytes read into memory during the lazy parse. This is critical to avoid
+	// out-of-memory situations with unexpected file formats.
+	lr := newLimitedReadSeeker(r, maxLazyReadBytes)
+
+	mp4Data, err := mp4.DecodeFile(lr, mp4.WithDecodeMode(mp4.DecModeLazyMdat))
 	if err != nil {
 		return nil, e("reason", "failed to parse MP4", "cause", sanitizeString(err.Error()))
 	}
 	return extractCodecInfoFromFile(mp4Data)
+}
+
+// maxLazyReadBytes bounds the cumulative bytes read into memory during a lazy MP4 parse
+const maxLazyReadBytes = 512 << 20 // 512 MB
+
+// limitedReadSeeker caps the cumulative number of bytes returned by Read (passing Seek through unchanged)
+type limitedReadSeeker struct {
+	r         io.ReadSeeker
+	remaining int64
+}
+
+func newLimitedReadSeeker(r io.ReadSeeker, limit int64) *limitedReadSeeker {
+	return &limitedReadSeeker{r: r, remaining: limit}
+}
+
+func (l *limitedReadSeeker) Read(p []byte) (int, error) {
+	if l.remaining <= 0 {
+		return 0, errors.E("mp4 codec info", "reason", "read limit exceeded", "bytes", maxLazyReadBytes)
+	}
+	if int64(len(p)) > l.remaining {
+		p = p[:l.remaining]
+	}
+	n, err := l.r.Read(p)
+	l.remaining -= int64(n)
+	return n, err
+}
+
+func (l *limitedReadSeeker) Seek(offset int64, whence int) (int64, error) {
+	return l.r.Seek(offset, whence)
 }
 
 // extractCodecInfoFromFile builds CodecInfo for every track of a decoded MP4.

--- a/mp4e/codec_info_test.go
+++ b/mp4e/codec_info_test.go
@@ -233,7 +233,7 @@ func TestExtractCodecInfoLazyBoundsMemoryOnGarbage(t *testing.T) {
 	require.Nil(t, infos)
 }
 
-// TestLimitedReadSeeker verifies probe MP$ extrace read cap
+// TestLimitedReadSeeker verifies probe MP4 extract read cap
 func TestLimitedReadSeeker(t *testing.T) {
 	data := make([]byte, 1000)
 	lr := newLimitedReadSeeker(bytes.NewReader(data), 100)

--- a/mp4e/codec_info_test.go
+++ b/mp4e/codec_info_test.go
@@ -222,3 +222,47 @@ func TestExtractCodecInfo(t *testing.T) {
 		assert.Equal(t, 16, info.EC3.ComplexityIndex)
 	})
 }
+
+// TestExtractCodecInfoLazyBoundsMemoryOnGarbage verifies parsing of a bogus header
+// advertising a multi-GB body
+func TestExtractCodecInfoLazyBoundsMemoryOnGarbage(t *testing.T) {
+	// size = 0x7fffffff (~2GB) followed by a garbage box type and a little data.
+	data := []byte{0x7f, 0xff, 0xff, 0xff, 0x2d, 0x85, 0x00, 0x1e, 0xde, 0xad, 0xbe, 0xef}
+	infos, err := ExtractCodecInfoLazy(bytes.NewReader(data))
+	require.Error(t, err)
+	require.Nil(t, infos)
+}
+
+// TestLimitedReadSeeker verifies probe MP$ extrace read cap
+func TestLimitedReadSeeker(t *testing.T) {
+	data := make([]byte, 1000)
+	lr := newLimitedReadSeeker(bytes.NewReader(data), 100)
+
+	// Seeks are free and must not consume the read budget.
+	pos, err := lr.Seek(500, 0) // io.SeekStart
+	require.NoError(t, err)
+	require.Equal(t, int64(500), pos)
+	pos, err = lr.Seek(0, 0)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), pos)
+
+	// Reads are capped: io.ReadAll accumulates at most the limit, then errors.
+	buf := make([]byte, 4096)
+	got, err := lr.Read(buf)
+	require.NoError(t, err)
+	require.Equal(t, 100, got) // truncated to the remaining budget
+	_, err = lr.Read(buf)
+	require.Error(t, err) // budget exhausted
+	require.Contains(t, err.Error(), "read limit")
+}
+
+// TestExtractCodecInfoLazyRewindsOnNonMP4 verifies probe header sniff
+func TestExtractCodecInfoLazyRewindsOnNonMP4(t *testing.T) {
+	r := bytes.NewReader([]byte("RIFF\x24\x00\x00\x00WAVEfmt some more bytes here"))
+	infos, err := ExtractCodecInfoLazy(r)
+	require.Error(t, err)
+	require.Nil(t, infos)
+	pos, seekErr := r.Seek(0, 1) // io.SeekCurrent
+	require.NoError(t, seekErr)
+	require.Equal(t, int64(0), pos)
+}

--- a/mp4e/detect.go
+++ b/mp4e/detect.go
@@ -65,10 +65,13 @@ var isobmffTopLevelBoxTypes = map[string]bool{
 // HasFtypHeader it also accepts segment leaders (styp/moof), so it recognizes
 // DASH/HLS fMP4 segments as well as whole files. It reads 8 bytes and does not
 // seek back, so the caller must reposition the reader before decoding.
-func HasISOBMFFHeader(r io.Reader) bool {
-	var hdr [8]byte
-	if _, err := io.ReadFull(r, hdr[:]); err != nil {
-		return false
+//
+// Returns the header bytes read (up to 8)
+func HasISOBMFFHeader(r io.Reader) (ok bool, hdr []byte) {
+	var buf [8]byte
+	n, err := io.ReadFull(r, buf[:])
+	if err != nil {
+		return false, buf[:n]
 	}
-	return isobmffTopLevelBoxTypes[string(hdr[4:8])]
+	return isobmffTopLevelBoxTypes[string(buf[4:8])], buf[:n]
 }

--- a/mp4e/detect.go
+++ b/mp4e/detect.go
@@ -1,0 +1,74 @@
+package mp4e
+
+import (
+	"io"
+	"path/filepath"
+	"strings"
+)
+
+// This file centralizes detection of the MP4 / MOV (ISOBMFF) family
+
+// mp4Extensions are the file extensions of the MP4 / MOV (ISOBMFF) family.
+var mp4Extensions = map[string]bool{
+	".mp4":  true,
+	".m4v":  true,
+	".m4a":  true,
+	".mov":  true,
+	".fmp4": true,
+}
+
+// IsMP4Extension reports whether path has an MP4/MOV-family file extension.
+func IsMP4Extension(path string) bool {
+	return mp4Extensions[strings.ToLower(filepath.Ext(path))]
+}
+
+// IsMP4FormatName reports whether the container format name reported by FFmpeg
+// belongs to the MP4/MOV family.
+// FFmpeg's demuxer reports a single comma-separated name ("mov,mp4,m4a,3gp,3g2,mj2")
+func IsMP4FormatName(formatName string) bool {
+	return strings.Contains(formatName, "mp4") || strings.Contains(formatName, "mov")
+}
+
+// HasFtypHeader reports whether r begins with an ISOBMFF/QuickTime "ftyp" box
+// It doesn't match 'styp' or 'moof' so it will not match raw DASH/HLS segments.
+// It reads the first 8 bytes and does not seek back.
+func HasFtypHeader(r io.Reader) bool {
+	var hdr [8]byte
+	if _, err := io.ReadFull(r, hdr[:]); err != nil {
+		return false
+	}
+	return string(hdr[4:8]) == "ftyp"
+}
+
+// isobmffTopLevelBoxTypes are box types that may legitimately appear as the
+// first box of an ISOBMFF stream or segment. It covers whole files/init segments
+// (ftyp/moov), fragmented media segments (styp/moof/mdat), and the assorted
+// filler/index boxes that can lead a file.
+var isobmffTopLevelBoxTypes = map[string]bool{
+	"ftyp": true, // file type (files, init segments)
+	"styp": true, // segment type (fMP4 media segments)
+	"moov": true, // movie box (some QuickTime .mov lead with this)
+	"moof": true, // movie fragment (media segment with no styp)
+	"mdat": true, // media data
+	"free": true, // free space
+	"skip": true, // free space
+	"sidx": true, // segment index
+	"pdin": true, // progressive download info
+	"meta": true, // metadata
+	"mfra": true, // movie fragment random access
+	"wide": true, // QuickTime padding atom
+	"pnot": true, // QuickTime preview atom
+}
+
+// HasISOBMFFHeader reports whether the first 8 bytes of r are a plausible
+// top-level ISOBMFF box header (a recognized box type in bytes 4..8). Unlike
+// HasFtypHeader it also accepts segment leaders (styp/moof), so it recognizes
+// DASH/HLS fMP4 segments as well as whole files. It reads 8 bytes and does not
+// seek back, so the caller must reposition the reader before decoding.
+func HasISOBMFFHeader(r io.Reader) bool {
+	var hdr [8]byte
+	if _, err := io.ReadFull(r, hdr[:]); err != nil {
+		return false
+	}
+	return isobmffTopLevelBoxTypes[string(hdr[4:8])]
+}

--- a/mp4e/detect_test.go
+++ b/mp4e/detect_test.go
@@ -38,10 +38,19 @@ func TestHasISOBMFFHeader(t *testing.T) {
 		return b
 	}
 	for _, typ := range []string{"ftyp", "styp", "moov", "moof", "mdat", "sidx", "free"} {
-		require.True(t, HasISOBMFFHeader(bytes.NewReader(box(typ))), typ)
+		ok, _ := HasISOBMFFHeader(bytes.NewReader(box(typ)))
+		require.True(t, ok, typ)
 	}
-	// non-ISOBMFF leaders
-	require.False(t, HasISOBMFFHeader(bytes.NewReader([]byte("RIFF\x00\x00\x00\x00WAVE"))))
-	require.False(t, HasISOBMFFHeader(bytes.NewReader([]byte{0x06, 0x0e, 0x2b, 0x34, 0x02, 0x05, 0x01, 0x01}))) // MXF
-	require.False(t, HasISOBMFFHeader(bytes.NewReader([]byte{0x00, 0x01})))                                     // too short
+	// non-ISOBMFF leaders: header bytes are returned so a caller can log them
+	ok, hdr := HasISOBMFFHeader(bytes.NewReader([]byte("RIFF\x00\x00\x00\x00WAVE")))
+	require.False(t, ok)
+	require.Equal(t, []byte("RIFF\x00\x00\x00\x00"), hdr)
+
+	ok, _ = HasISOBMFFHeader(bytes.NewReader([]byte{0x06, 0x0e, 0x2b, 0x34, 0x02, 0x05, 0x01, 0x01})) // MXF
+	require.False(t, ok)
+
+	// too short: returns the partial header actually read
+	ok, hdr = HasISOBMFFHeader(bytes.NewReader([]byte{0x00, 0x01}))
+	require.False(t, ok)
+	require.Equal(t, []byte{0x00, 0x01}, hdr)
 }

--- a/mp4e/detect_test.go
+++ b/mp4e/detect_test.go
@@ -1,0 +1,47 @@
+package mp4e
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsMP4Extension(t *testing.T) {
+	for _, p := range []string{"a.mp4", "A.MP4", "clip.m4v", "song.m4a", "movie.mov", "/x/y/z.MoV"} {
+		require.True(t, IsMP4Extension(p), p)
+	}
+	for _, p := range []string{"a.mxf", "a.wav", "a.mkv", "a.ts", "noext", "a.mp3"} {
+		require.False(t, IsMP4Extension(p), p)
+	}
+}
+
+func TestIsMP4FormatName(t *testing.T) {
+	// FFmpeg reports the whole ISOBMFF family under one name.
+	require.True(t, IsMP4FormatName("mov,mp4,m4a,3gp,3g2,mj2"))
+	require.False(t, IsMP4FormatName("mxf"))
+	require.False(t, IsMP4FormatName("wav"))
+	require.False(t, IsMP4FormatName("matroska,webm"))
+}
+
+func TestHasFtypHeader(t *testing.T) {
+	ftyp := []byte{0x00, 0x00, 0x00, 0x18, 'f', 't', 'y', 'p', 'i', 's', 'o', 'm'}
+	require.True(t, HasFtypHeader(bytes.NewReader(ftyp)))
+	require.False(t, HasFtypHeader(bytes.NewReader([]byte("RIFF\x00\x00\x00\x00WAVE"))))
+	require.False(t, HasFtypHeader(bytes.NewReader([]byte{0x00, 0x01}))) // too short
+}
+
+func TestHasISOBMFFHeader(t *testing.T) {
+	box := func(typ string) []byte {
+		b := []byte{0x00, 0x00, 0x00, 0x18, 0, 0, 0, 0, 'x', 'y'}
+		copy(b[4:8], typ)
+		return b
+	}
+	for _, typ := range []string{"ftyp", "styp", "moov", "moof", "mdat", "sidx", "free"} {
+		require.True(t, HasISOBMFFHeader(bytes.NewReader(box(typ))), typ)
+	}
+	// non-ISOBMFF leaders
+	require.False(t, HasISOBMFFHeader(bytes.NewReader([]byte("RIFF\x00\x00\x00\x00WAVE"))))
+	require.False(t, HasISOBMFFHeader(bytes.NewReader([]byte{0x06, 0x0e, 0x2b, 0x34, 0x02, 0x05, 0x01, 0x01}))) // MXF
+	require.False(t, HasISOBMFFHeader(bytes.NewReader([]byte{0x00, 0x01})))                                     // too short
+}

--- a/mp4e/mvhevc/add.go
+++ b/mp4e/mvhevc/add.go
@@ -3,14 +3,13 @@ package mvhevc
 import (
 	"encoding/binary"
 	"fmt"
-	"io"
 	"os"
-	"path/filepath"
-	"strings"
 
 	"github.com/Eyevinn/mp4ff/avc"
 	"github.com/Eyevinn/mp4ff/hevc"
 	"github.com/Eyevinn/mp4ff/mp4"
+
+	"github.com/eluv-io/avpipe/mp4e"
 )
 
 const (
@@ -114,8 +113,7 @@ func applySpatialOptions(inp *input, opts AddOptions) error {
 }
 
 func isMP4Input(path string) bool {
-	ext := strings.ToLower(filepath.Ext(path))
-	if ext == ".mp4" || ext == ".m4v" || ext == ".mov" {
+	if mp4e.IsMP4Extension(path) {
 		return true
 	}
 	// Also check ISOBMFF/QuickTime ftyp box
@@ -124,11 +122,7 @@ func isMP4Input(path string) bool {
 		return false
 	}
 	defer func() { _ = f.Close() }()
-	var hdr [8]byte
-	if _, err := io.ReadFull(f, hdr[:]); err != nil {
-		return false
-	}
-	return string(hdr[4:8]) == "ftyp"
+	return mp4e.HasFtypHeader(f)
 }
 
 func parseAnnexBInput(inputPath string, fps float64) (*input, error) {


### PR DESCRIPTION
- add light verification for MP4/ISOBMFF
- add read limit 512MB