### PR TITLE
Fix MP4 decoder test for misbehaving reader returning -1

### DIFF
--- a/mp4e/detect.go
+++ b/mp4e/detect.go
@@ -70,6 +70,10 @@ var isobmffTopLevelBoxTypes = map[string]bool{
 func HasISOBMFFHeader(r io.Reader) (ok bool, hdr []byte) {
 	var buf [8]byte
 	n, err := io.ReadFull(r, buf[:])
+	// Extra careful with misbehaving reader returning negative count
+	if n < 0 {
+		n = 0
+	}
 	if err != nil {
 		return false, buf[:n]
 	}


### PR DESCRIPTION
We have a test that returns -1 deliberately (violates io Reader contract)
I added an extra check to avoid a panic.