### PR TITLE
Migrate mp4ff dependency to upstream Eyevinn v0.56.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/eluv-io/avpipe
 require (
 	github.com/Comcast/gots v0.0.0-20200213175321-9799558ed3e2
 	github.com/Comcast/gots/v2 v2.2.1
-	github.com/Eyevinn/mp4ff v0.51.0
+	github.com/Eyevinn/mp4ff v0.53.0
 	github.com/eluv-io/errors-go v1.0.0
 	github.com/eluv-io/log-go v1.0.1
 	github.com/grafov/m3u8 v0.11.1
@@ -30,7 +30,6 @@ require (
 )
 
 replace (
-	github.com/Eyevinn/mp4ff => github.com/eluv-io/mp4ff v0.47.1-0.20260603013458-2403cac8f06c
 	github.com/modern-go/gls => github.com/eluv-io/gls v1.0.0-elv1
 	github.com/prometheus/prometheus => github.com/prometheus/prometheus v1.7.1-0.20170814170113-3101606756c5
 	gopkg.in/urfave/cli.v1 => github.com/urfave/cli v1.22.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26
 require (
 	github.com/Comcast/gots v0.0.0-20200213175321-9799558ed3e2
 	github.com/Comcast/gots/v2 v2.2.1
-	github.com/Eyevinn/mp4ff v0.51.0
+	github.com/Eyevinn/mp4ff v0.56.0
 	github.com/eluv-io/common-go v1.1.27
 	github.com/eluv-io/errors-go v1.0.5
 	github.com/eluv-io/log-go v1.0.10
@@ -67,7 +67,6 @@ require (
 )
 
 replace (
-	github.com/Eyevinn/mp4ff => github.com/eluv-io/mp4ff v0.47.1-0.20260603013458-2403cac8f06c
 	github.com/fxamacker/cbor/v2 => github.com/eluv-io/cbor/v2 v2.8.1-0.20250506081522-e7b11bfa1dad
 	github.com/modern-go/gls => github.com/eluv-io/gls v1.0.0-elv1
 	github.com/prometheus/prometheus => github.com/prometheus/prometheus v1.7.1-0.20170814170113-3101606756c5

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/Comcast/gots v0.0.0-20200213175321-9799558ed3e2 h1:zMuszK7xNca8fNxQ4n
 github.com/Comcast/gots v0.0.0-20200213175321-9799558ed3e2/go.mod h1:Mk3QwecRoaG2Qh+uiS8t8IOd7QlKl7Xp1ujNRn/zJxw=
 github.com/Comcast/gots/v2 v2.2.1 h1:LU/SRg7p2KQqVkNqInV7I4MOQKAqvWQP/PSSLtygP2s=
 github.com/Comcast/gots/v2 v2.2.1/go.mod h1:firJ11on3eUiGHAhbY5cZNqG0OqhQ1+nSZHfsEEzVVU=
+github.com/Eyevinn/mp4ff v0.53.0 h1:aK4OF9gFwjrqvHRf0znEMCUVupgRFR1LB8OVpw9z1RA=
+github.com/Eyevinn/mp4ff v0.53.0/go.mod h1:AhC+bOI7GSZmzuN4zFY9U76qMedbHI+8BdQXWrC9+8U=
 github.com/apex/log v1.9.0/go.mod h1:m82fZlWIuiWzWP04XCTXmnX0xRkYYbCdYn8jbJeLBEA=
 github.com/apex/logs v1.0.0/go.mod h1:XzxuLZ5myVHDy9SAmYpamKKRNApGj54PfYLcFrXqDwo=
 github.com/aphistic/golf v0.0.0-20180712155816-02c07f170c5a/go.mod h1:3NqKYiepwy8kCu4PNA+aP7WUV72eXWJeP9/r3/K9aLE=
@@ -28,8 +30,6 @@ github.com/eluv-io/gls v1.0.0-elv1 h1:fV9z/aLSs5KH8wWMkamoS/Xxl8wmXF76WMx8/N5XEr
 github.com/eluv-io/gls v1.0.0-elv1/go.mod h1:4rPCrom1ZvL5sqFMGiNbCr/QfDq3oljqXEBdstdge0o=
 github.com/eluv-io/log-go v1.0.1 h1:j+/vNR7IwPxzgiwOWOKffWevEGeMhTXZVK7448FUuQg=
 github.com/eluv-io/log-go v1.0.1/go.mod h1:zXLeleJ9LQRHdEOvm7xh1dBQ/t5MJurj7vgfdUmL4jc=
-github.com/eluv-io/mp4ff v0.47.1-0.20260603013458-2403cac8f06c h1:MuqTJa23RhKhk8GFFfjU6vR5zD7j0Fe9x6A9n6WDogg=
-github.com/eluv-io/mp4ff v0.47.1-0.20260603013458-2403cac8f06c/go.mod h1:hJNUUqOBryLAzUW9wpCJyw2HaI+TCd2rUPhafoS5lgg=
 github.com/eluv-io/stack v1.8.2 h1:yocCvAcPy9vW5iBdNnig5Tem8LgOTT8JrOLvDcacnEQ=
 github.com/eluv-io/stack v1.8.2/go.mod h1:MIN/UfmiJlJUFpglnJCj+7DR5sDBUuvQRTENHm1F310=
 github.com/eluv-io/utc-go v1.0.0 h1:SUC9bdAginhb0a9qKZDY4MD1usQedoWN5XjNqdYag6A=

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/Comcast/gots v0.0.0-20200213175321-9799558ed3e2 h1:zMuszK7xNca8fNxQ4n
 github.com/Comcast/gots v0.0.0-20200213175321-9799558ed3e2/go.mod h1:Mk3QwecRoaG2Qh+uiS8t8IOd7QlKl7Xp1ujNRn/zJxw=
 github.com/Comcast/gots/v2 v2.2.1 h1:LU/SRg7p2KQqVkNqInV7I4MOQKAqvWQP/PSSLtygP2s=
 github.com/Comcast/gots/v2 v2.2.1/go.mod h1:firJ11on3eUiGHAhbY5cZNqG0OqhQ1+nSZHfsEEzVVU=
+github.com/Eyevinn/mp4ff v0.56.0 h1:K81hqadHOLqQP+Rr610dwy7Cn3tLLEejCljzIfcNo+k=
+github.com/Eyevinn/mp4ff v0.56.0/go.mod h1:AhC+bOI7GSZmzuN4zFY9U76qMedbHI+8BdQXWrC9+8U=
 github.com/HdrHistogram/hdrhistogram-go v1.2.0 h1:XMJkDWuz6bM9Fzy7zORuVFKH7ZJY41G2q8KWhVGkNiY=
 github.com/HdrHistogram/hdrhistogram-go v1.2.0/go.mod h1:CiIeGiHSd06zjX+FypuEJ5EQ07KKtxZ+8J6hszwVQig=
 github.com/PaesslerAG/gval v1.0.0/go.mod h1:y/nm5yEyTeX6av0OfKJNp9rBNj2XrGhAf5+v24IBN1I=
@@ -46,8 +48,6 @@ github.com/eluv-io/log-go v1.0.10 h1:/fjLjiBXwy5ocJXuzneRVzvUalIeTPSH6jAdFiaWN+Y
 github.com/eluv-io/log-go v1.0.10/go.mod h1:TvBaLIOvcrBpmgMaewgyZQSVY056WIfdCIliuGou+iw=
 github.com/eluv-io/mapstructure v1.5.1 h1:yxilnJ5GN6K2Kn1tEEuWJcVmONEMNso1uNJkJYIWQbQ=
 github.com/eluv-io/mapstructure v1.5.1/go.mod h1:HGl3bHmRju3DIQnCWotnLvMLhiTrYCLR9fOKtK8W5uQ=
-github.com/eluv-io/mp4ff v0.47.1-0.20260603013458-2403cac8f06c h1:MuqTJa23RhKhk8GFFfjU6vR5zD7j0Fe9x6A9n6WDogg=
-github.com/eluv-io/mp4ff v0.47.1-0.20260603013458-2403cac8f06c/go.mod h1:hJNUUqOBryLAzUW9wpCJyw2HaI+TCd2rUPhafoS5lgg=
 github.com/eluv-io/stack v1.8.2 h1:yocCvAcPy9vW5iBdNnig5Tem8LgOTT8JrOLvDcacnEQ=
 github.com/eluv-io/stack v1.8.2/go.mod h1:MIN/UfmiJlJUFpglnJCj+7DR5sDBUuvQRTENHm1F310=
 github.com/eluv-io/utc-go v1.0.1 h1:bFE8CFQT+ln8A8QK5SDBdUKtUfeOFnPF50c+Npz3pv0=

--- a/mp4e/atmos.go
+++ b/mp4e/atmos.go
@@ -1,6 +1,7 @@
 package mp4e
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 
@@ -44,7 +45,10 @@ type AtmosEC3Info struct {
 	ChanMap         uint16
 	JOC             bool
 	ComplexityIndex int
-	ReservedBytes   int
+	// ReservedBytes holds the dec3 trailing bytes that mp4ff did not consume.
+	// When JOC is signaled, the two extension bytes are decoded into
+	// JOCComplexity and are therefore not included here.
+	ReservedBytes []byte
 }
 
 type AtmosEC3Substream struct {
@@ -199,7 +203,7 @@ func (a *AtmosInfo) validateEC3(ase *mp4.AudioSampleEntryBox) {
 		NumSubstreams: len(d.EC3Subs),
 		NrChannels:    nrChannels,
 		ChanMap:       chanMap,
-		ReservedBytes: len(d.Reserved),
+		ReservedBytes: bytes.Clone(d.Reserved),
 	}
 	for _, sub := range d.EC3Subs {
 		ec3.Substreams = append(ec3.Substreams, AtmosEC3Substream{
@@ -213,16 +217,11 @@ func (a *AtmosInfo) validateEC3(ase *mp4.AudioSampleEntryBox) {
 		})
 	}
 
-	// JOC extension (ETSI TS 103 420):
-	//   bits[7:1] reserved (7 bits, all zero)
-	//   bits[0]   flag_ec3_extension_type_a (1 bit, LSB of first byte)
-	//   bits[15:8] complexity_index_type_a (8 bits, present iff flag==1)
-	if len(d.Reserved) >= 1 && d.Reserved[0]&0x01 == 1 {
-		ec3.JOC = true
-		if len(d.Reserved) >= 2 {
-			ec3.ComplexityIndex = int(d.Reserved[1])
-		}
-	}
+	// mp4ff decodes the JOC extension (ETSI TS 103 420) into Dec3Box.JOCComplexity,
+	// which is non-zero only when flag_ec3_extension_type_a is set. The two extension
+	// bytes are consumed by that parse, so Reserved holds only what follows them.
+	ec3.JOC = d.JOCComplexity > 0
+	ec3.ComplexityIndex = int(d.JOCComplexity)
 
 	a.EC3 = ec3
 
@@ -233,7 +232,7 @@ func (a *AtmosInfo) validateEC3(ase *mp4.AudioSampleEntryBox) {
 		a.addCheck("joc", true, "flag_ec3_extension_type_a=1 complexity_index=%d",
 			ec3.ComplexityIndex)
 	} else {
-		a.addCheck("joc", false, "flag_ec3_extension_type_a not set (reservedBytes=%d) - not Atmos",
+		a.addCheck("joc", false, "flag_ec3_extension_type_a not set (reservedBytes=%#x) - not Atmos",
 			ec3.ReservedBytes)
 	}
 }

--- a/mp4e/codec_info.go
+++ b/mp4e/codec_info.go
@@ -310,6 +310,21 @@ func ParseDOVIBox(payload []byte) (*avdesc.DOVIInfo, error) {
 	}, nil
 }
 
+// doviInfoFromBox converts a natively-decoded mp4ff Dolby Vision configuration
+// box into a DOVIInfo. FourCC and BoxType are set by the caller.
+func doviInfoFromBox(b *mp4.DoViConfigurationBox) *avdesc.DOVIInfo {
+	return &avdesc.DOVIInfo{
+		VersionMajor:            int(b.DVVersionMajor),
+		VersionMinor:            int(b.DVVersionMinor),
+		Profile:                 int(b.DVProfile),
+		Level:                   int(b.DVLevel),
+		RPUPresent:              b.RPUPresentFlag,
+		ELPresent:               b.ELPresentFlag,
+		BLPresent:               b.BLPresentFlag,
+		BLSignalCompatibilityID: int(b.DVBLSignalCompatibilityID),
+	}
+}
+
 // sanitizeString replaces invalid UTF-8 sequences and non-printable characters
 // with '?' so error messages containing binary data are safe to log.
 func sanitizeString(s string) string {
@@ -359,21 +374,13 @@ func parseVisualSampleEntryBox(se *mp4.VisualSampleEntryBox) (*CodecInfo, error)
 			VideoLayout:     Mp4VideoLayoutMono,
 		}
 
-		// Look for Dolby Vision configuration box (dvvC, dvcC, or dvwC) in children.
-		for _, child := range se.Children {
-			boxType := child.Type()
-			if IsDOVIBoxType(boxType) {
-				if ub, ok := child.(*mp4.UnknownBox); ok {
-					dovi, doviErr := ParseDOVIBox(ub.Payload())
-					if doviErr != nil {
-						return nil, e(doviErr, "reason", "failed to parse Dolby Vision box", "box", boxType)
-					}
-					dovi.FourCC = avdesc.DOVIFourCC(codecTag)
-					info.DOVI = dovi
-					info.DOVI.BoxType = boxType
-				}
-				break
-			}
+		// Dolby Vision configuration box (dvcC/dvvC/dvwC) is decoded natively by
+		// mp4ff (>= v0.53.0) and exposed as VisualSampleEntryBox.DoViConfig.
+		if se.DoViConfig != nil {
+			dovi := doviInfoFromBox(se.DoViConfig)
+			dovi.FourCC = avdesc.DOVIFourCC(codecTag)
+			dovi.BoxType = se.DoViConfig.Type()
+			info.DOVI = dovi
 		}
 
 		// If VPS declares multiple layers - it's MV-HEVC
@@ -438,8 +445,11 @@ func parseHvcCVPS(hvcC *mp4.HvcCBox) *hevc.VPS {
 // (for MV-HEVC this is the Multiview Main profile idc=6)
 func mvhevcEnhancementPTL(vps *hevc.VPS) *hevc.ProfileTierLevel {
 	basePTL := vps.ProfileTierLevel
-	for i := range vps.ExtProfileTierLevels {
-		ptl := vps.ExtProfileTierLevels[i]
+	if vps.Extension == nil {
+		return nil
+	}
+	for i := range vps.Extension.ExtProfileTierLevels {
+		ptl := vps.Extension.ExtProfileTierLevels[i]
 		if ptl.GeneralProfileIDC == 0 {
 			continue // placeholder/copy of base
 		}

--- a/mp4e/codec_info.go
+++ b/mp4e/codec_info.go
@@ -230,19 +230,10 @@ func parseEC3CodecInfo(se *mp4.AudioSampleEntryBox) (*CodecInfo, error) {
 	d := se.Dec3
 	nChannels, chanMap := d.ChannelInfo()
 
-	// Parse the JOC extension from the dec3 reserved bytes (ETSI TS 103 420).
-	// Layout (big-endian, MSB-first within each byte):
-	//   bits[7:1]  reserved (7 bits, all zero)
-	//   bits[0]    flag_ec3_extension_type_a (1 bit, LSB of first byte)
-	//   bits[15:8] complexity_index_type_a   (8 bits, second byte; present iff flag==1)
-	var joc bool
-	var complexityIndex int
-	if len(d.Reserved) >= 1 && d.Reserved[0]&0x01 == 1 {
-		joc = true
-		if len(d.Reserved) >= 2 {
-			complexityIndex = int(d.Reserved[1])
-		}
-	}
+	// mp4ff decodes the JOC extension (ETSI TS 103 420) into Dec3Box.JOCComplexity,
+	// which is non-zero only when flag_ec3_extension_type_a is set.
+	joc := d.JOCComplexity > 0
+	complexityIndex := int(d.JOCComplexity)
 
 	return &CodecInfo{
 		MimeCodecString: "ec-3",
@@ -310,6 +301,21 @@ func ParseDOVIBox(payload []byte) (*avdesc.DOVIInfo, error) {
 	}, nil
 }
 
+// doviInfoFromBox converts a natively-decoded mp4ff Dolby Vision configuration
+// box into a DOVIInfo. FourCC and BoxType are set by the caller.
+func doviInfoFromBox(b *mp4.DoViConfigurationBox) *avdesc.DOVIInfo {
+	return &avdesc.DOVIInfo{
+		VersionMajor:            int(b.DVVersionMajor),
+		VersionMinor:            int(b.DVVersionMinor),
+		Profile:                 int(b.DVProfile),
+		Level:                   int(b.DVLevel),
+		RPUPresent:              b.RPUPresentFlag,
+		ELPresent:               b.ELPresentFlag,
+		BLPresent:               b.BLPresentFlag,
+		BLSignalCompatibilityID: int(b.DVBLSignalCompatibilityID),
+	}
+}
+
 // sanitizeString replaces invalid UTF-8 sequences and non-printable characters
 // with '?' so error messages containing binary data are safe to log.
 func sanitizeString(s string) string {
@@ -359,21 +365,13 @@ func parseVisualSampleEntryBox(se *mp4.VisualSampleEntryBox) (*CodecInfo, error)
 			VideoLayout:     Mp4VideoLayoutMono,
 		}
 
-		// Look for Dolby Vision configuration box (dvvC, dvcC, or dvwC) in children.
-		for _, child := range se.Children {
-			boxType := child.Type()
-			if IsDOVIBoxType(boxType) {
-				if ub, ok := child.(*mp4.UnknownBox); ok {
-					dovi, doviErr := ParseDOVIBox(ub.Payload())
-					if doviErr != nil {
-						return nil, e(doviErr, "reason", "failed to parse Dolby Vision box", "box", boxType)
-					}
-					dovi.FourCC = avdesc.DOVIFourCC(codecTag)
-					info.DOVI = dovi
-					info.DOVI.BoxType = boxType
-				}
-				break
-			}
+		// Dolby Vision configuration box (dvcC/dvvC/dvwC) is decoded natively by
+		// mp4ff (>= v0.53.0) and exposed as VisualSampleEntryBox.DoViConfig.
+		if se.DoViConfig != nil {
+			dovi := doviInfoFromBox(se.DoViConfig)
+			dovi.FourCC = avdesc.DOVIFourCC(codecTag)
+			dovi.BoxType = se.DoViConfig.Type()
+			info.DOVI = dovi
 		}
 
 		// If VPS declares multiple layers - it's MV-HEVC
@@ -438,8 +436,11 @@ func parseHvcCVPS(hvcC *mp4.HvcCBox) *hevc.VPS {
 // (for MV-HEVC this is the Multiview Main profile idc=6)
 func mvhevcEnhancementPTL(vps *hevc.VPS) *hevc.ProfileTierLevel {
 	basePTL := vps.ProfileTierLevel
-	for i := range vps.ExtProfileTierLevels {
-		ptl := vps.ExtProfileTierLevels[i]
+	if vps.Extension == nil {
+		return nil
+	}
+	for i := range vps.Extension.ExtProfileTierLevels {
+		ptl := vps.Extension.ExtProfileTierLevels[i]
 		if ptl.GeneralProfileIDC == 0 {
 			continue // placeholder/copy of base
 		}

--- a/mp4e/dovi/info.go
+++ b/mp4e/dovi/info.go
@@ -1,7 +1,6 @@
 package dovi
 
 import (
-	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"os"
@@ -38,35 +37,19 @@ type DVConfigRecord struct {
 	BLSignalCompatibilityID uint8
 }
 
-// parseDVConfig parses the raw payload of a dvcC or dvvC UnknownBox.
-// The payload is the box body after the 8-byte box header has been stripped
-// by mp4ff, so byte 0 is dv_version_major.
-func parseDVConfig(payload []byte) (*DVConfigRecord, error) {
-	if len(payload) < 4 {
-		return nil, fmt.Errorf("dv config payload too short: %d bytes (need 4)", len(payload))
+// dvRecordFromBox converts a natively-decoded mp4ff Dolby Vision configuration
+// box (dvcC/dvvC/dvwC) into a DVConfigRecord.
+func dvRecordFromBox(b *mp4.DoViConfigurationBox) *DVConfigRecord {
+	return &DVConfigRecord{
+		DVVersionMajor:          b.DVVersionMajor,
+		DVVersionMinor:          b.DVVersionMinor,
+		DVProfile:               b.DVProfile,
+		DVLevel:                 b.DVLevel,
+		RPUPresentFlag:          b.RPUPresentFlag,
+		ELPresentFlag:           b.ELPresentFlag,
+		BLPresentFlag:           b.BLPresentFlag,
+		BLSignalCompatibilityID: b.DVBLSignalCompatibilityID,
 	}
-	r := &DVConfigRecord{}
-	r.DVVersionMajor = payload[0]
-	r.DVVersionMinor = payload[1]
-
-	// Bytes 2-3 packed (big-endian 16-bit word):
-	// [15:9]  dv_profile        (7 bits)
-	// [8:3]   dv_level          (6 bits)
-	// [2]     rpu_present_flag
-	// [1]     el_present_flag
-	// [0]     bl_present_flag
-	word := binary.BigEndian.Uint16(payload[2:4])
-	r.DVProfile = uint8((word >> 9) & 0x7F)
-	r.DVLevel = uint8((word >> 3) & 0x3F)
-	r.RPUPresentFlag = (word>>2)&0x1 == 1
-	r.ELPresentFlag = (word>>1)&0x1 == 1
-	r.BLPresentFlag = word&0x1 == 1
-
-	// byte 4: bl_signal_compat_id in the high nibble (bits [7:4])
-	if len(payload) >= 5 {
-		r.BLSignalCompatibilityID = (payload[4] >> 4) & 0x0F
-	}
-	return r, nil
 }
 
 // Info inspects an MP4 file for Dolby Vision correctness and QC,
@@ -115,24 +98,16 @@ func Info(inputPath string, opts InfoOptions) (map[string]any, error) {
 
 			track["Sample entry"] = fmt.Sprintf("%s (%dx%d)", vse.Type(), vse.Width, vse.Height)
 
-			// dvcC / dvvC land as UnknownBox children of the sample entry
+			// dvcC / dvvC / dvwC are decoded natively by mp4ff (>= v0.53.0) into
+			// a typed DoViConfigurationBox.
 			for _, vseChild := range vse.Children {
-				ub, ok := vseChild.(*mp4.UnknownBox)
+				dcfg, ok := vseChild.(*mp4.DoViConfigurationBox)
 				if !ok {
 					continue
 				}
-				boxType := ub.Type()
-				if boxType != "dvcC" && boxType != "dvvC" {
-					continue
-				}
+				boxType := dcfg.Type()
 				isDVTrack = true
-				rec, parseErr := parseDVConfig(ub.Payload())
-				if parseErr != nil {
-					track[fmt.Sprintf("%s (DV config)", boxType)] = map[string]any{
-						"error": parseErr.Error(),
-					}
-					continue
-				}
+				rec := dvRecordFromBox(dcfg)
 				infoKey := fmt.Sprintf("%s (DV config)", boxType)
 				track[infoKey] = formatDVConfig(rec)
 				track[infoKey+" QC"] = validateDVConfig(rec)

--- a/mp4e/mvhevc/add.go
+++ b/mp4e/mvhevc/add.go
@@ -557,7 +557,10 @@ func buildAndWriteMP4(inp *input, outputPath string) error {
 	stbl.AddChild(stco)
 
 	if inp.vps.IsMultiLayer() {
-		oinf := mp4.BuildOinfFromVPS(inp.vps)
+		oinf, err := mp4.BuildOinfFromVPS(inp.vps)
+		if err != nil {
+			return fmt.Errorf("build oinf from VPS: %w", err)
+		}
 		sgpdOinf := &mp4.SgpdBox{
 			Version:            2,
 			GroupingType:       "oinf",
@@ -572,7 +575,10 @@ func buildAndWriteMP4(inp *input, outputPath string) error {
 		stbl.AddChild(sbgpOinf)
 
 		maxTids := make([]byte, inp.vps.GetNumLayers())
-		linf := mp4.BuildLinfFromVPS(inp.vps, maxTids)
+		linf, err := mp4.BuildLinfFromVPS(inp.vps, maxTids)
+		if err != nil {
+			return fmt.Errorf("build linf from VPS: %w", err)
+		}
 		sgpdLinf := &mp4.SgpdBox{
 			Version:            2,
 			GroupingType:       "linf",

--- a/mp4e/mvhevc/fix.go
+++ b/mp4e/mvhevc/fix.go
@@ -1,13 +1,12 @@
 package mvhevc
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 
 	"github.com/Eyevinn/mp4ff/hevc"
 	"github.com/Eyevinn/mp4ff/mp4"
-
-	"github.com/eluv-io/avpipe/mp4e"
 )
 
 // Fix restores MV-HEVC sample-group and track-group boxes that FFmpeg's
@@ -104,13 +103,21 @@ func fixVideoTrak(trak *mp4.TrakBox, _ *mp4.File) (bool, error) {
 		changed = true
 	}
 	if !hasSgpd(stbl, "oinf") {
-		appendStblSgpd(stbl, "oinf", mp4.BuildOinfFromVPS(vps))
+		oinf, err := mp4.BuildOinfFromVPS(vps)
+		if err != nil {
+			return false, fmt.Errorf("build oinf from VPS: %w", err)
+		}
+		appendStblSgpd(stbl, "oinf", oinf)
 		log.Info("added oinf sgpd", "trackID", trak.Tkhd.TrackID)
 		changed = true
 	}
 	if !hasSgpd(stbl, "linf") {
 		maxTids := make([]byte, vps.GetNumLayers())
-		appendStblSgpd(stbl, "linf", mp4.BuildLinfFromVPS(vps, maxTids))
+		linf, err := mp4.BuildLinfFromVPS(vps, maxTids)
+		if err != nil {
+			return false, fmt.Errorf("build linf from VPS: %w", err)
+		}
+		appendStblSgpd(stbl, "linf", linf)
 		log.Info("added linf sgpd", "trackID", trak.Tkhd.TrackID)
 		changed = true
 	}
@@ -214,28 +221,24 @@ func appendStblSgpd(stbl *mp4.StblBox, groupingType string, entry mp4.SampleGrou
 // FFmpeg uses dvwC for all profiles > 10 (a bug for profile 20), and content
 // tools sometimes mislabel the box. This function re-checks every DV config
 // box and renames it to the spec-correct FourCC if it differs.
+//
+// mp4ff (>= v0.53.0) decodes dvcC/dvvC/dvwC into a typed DoViConfigurationBox
+// that preserves the on-disk FourCC (its Type() returns the name it was decoded
+// with), so a mislabeled box survives a round-trip unchanged. mp4ff's own
+// profile→FourCC mapping also differs from the Dolby spec for profile 20
+// (it emits dvwC, we want dvcC), so we re-wrap the encoded record under the
+// spec-correct FourCC rather than reconstructing the box via mp4ff helpers.
 func fixDVBoxType(vse *mp4.VisualSampleEntryBox, trackID uint32) bool {
 	const op = "mvhevc.fixDVBoxType"
+	const boxHdrSize = 8
 
 	changed := false
 	for i, c := range vse.Children {
-		if !mp4e.IsDOVIBoxType(c.Type()) {
-			continue
-		}
-		// If mp4ff adds support for parsing DOVI, revisit this code
-		ub, ok := c.(*mp4.UnknownBox)
+		dcfg, ok := c.(*mp4.DoViConfigurationBox)
 		if !ok {
-			log.Warn("DV config box has unexpected Go type, skipping",
-				"boxType", c.Type(), "trackID", trackID, "op", op)
 			continue
 		}
-		dovi, err := mp4e.ParseDOVIBox(ub.Payload())
-		if err != nil {
-			log.Warn("failed to parse DV config box payload — skipping",
-				"boxType", c.Type(), "trackID", trackID, "error", err, "op", op)
-			continue
-		}
-		profile := dovi.Profile
+		profile := int(dcfg.DVProfile)
 
 		var want string
 		switch {
@@ -250,8 +253,22 @@ func fixDVBoxType(vse *mp4.VisualSampleEntryBox, trackID uint32) bool {
 		if c.Type() == want {
 			continue
 		}
-		const boxHdrSize = 8
-		payload := ub.Payload()
+
+		// Re-encode the 24-byte DV configuration record and re-wrap it under the
+		// spec-correct FourCC.
+		var buf bytes.Buffer
+		if err := dcfg.Encode(&buf); err != nil {
+			log.Warn("failed to encode DV config box — skipping",
+				"boxType", c.Type(), "trackID", trackID, "error", err, "op", op)
+			continue
+		}
+		body := buf.Bytes()
+		if len(body) <= boxHdrSize {
+			log.Warn("DV config box unexpectedly short — skipping",
+				"boxType", c.Type(), "trackID", trackID, "size", len(body), "op", op)
+			continue
+		}
+		payload := body[boxHdrSize:]
 		vse.Children[i] = mp4.CreateUnknownBox(want, uint64(boxHdrSize+len(payload)), payload)
 		log.Info("corrected DV config box", "from", c.Type(), "to", want, "trackID", trackID, "profile", profile, "op", op)
 		changed = true


### PR DESCRIPTION
## Summary

Migrate the `mp4ff` dependency from the `eluv-io/mp4ff` fork to upstream **`Eyevinn/mp4ff v0.56.0`** and drop the `replace` directive. All the MV-HEVC / Dolby Vision / HDR features the fork carried are now upstreamed (including `dvh1`/`dvhe` CENC/CBCS encryption support), so the fork is no longer needed.

## API adaptations for v0.53.0

- **VPS extension restructured**: `vps_extension()` is now parsed into a structured `VPSExtension`; `ExtProfileTierLevels` moved under `vps.Extension` (with a nil guard). — `mp4e/codec_info.go`
- **`BuildOinfFromVPS` / `BuildLinfFromVPS` now return `(value, error)`** — `mp4e/mvhevc/{add,fix}.go`
- **Dolby Vision boxes are now decoded natively**: `dvcC`/`dvvC`/`dvwC` decode into a typed `mp4.DoViConfigurationBox` (exposed via `VisualSampleEntryBox.DoViConfig`) instead of `UnknownBox`. Updated the codec-info DoVi detection, the `dovi` inspector, and `mvhevc.fixDVBoxType` to read the typed box. avpipe's own `ParseDOVIBox`/`IsDOVIBoxType` helpers are kept (still unit-tested).

## API adaptations for v0.55.0

- **The dec3 JOC extension is now decoded natively.** mp4ff parses the ETSI TS 103 420 extension into `Dec3Box.JOCComplexity`, consuming the two extension bytes that previously sat at the front of `Dec3Box.Reserved`. avpipe was hand-parsing those bytes, so the bump silently broke Atmos detection — `TestExtractCodecInfo/Atmos` failed with `JOC=false, complexity=0` instead of `16`. Both call sites now read the typed field and the manual bit-twiddling is gone. — `mp4e/codec_info.go` (`parseEC3CodecInfo`), `mp4e/atmos.go` (`validateEC3`)
- **`sei` package rename is a non-issue.** v0.55.0 renames `CEA608*` → `CTA608*`, which is a breaking change but does not affect avpipe: it uses only `ContentLightLevelInformationSEI`, `MasteringDisplayColourVolumeSEI`, `SEIFramePackingArrangementType`, `UnregisteredSEI` and `ErrRbspTrailingBitsMissing`.

## v0.54.0 and v0.56.0 need no avpipe changes

- **v0.54.0** is purely additive for avpipe (AV1/VP8/VP9 parsing, AV1 encryption); nothing avpipe uses changed.
- **v0.56.0** is additive — `labl`, QuickTime v1/v2 sound sample descriptions, `WaveBox` (so a `wave`-wrapped `esds` is reachable), esds vocabulary constants, `aac.DecodeAudioSpecificConfigHeader`, `ElstEntry.MediaRateFixed32` — plus parser hardening: `hevc.ParseSliceHeader` applies the Section 7.4.7.1 inferences for absent fields (fixes a parse failure on x265 `--no-deblock` output), allocation guards on malformed AVC/HEVC NAL units and `alst` entries, and `MdatBox.HeaderSize` for fragments above 4 GiB. Nothing avpipe references was removed or re-typed.
- The one v0.56.0 behavior change worth knowing about: the QuickTime audio sample entries `.mp3`, `lpcm`, `twos` and `sowt` now decode as `AudioSampleEntryBox` (reachable as `StsdBox.Mp3` / `StsdBox.QtPcm`) rather than falling through to `UnknownBox`. avpipe does not read those entries, and a body that fails to parse as a sound sample description still becomes an `UnknownBox`.

## Behavior change worth reviewing

`AtmosEC3Info.ReservedBytes` changes from `int` (a count) to `[]byte` (the actual unconsumed dec3 trailing bytes, cloned so the struct does not alias mp4ff's decoded box). **This changes the JSON representation from a number to a base64 string.** When JOC is signaled, the two extension bytes are no longer included, since mp4ff consumes them into `JOCComplexity`.

## Rebase

Rebased onto current `master` (`2cc0613`, i.e. after #223). The rebase was conflict-free: none of the commits on `master` since the previous base (`9b2b3ba`) touch `go.mod`, `go.sum` or `mp4e/`. The net diff against `master` is exactly:

- `go.mod`: `mp4ff v0.51.0` → `v0.56.0`, and the `Eyevinn/mp4ff => eluv-io/mp4ff` replace removed
- `go.sum`: the matching hash swap
- the five `mp4e/` source files

## Testing

Re-verified after the rebase onto `master` (`2cc0613`):

- `go build ./...` — clean
- `go vet ./mp4e/... ./cmd/... ./pkg/...` — clean
- `go test ./mp4e/... ./cmd/... ./pkg/...` — pass, including `TestExtractCodecInfo/Atmos` (the JOC test above)
- every test binary in the repo compiles (`go test -run <no-match> ./...`)

The full end-to-end suite below was run against **v0.53.0** on the pre-rebase base, and has **not** been re-run since the v0.55.0/v0.56.0 bumps or the rebases. The changes in this PR are confined to `mp4e/`, but the long-running e2e suites should be re-run before merge:

- `avpipe` (root e2e) — ok (~730s)
- `xc` (ABR/mez e2e, incl. DoVi/MV-HEVC/HDR10) — ok (~2040s)
- `live` (SRT/RTMP/UDP) — ok (~545s)
- `mp4e`, `mp4e/mvhevc`, `cmd/mvhevc`, `cmd/mez-validator`, `ts`, `smpte20xx/anc`, `broadcastproto/transport`, `goavpipe` — ok

## FFmpeg build notes

The migration requires an FFmpeg new enough for the `AVChannelLayout` API (≥ 5.1); validated on 8.0.2. Building FFmpeg 8 for the full test suite needs these config changes vs. the older build flags:

- **add** `--enable-libharfbuzz` — `drawtext` (text watermarks) has a hard harfbuzz dependency since FFmpeg 7; without it every `*_wmtxt` test fails with `EAV_FILTER_INIT`.
- **add** `--enable-libsrt` — the `live` SRT recorder tests spawn an ffmpeg source that needs `srt://` protocol support (otherwise `EAV_OPEN_INPUT`).
- **drop** `--enable-avresample` (removed in FFmpeg 5) and `--enable-opencl` (OpenCL-kernel link failure on arm64 macOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

