### PR TITLE
Add MPEGTS timestamp unwrapper

### DIFF
--- a/libavpipe/include/avpipe_xc.h
+++ b/libavpipe/include/avpipe_xc.h
@@ -267,8 +267,23 @@ typedef struct avpipe_io_handler_t {
     avpipe_stater_f avpipe_stater;
 } avpipe_io_handler_t;
 
-#define MAX_WRAP_PTS        ((int64_t)8589000000)
 #define MAX_AVFILENAME_LEN  128
+
+/*
+ * PTS/DTS unwrapper state for one input stream
+ *
+ * MPEGTS timestamps wrap every 2^33/90000 ~= 26.5 hours
+ * Unwrapping converts timestamps to monotonic int64. PTS and DTS are unwrapped independently.
+ */
+typedef struct pts_unwrapper_t {
+    const char *url;            /* input url */
+    int         stream_index;   /* input stream index */
+    int64_t     wrap_modulus;   /* 2^pts_wrap_bits, or 0 to disable unwrapping */
+    int         has_last;       /* set once the first timestamp is seen */
+    int64_t     last;           /* last raw (wrapped) input timestamp */
+    int64_t     offset;         /* accumulated wrap offset (added to raw timestamps) */
+    char        kind;           /* 'P' (PTS) or 'T' (DTS) */
+} pts_unwrapper_t;
 
 /*
  * Decoder/encoder context, keeps both video and audio stream ffmpeg contexts
@@ -355,10 +370,8 @@ typedef struct coderctx_t {
     int data_scte35_stream_index;                       /* Index of SCTE-35 data stream */
     int data_stream_index;                              /* Index of an unrecognized data stream */
 
-    int64_t video_last_wrapped_pts;                     /* Video last wrapped pts */
-    int64_t video_last_input_pts;                       /* Video last input pts */
-    int64_t audio_last_wrapped_pts[MAX_STREAMS];        /* Audio last wrapped pts */
-    int64_t audio_last_input_pts[MAX_STREAMS];          /* Audio last input pts */
+    pts_unwrapper_t pts_unwrapper[MAX_STREAMS];         /* PTS unwrap state (per stream)*/
+    pts_unwrapper_t dts_unwrapper[MAX_STREAMS];         /* DTS unwrap state (per stream)*/
     int64_t video_last_dts;
     int64_t audio_last_dts[MAX_STREAMS];
     int64_t last_key_frame;                             /* pts of last key frame */

--- a/libavpipe/src/avpipe_format.c
+++ b/libavpipe/src/avpipe_format.c
@@ -11,6 +11,7 @@
 #include <libavutil/pixdesc.h>
 
 #include <string.h>
+#include <inttypes.h>
 
 #include "avpipe_utils.h"
 #include "avpipe_xc.h"
@@ -395,6 +396,105 @@ void frame_rescale_time_base(
 
     if (frame->duration > 0)
         frame->duration = av_rescale_q(frame->duration, src_time_base, dst_time_base);
+}
+
+/*
+ * Initialize the PTS/DTS unwrap state.
+ * Compute wrap modulus once per stream (modulus is 0 for streams that don't need unrwap).
+ */
+void
+pts_unwrap_init(
+    coderctx_t *ctx)
+{
+    AVFormatContext *fc = ctx->format_context;
+    unsigned nb = fc ? fc->nb_streams : 0;
+    int is_mpegts = fc && fc->iformat && fc->iformat->name &&
+        !strcmp(fc->iformat->name, "mpegts");
+    const char *url = (ctx->inctx && ctx->inctx->url) ? ctx->inctx->url : "";
+
+    for (unsigned i = 0; i < nb && i < MAX_STREAMS; i++) {
+        AVStream *st = fc->streams[i];
+        int pts_wrap_bits = st->pts_wrap_bits;
+        enum AVMediaType mtype = st->codecpar->codec_type;
+        const char *mtype_str = av_get_media_type_string(mtype);
+        int64_t wrap_modulus = (pts_wrap_bits > 0 && pts_wrap_bits < 63) ?
+            ((int64_t)1 << pts_wrap_bits) : 0;
+
+        ctx->pts_unwrapper[i].wrap_modulus = wrap_modulus;
+        ctx->pts_unwrapper[i].stream_index = i;
+        ctx->pts_unwrapper[i].kind = 'P';
+        ctx->pts_unwrapper[i].url = url;
+
+        ctx->dts_unwrapper[i].wrap_modulus = wrap_modulus;
+        ctx->dts_unwrapper[i].stream_index = i;
+        ctx->dts_unwrapper[i].kind = 'T';
+        ctx->dts_unwrapper[i].url = url;
+
+        if (!mtype_str)
+            mtype_str = "unknown";
+
+        elv_log("PTS UNWRAP INIT stream_index=%d, media_type=%s, pts_wrap_bits=%d, "
+            "time_base=%d/%d, wrap_modulus=%"PRId64", is_mpegts=%d, url=%s",
+            i, mtype_str, pts_wrap_bits, st->time_base.num, st->time_base.den,
+            wrap_modulus, is_mpegts, url);
+
+        /*
+         * For MPEGTS timestamps are always 33-bit (90 kHz).
+         */
+        if (is_mpegts &&
+            (mtype == AVMEDIA_TYPE_VIDEO || mtype == AVMEDIA_TYPE_AUDIO) &&
+            pts_wrap_bits != 33) {
+            elv_err("PTS UNWRAP INIT unexpected pts_wrap_bits for MPEGTS stream_index=%d, "
+                "media_type=%s, pts_wrap_bits=%d (expected 33), url=%s",
+                i, mtype_str, pts_wrap_bits, url);
+        }
+    }
+}
+
+/*
+ * Convert a wrapped timestamp into a monotonic int64 value.
+ * Unwrap state is stored per stream (modulus is calculated at initialization).
+ *
+ * Wrap detection:
+ * - when step between consecutive raw values exceeds half the modular range:
+ *   - a large negative step means the counter wrapped forward (so add one modulus),
+ *   - a large positive step means it wrapped backward (so subtract one modulus).
+ * - if wrap modulus is 0 - no unwrapping
+ */
+int64_t
+pts_unwrap(
+    pts_unwrapper_t *u,
+    int64_t ts)
+{
+    if (ts == AV_NOPTS_VALUE || u->wrap_modulus <= 0)
+        return ts;
+
+    if (!u->has_last) {
+        u->has_last = 1;
+        u->last = ts;
+        u->offset = 0;
+        return ts;
+    }
+
+    const int64_t half = u->wrap_modulus / 2;
+    int64_t diff = ts - u->last;
+    if (diff < -half || diff > half) {
+        const char *direction;
+        if (diff < -half) {
+            u->offset += u->wrap_modulus;   /* wrapped forward (jumped back near 0) */
+            direction = "forward";
+        } else {
+            u->offset -= u->wrap_modulus;   /* wrapped backward */
+            direction = "backward";
+        }
+        elv_log("PTS UNWRAP stream_index=%d, kind=%c, direction=%s, raw=%"PRId64", "
+            "prev_raw=%"PRId64", offset=%"PRId64", unwrapped=%"PRId64", url=%s",
+            u->stream_index, u->kind ? u->kind : '?', direction, ts, u->last,
+            u->offset, ts + u->offset, u->url ? u->url : "");
+    }
+
+    u->last = ts;
+    return ts + u->offset;
 }
 
 /*

--- a/libavpipe/src/avpipe_format.c
+++ b/libavpipe/src/avpipe_format.c
@@ -400,9 +400,9 @@ void frame_rescale_time_base(
 
 /*
  * Initialize the PTS/DTS unwrap state.
- * Compute wrap modulus once per stream (modulus is 0 for streams that don't need unrwap).
+ * Compute wrap modulus once per stream (modulus is 0 for streams that don't need unwrap).
  */
-void
+int
 pts_unwrap_init(
     coderctx_t *ctx)
 {
@@ -417,44 +417,50 @@ pts_unwrap_init(
         int pts_wrap_bits = st->pts_wrap_bits;
         enum AVMediaType mtype = st->codecpar->codec_type;
         const char *mtype_str = av_get_media_type_string(mtype);
-        int64_t wrap_modulus = (pts_wrap_bits > 0 && pts_wrap_bits < 63) ?
-            ((int64_t)1 << pts_wrap_bits) : 0;
-
-        ctx->pts_unwrapper[i].wrap_modulus = wrap_modulus;
-        ctx->pts_unwrapper[i].stream_index = i;
-        ctx->pts_unwrapper[i].kind = 'P';
-        ctx->pts_unwrapper[i].url = url;
-
-        ctx->dts_unwrapper[i].wrap_modulus = wrap_modulus;
-        ctx->dts_unwrapper[i].stream_index = i;
-        ctx->dts_unwrapper[i].kind = 'T';
-        ctx->dts_unwrapper[i].url = url;
+        int64_t wrap_modulus = is_mpegts ? ((int64_t)1 << 33) : 0;
 
         if (!mtype_str)
             mtype_str = "unknown";
 
+         /* MPEGTS timestamps are always 33-bit with timescale 90,000 */
+        if (is_mpegts &&
+            (pts_wrap_bits != 33 ||
+             st->time_base.num != 1 ||
+             st->time_base.den != 90000)) {
+            elv_err("PTS UNWRAP INIT unexpected MPEGTS timestamp parameters "
+                "stream_index=%d, media_type=%s, pts_wrap_bits=%d, "
+                "time_base=%d/%d (expected 33, 1/90000), url=%s",
+                (int)i, mtype_str, pts_wrap_bits,
+                st->time_base.num, st->time_base.den, url);
+            return -1;
+        }
+
+        ctx->pts_unwrapper[i].wrap_modulus = wrap_modulus;
+        ctx->pts_unwrapper[i].stream_index = (int)i;
+        ctx->pts_unwrapper[i].kind = 'P';
+        ctx->pts_unwrapper[i].url = url;
+
+        ctx->dts_unwrapper[i].wrap_modulus = wrap_modulus;
+        ctx->dts_unwrapper[i].stream_index = (int)i;
+        ctx->dts_unwrapper[i].kind = 'T';
+        ctx->dts_unwrapper[i].url = url;
+
         elv_log("PTS UNWRAP INIT stream_index=%d, media_type=%s, pts_wrap_bits=%d, "
             "time_base=%d/%d, wrap_modulus=%"PRId64", is_mpegts=%d, url=%s",
-            i, mtype_str, pts_wrap_bits, st->time_base.num, st->time_base.den,
+            (int)i, mtype_str, pts_wrap_bits, st->time_base.num, st->time_base.den,
             wrap_modulus, is_mpegts, url);
-
-        /*
-         * For MPEGTS timestamps are always 33-bit (90 kHz).
-         */
-        if (is_mpegts &&
-            (mtype == AVMEDIA_TYPE_VIDEO || mtype == AVMEDIA_TYPE_AUDIO) &&
-            pts_wrap_bits != 33) {
-            elv_err("PTS UNWRAP INIT unexpected pts_wrap_bits for MPEGTS stream_index=%d, "
-                "media_type=%s, pts_wrap_bits=%d (expected 33), url=%s",
-                i, mtype_str, pts_wrap_bits, url);
-        }
     }
+
+    return 0;
 }
 
 /*
  * Convert a wrapped timestamp into a monotonic int64 value.
  * Unwrap state is stored per stream (modulus is calculated at initialization).
  *
+ * Limitations:
+ * - unwrapping doesn't distinguish an actual MPEGTS stream reset - this has to be
+ *   handled by starting a new xc job by the upper layer
  * Wrap detection:
  * - when step between consecutive raw values exceeds half the modular range:
  *   - a large negative step means the counter wrapped forward (so add one modulus),

--- a/libavpipe/src/avpipe_format.h
+++ b/libavpipe/src/avpipe_format.h
@@ -90,6 +90,15 @@ void frame_rescale_time_base(
     AVRational src_time_base,
     AVRational dst_time_base);
 
+void
+pts_unwrap_init(
+    coderctx_t *ctx);
+
+int64_t
+pts_unwrap(
+    pts_unwrapper_t *u,
+    int64_t ts);
+
 int
 copy_stream_side_data(
     AVStream *out_stream,

--- a/libavpipe/src/avpipe_format.h
+++ b/libavpipe/src/avpipe_format.h
@@ -90,7 +90,7 @@ void frame_rescale_time_base(
     AVRational src_time_base,
     AVRational dst_time_base);
 
-void
+int
 pts_unwrap_init(
     coderctx_t *ctx);
 

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -290,6 +290,12 @@ prepare_decoder(
         av_dict_set(&opts, "analyzeduration", "10000000", 0);  // microseconds
     }
 
+    /*
+     * Disable ffmpeg timestamp correction (it only works once an produces bad PTS after)
+     * This way we receive raw wrapped timestamp and apply our own unwrapping.
+     */
+    av_dict_set(&opts, "correct_ts_overflow", "0", 0);
+
     /* Allocate AVFormatContext in format_context and find input file format */
     const char *open_url = (inctx->alt_url && inctx->alt_url[0]) ? inctx->alt_url : inctx->url;
     rc = avformat_open_input(&decoder_context->format_context, open_url, NULL, &opts);
@@ -305,6 +311,9 @@ prepare_decoder(
         elv_err("Could not get input stream info, url=%s", url);
         return eav_stream_info;
     }
+
+    /* Precompute per-stream PTS/DTS wrap moduli now that pts_wrap_bits is known. */
+    pts_unwrap_init(decoder_context);
 
     dump_streams(inctx->url, decoder_context->format_context);
 
@@ -2565,27 +2574,6 @@ do_bypass(
     return eav_success;
 }
 
-static avpipe_error_t
-check_pts_wrapped(
-    int64_t *last_input_pts,
-    AVFrame *frame,
-    int stream_index)
-{
-    if (!frame || !last_input_pts)
-        return eav_success;
-
-    /* If the stream was wrapped then issue an error */
-    if (*last_input_pts && *last_input_pts - frame->pts > MAX_WRAP_PTS) {
-        elv_warn("PTS WRAPPED stream_index=%d, last_input_pts=%"PRId64", frame->pts=%"PRId64, stream_index, *last_input_pts, frame->pts);
-        return eav_pts_wrapped;
-    }
-
-    if (frame->pts > *last_input_pts)
-        *last_input_pts = frame->pts;
-
-    return eav_success;
-}
-
 static int
 transcode_audio(
     coderctx_t *decoder_context,
@@ -2657,12 +2645,6 @@ transcode_audio(
         }
 
         dump_frame(1, stream_index, "IN ", codec_context->frame_num, frame, debug_frame_level);
-
-        ret = check_pts_wrapped(&decoder_context->audio_last_input_pts[stream_index], frame, stream_index);
-        if (ret == eav_pts_wrapped) {
-            av_frame_unref(frame);
-            return ret;
-        }
 
         decoder_context->audio_pts[stream_index] = packet->pts;
 
@@ -2810,12 +2792,6 @@ transcode_video(
 
         fix_video_frame_color(decoder_context, frame);
         dump_frame(0, stream_index, "IN ", codec_context->frame_num, frame, debug_frame_level);
-
-        ret = check_pts_wrapped(&decoder_context->audio_last_input_pts[stream_index], frame, stream_index);
-        if (ret == eav_pts_wrapped) {
-            av_frame_unref(frame);
-            return ret;
-        }
 
         if (do_instrument) {
             elv_since(&tv, &since);
@@ -3889,6 +3865,12 @@ avpipe_xc(
 
         const char *st = stream_type_str(encoder_context, input_packet->stream_index);
         int stream_index = input_packet->stream_index;
+
+        /* Unwrap MPEGTS timestamps into a monotonic timeline */
+        if (stream_index >= 0 && stream_index < MAX_STREAMS) {
+            input_packet->pts = pts_unwrap(&decoder_context->pts_unwrapper[stream_index], input_packet->pts);
+            input_packet->dts = pts_unwrap(&decoder_context->dts_unwrapper[stream_index], input_packet->dts);
+        }
 
         // Record PTS of first frame read - excute only for the desired stream
         if ((stream_index == decoder_context->video_stream_index && (params->xc_type & xc_video)) ||

--- a/libavpipe/src/avpipe_xc.c
+++ b/libavpipe/src/avpipe_xc.c
@@ -214,7 +214,8 @@ prepare_decoder(
     avpipe_io_handler_t *in_handlers,
     ioctx_t *inctx,
     xcparams_t *params,
-    int seekable)
+    int seekable,
+    int use_custom_pts_unwrap)
 {
     int rc;
     decoder_context->video_last_dts = AV_NOPTS_VALUE;
@@ -290,12 +291,6 @@ prepare_decoder(
         av_dict_set(&opts, "analyzeduration", "10000000", 0);  // microseconds
     }
 
-    /*
-     * Disable ffmpeg timestamp correction (it only works once an produces bad PTS after)
-     * This way we receive raw wrapped timestamp and apply our own unwrapping.
-     */
-    av_dict_set(&opts, "correct_ts_overflow", "0", 0);
-
     /* Allocate AVFormatContext in format_context and find input file format */
     const char *open_url = (inctx->alt_url && inctx->alt_url[0]) ? inctx->alt_url : inctx->url;
     rc = avformat_open_input(&decoder_context->format_context, open_url, NULL, &opts);
@@ -306,6 +301,16 @@ prepare_decoder(
         return eav_open_input;
     }
 
+    /*
+     * Disable ffmpeg timestamp correction for MPEG TS (it doesn't handle it correctly).
+     * Keep the ffmpeg correction for probe (even when mepgts) and all other streams.
+     */
+    int is_mpegts = decoder_context->format_context->iformat &&
+        decoder_context->format_context->iformat->name &&
+        !strcmp(decoder_context->format_context->iformat->name, "mpegts");
+    decoder_context->format_context->correct_ts_overflow =
+        !(use_custom_pts_unwrap && is_mpegts);
+
     /* Retrieve stream information */
     if (avformat_find_stream_info(decoder_context->format_context,  NULL) < 0) {
         elv_err("Could not get input stream info, url=%s", url);
@@ -313,7 +318,8 @@ prepare_decoder(
     }
 
     /* Precompute per-stream PTS/DTS wrap moduli now that pts_wrap_bits is known. */
-    pts_unwrap_init(decoder_context);
+    if (pts_unwrap_init(decoder_context) < 0)
+        return eav_timebase;
 
     dump_streams(inctx->url, decoder_context->format_context);
 
@@ -3292,7 +3298,12 @@ skip_for_sync(
 
     /* We are processing the audio packets now.
      * Skip until the audio PTS has reached the first video key frame PTS
-     * PENDING(SSS) - this is incorrect if audio PTS is muxed ahead of video
+     *
+     * PENDING(SS) - this fails in several cases:
+     * - if audio PTS is muxed ahead of video
+     * - if audio and video PTS start right at the wrap point for example:
+     *   - first video PTS: 8,589,927,600  (just before wrap)
+     *   - first audio PTS:         2,788  (just after wrap)
      */
     if (decoder_context->first_key_frame_pts == AV_NOPTS_VALUE ||
         input_packet->pts < decoder_context->first_key_frame_pts) {
@@ -3612,7 +3623,7 @@ avpipe_xc(
     }
 
     if ((rc = prepare_decoder(&xctx->decoder_ctx,
-            in_handlers, inctx, params, params->seekable)) != eav_success) {
+            in_handlers, inctx, params, params->seekable, 1)) != eav_success) {
         elv_err("Failure in preparing decoder, url=%s, rc=%d", params->url, rc);
         return rc;
     }
@@ -4351,7 +4362,8 @@ avpipe_probe(
         goto avpipe_probe_end;
     }
 
-    if ((rc = prepare_decoder(&decoder_ctx, in_handlers, &inctx, params, params->seekable)) != eav_success) {
+    if ((rc = prepare_decoder(
+            &decoder_ctx, in_handlers, &inctx, params, params->seekable, 0)) != eav_success) {
         elv_err("avpipe_probe failed to prepare decoder, url=%s", url);
         goto avpipe_probe_end;
     }

--- a/libavpipe/test/Makefile
+++ b/libavpipe/test/Makefile
@@ -12,7 +12,7 @@ CFLAGS := -O0 -ggdb -Wall \
 LIBS := $(FFMPEG_LIBS) \
 	-L$(TOP_DIR)/lib -lutils
 
-TESTS := test_color_defaults
+TESTS := test_color_defaults test_pts_unwrap
 OUT   := out
 BINS  := $(addprefix $(OUT)/,$(TESTS))
 
@@ -25,6 +25,9 @@ $(OUT):
 	mkdir -p $(OUT)
 
 $(OUT)/test_color_defaults: test_color_defaults.c unity/unity.c | $(OUT)
+	gcc $(CFLAGS) $^ -o $@ $(LIBS)
+
+$(OUT)/test_pts_unwrap: test_pts_unwrap.c unity/unity.c | $(OUT)
 	gcc $(CFLAGS) $^ -o $@ $(LIBS)
 
 clean:

--- a/libavpipe/test/test_pts_unwrap.c
+++ b/libavpipe/test/test_pts_unwrap.c
@@ -1,0 +1,572 @@
+/*
+ * Unit tests and generated MPEGTS tests for PTS unwrap.
+ */
+
+#include "unity/unity.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libavutil/error.h>
+#include <libavutil/frame.h>
+#include <libavutil/opt.h>
+
+#include "../src/avpipe_format.c"
+
+#define MPEGTS_WRAP_MODULUS ((int64_t)1 << 33)
+#define VIDEO_TIME_BASE     ((AVRational){1, 25})
+#define MPEGTS_TIME_BASE    ((AVRational){1, 90000})
+#define FRAME_DURATION_TS   3600
+#define GENERATED_FRAMES    24
+#define MAX_CAPTURED_PTS    64
+
+typedef struct unwrap_result_t {
+    int rc;
+    int packet_count;
+    int missing_timestamps;
+    int pts_reorders;
+    int pts_forward_wraps;
+    int pts_backward_wraps;
+    int dts_forward_wraps;
+    int dts_backward_wraps;
+    int nonmonotonic_dts;
+    int dts_duration_errors;
+    int invalid_pts_dts;
+    int presentation_gaps;
+} unwrap_result_t;
+
+static const AVInputFormat test_mpegts_input_format = {
+    .name = "mpegts",
+};
+
+static const AVInputFormat test_non_mpegts_input_format = {
+    .name = "matroska,webm",
+};
+
+void setUp(void)    {}
+void tearDown(void) {}
+
+static int
+make_unwrap_context(
+    coderctx_t *ctx,
+    const AVInputFormat *input_format,
+    int pts_wrap_bits,
+    AVRational time_base)
+{
+    AVStream *stream;
+
+    memset(ctx, 0, sizeof(*ctx));
+    ctx->format_context = avformat_alloc_context();
+    if (!ctx->format_context)
+        return AVERROR(ENOMEM);
+
+    ctx->format_context->iformat = input_format;
+    stream = avformat_new_stream(ctx->format_context, NULL);
+    if (!stream) {
+        avformat_free_context(ctx->format_context);
+        ctx->format_context = NULL;
+        return AVERROR(ENOMEM);
+    }
+
+    stream->codecpar->codec_type = AVMEDIA_TYPE_VIDEO;
+    stream->pts_wrap_bits = pts_wrap_bits;
+    stream->time_base = time_base;
+    return 0;
+}
+
+static void
+free_unwrap_context(
+    coderctx_t *ctx)
+{
+    avformat_free_context(ctx->format_context);
+    ctx->format_context = NULL;
+}
+
+static int
+write_available_packets(
+    AVFormatContext *format_context,
+    AVCodecContext *codec_context,
+    AVStream *stream,
+    AVPacket *packet)
+{
+    int rc;
+
+    while ((rc = avcodec_receive_packet(codec_context, packet)) >= 0) {
+        av_packet_rescale_ts(packet, codec_context->time_base, stream->time_base);
+        packet->stream_index = stream->index;
+        rc = av_interleaved_write_frame(format_context, packet);
+        av_packet_unref(packet);
+        if (rc < 0)
+            return rc;
+    }
+
+    if (rc == AVERROR(EAGAIN) || rc == AVERROR_EOF)
+        return 0;
+    return rc;
+}
+
+static void
+fill_test_frame(
+    AVFrame *frame,
+    int frame_number)
+{
+    for (int y = 0; y < frame->height; y++)
+        memset(frame->data[0] + y * frame->linesize[0],
+            16 + (frame_number * 7) % 200, frame->width);
+
+    for (int y = 0; y < frame->height / 2; y++) {
+        memset(frame->data[1] + y * frame->linesize[1],
+            96 + (frame_number * 3) % 64, frame->width / 2);
+        memset(frame->data[2] + y * frame->linesize[2],
+            160 - (frame_number * 3) % 64, frame->width / 2);
+    }
+}
+
+/*
+ * Generated tests encode MPEG-2 video with B-frames and mux as MPEG TS
+ * around 33-bit timestamps.
+ */
+static int
+generate_bframe_mpegts(
+    const char *path,
+    int64_t first_frame_pts)
+{
+    AVFormatContext *format_context = NULL;
+    AVCodecContext *codec_context = NULL;
+    const AVCodec *codec = NULL;
+    AVStream *stream = NULL;
+    AVFrame *frame = NULL;
+    AVPacket *packet = NULL;
+    int header_written = 0;
+    int rc;
+
+    rc = avformat_alloc_output_context2(&format_context, NULL, "mpegts", path);
+    if (rc < 0)
+        goto done;
+    if (!format_context) {
+        rc = AVERROR_UNKNOWN;
+        goto done;
+    }
+
+    codec = avcodec_find_encoder(AV_CODEC_ID_MPEG2VIDEO);
+    if (!codec) {
+        rc = AVERROR_ENCODER_NOT_FOUND;
+        goto done;
+    }
+
+    stream = avformat_new_stream(format_context, NULL);
+    if (!stream) {
+        rc = AVERROR(ENOMEM);
+        goto done;
+    }
+
+    codec_context = avcodec_alloc_context3(codec);
+    if (!codec_context) {
+        rc = AVERROR(ENOMEM);
+        goto done;
+    }
+
+    codec_context->codec_id = AV_CODEC_ID_MPEG2VIDEO;
+    codec_context->codec_type = AVMEDIA_TYPE_VIDEO;
+    codec_context->width = 64;
+    codec_context->height = 64;
+    codec_context->pix_fmt = AV_PIX_FMT_YUV420P;
+    codec_context->time_base = VIDEO_TIME_BASE;
+    codec_context->framerate = (AVRational){25, 1};
+    codec_context->bit_rate = 400000;
+    codec_context->gop_size = 12;
+    codec_context->max_b_frames = 2;
+
+    if (format_context->oformat->flags & AVFMT_GLOBALHEADER)
+        codec_context->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+
+    rc = avcodec_open2(codec_context, codec, NULL);
+    if (rc < 0)
+        goto done;
+
+    rc = avcodec_parameters_from_context(stream->codecpar, codec_context);
+    if (rc < 0)
+        goto done;
+    stream->time_base = MPEGTS_TIME_BASE;
+
+    /*
+     * Preserve the large input timestamps so the muxer writes the real
+     * 33-bit wrap instead of starting output stream at zero.
+     */
+    rc = av_opt_set_int(format_context->priv_data, "mpegts_copyts", 1, 0);
+    if (rc < 0)
+        goto done;
+    format_context->max_delay = 0;
+    format_context->avoid_negative_ts = AVFMT_AVOID_NEG_TS_DISABLED;
+
+    rc = avio_open(&format_context->pb, path, AVIO_FLAG_WRITE);
+    if (rc < 0)
+        goto done;
+
+    rc = avformat_write_header(format_context, NULL);
+    if (rc < 0)
+        goto done;
+    header_written = 1;
+
+    frame = av_frame_alloc();
+    packet = av_packet_alloc();
+    if (!frame || !packet) {
+        rc = AVERROR(ENOMEM);
+        goto done;
+    }
+
+    frame->format = codec_context->pix_fmt;
+    frame->width = codec_context->width;
+    frame->height = codec_context->height;
+    rc = av_frame_get_buffer(frame, 32);
+    if (rc < 0)
+        goto done;
+
+    for (int i = 0; i < GENERATED_FRAMES; i++) {
+        rc = av_frame_make_writable(frame);
+        if (rc < 0)
+            goto done;
+
+        fill_test_frame(frame, i);
+        frame->pts = first_frame_pts + i;
+
+        rc = avcodec_send_frame(codec_context, frame);
+        if (rc < 0)
+            goto done;
+        rc = write_available_packets(format_context, codec_context, stream, packet);
+        if (rc < 0)
+            goto done;
+    }
+
+    rc = avcodec_send_frame(codec_context, NULL);
+    if (rc < 0)
+        goto done;
+    rc = write_available_packets(format_context, codec_context, stream, packet);
+    if (rc < 0)
+        goto done;
+
+    rc = av_write_trailer(format_context);
+    header_written = 0;
+
+done:
+    if (header_written)
+        av_write_trailer(format_context);
+    av_packet_free(&packet);
+    av_frame_free(&frame);
+    avcodec_free_context(&codec_context);
+    if (format_context && format_context->pb)
+        avio_closep(&format_context->pb);
+    avformat_free_context(format_context);
+    return rc;
+}
+
+static int
+compare_int64(
+    const void *a,
+    const void *b)
+{
+    const int64_t aa = *(const int64_t *)a;
+    const int64_t bb = *(const int64_t *)b;
+    return (aa > bb) - (aa < bb);
+}
+
+static unwrap_result_t
+analyze_generated_mpegts(
+    const char *path)
+{
+    unwrap_result_t result;
+    AVFormatContext *format_context = NULL;
+    AVDictionary *options = NULL;
+    AVPacket *packet = NULL;
+    coderctx_t *unwrap_context = NULL;
+    pts_unwrapper_t *pts_unwrapper = NULL;
+    pts_unwrapper_t *dts_unwrapper = NULL;
+    int64_t presentation_pts[MAX_CAPTURED_PTS];
+    int presentation_count = 0;
+    int video_stream_index;
+    int have_previous = 0;
+    int64_t previous_pts = 0;
+    int64_t previous_dts = 0;
+    int rc;
+
+    memset(&result, 0, sizeof(result));
+
+    av_dict_set(&options, "correct_ts_overflow", "0", 0);
+    rc = avformat_open_input(&format_context, path, NULL, &options);
+    av_dict_free(&options);
+    if (rc < 0)
+        goto done;
+
+    rc = avformat_find_stream_info(format_context, NULL);
+    if (rc < 0)
+        goto done;
+
+    video_stream_index = av_find_best_stream(
+        format_context, AVMEDIA_TYPE_VIDEO, -1, -1, NULL, 0);
+    if (video_stream_index < 0) {
+        rc = video_stream_index;
+        goto done;
+    }
+
+    unwrap_context = calloc(1, sizeof(*unwrap_context));
+    if (!unwrap_context) {
+        rc = AVERROR(ENOMEM);
+        goto done;
+    }
+    unwrap_context->format_context = format_context;
+    rc = pts_unwrap_init(unwrap_context);
+    if (rc < 0)
+        goto done;
+    pts_unwrapper = &unwrap_context->pts_unwrapper[video_stream_index];
+    dts_unwrapper = &unwrap_context->dts_unwrapper[video_stream_index];
+
+    packet = av_packet_alloc();
+    if (!packet) {
+        rc = AVERROR(ENOMEM);
+        goto done;
+    }
+
+    while ((rc = av_read_frame(format_context, packet)) >= 0) {
+        if (packet->stream_index == video_stream_index) {
+            int64_t old_pts_offset = pts_unwrapper->offset;
+            int64_t old_dts_offset = dts_unwrapper->offset;
+            int64_t pts;
+            int64_t dts;
+
+            result.packet_count++;
+            if (packet->pts == AV_NOPTS_VALUE || packet->dts == AV_NOPTS_VALUE) {
+                result.missing_timestamps++;
+                av_packet_unref(packet);
+                continue;
+            }
+
+            pts = pts_unwrap(pts_unwrapper, packet->pts);
+            dts = pts_unwrap(dts_unwrapper, packet->dts);
+
+            if (pts_unwrapper->offset > old_pts_offset)
+                result.pts_forward_wraps++;
+            else if (pts_unwrapper->offset < old_pts_offset)
+                result.pts_backward_wraps++;
+
+            if (dts_unwrapper->offset > old_dts_offset)
+                result.dts_forward_wraps++;
+            else if (dts_unwrapper->offset < old_dts_offset)
+                result.dts_backward_wraps++;
+
+            if (pts < dts)
+                result.invalid_pts_dts++;
+
+            if (have_previous) {
+                if (pts < previous_pts)
+                    result.pts_reorders++;
+                if (dts <= previous_dts)
+                    result.nonmonotonic_dts++;
+                if (dts - previous_dts != FRAME_DURATION_TS)
+                    result.dts_duration_errors++;
+            }
+
+            if (presentation_count < MAX_CAPTURED_PTS)
+                presentation_pts[presentation_count++] = pts;
+
+            previous_pts = pts;
+            previous_dts = dts;
+            have_previous = 1;
+        }
+        av_packet_unref(packet);
+    }
+
+    if (rc == AVERROR_EOF)
+        rc = 0;
+    if (rc < 0)
+        goto done;
+
+    qsort(presentation_pts, presentation_count,
+        sizeof(presentation_pts[0]), compare_int64);
+    for (int i = 1; i < presentation_count; i++) {
+        if (presentation_pts[i] - presentation_pts[i - 1] != FRAME_DURATION_TS)
+            result.presentation_gaps++;
+    }
+
+done:
+    result.rc = rc;
+    av_packet_free(&packet);
+    free(unwrap_context);
+    avformat_close_input(&format_context);
+    return result;
+}
+
+static void
+assert_generated_wrap_case(
+    int first_frame_delta)
+{
+    char path[] = "/tmp/avpipe_pts_unwrap_XXXXXX";
+    const int64_t wrap_frame = MPEGTS_WRAP_MODULUS / FRAME_DURATION_TS;
+    unwrap_result_t result;
+    int fd;
+    int rc;
+
+    fd = mkstemp(path);
+    TEST_ASSERT_GREATER_OR_EQUAL_INT(0, fd);
+    close(fd);
+
+    rc = generate_bframe_mpegts(path, wrap_frame + first_frame_delta);
+    if (rc != 0)
+        unlink(path);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(0, rc, "failed to generate B-frame MPEG-TS");
+
+    result = analyze_generated_mpegts(path);
+    unlink(path);
+
+    TEST_ASSERT_EQUAL_INT_MESSAGE(0, result.rc, "failed to demux generated MPEG-TS");
+    TEST_ASSERT_EQUAL_INT(GENERATED_FRAMES, result.packet_count);
+    TEST_ASSERT_EQUAL_INT(0, result.missing_timestamps);
+    TEST_ASSERT_GREATER_THAN_INT_MESSAGE(0, result.pts_reorders,
+        "generated stream did not contain decode-order PTS reordering");
+    TEST_ASSERT_GREATER_THAN_INT_MESSAGE(0, result.pts_forward_wraps,
+        "generated PTS did not cross the 33-bit wrap");
+    TEST_ASSERT_GREATER_THAN_INT_MESSAGE(0, result.dts_forward_wraps,
+        "generated DTS did not cross the 33-bit wrap");
+    TEST_ASSERT_EQUAL_INT(0, result.dts_backward_wraps);
+    TEST_ASSERT_EQUAL_INT(0, result.nonmonotonic_dts);
+    TEST_ASSERT_EQUAL_INT(0, result.dts_duration_errors);
+    TEST_ASSERT_EQUAL_INT(0, result.invalid_pts_dts);
+    TEST_ASSERT_EQUAL_INT(0, result.presentation_gaps);
+}
+
+static void
+assert_sequence(
+    const int64_t *raw,
+    const int64_t *expected,
+    int count,
+    int expected_forward_wraps,
+    int expected_backward_wraps)
+{
+    pts_unwrapper_t unwrapper;
+    int forward_wraps = 0;
+    int backward_wraps = 0;
+
+    memset(&unwrapper, 0, sizeof(unwrapper));
+    unwrapper.wrap_modulus = MPEGTS_WRAP_MODULUS;
+
+    for (int i = 0; i < count; i++) {
+        int64_t old_offset = unwrapper.offset;
+        int64_t actual = pts_unwrap(&unwrapper, raw[i]);
+        TEST_ASSERT_EQUAL_INT64(expected[i], actual);
+        if (unwrapper.offset > old_offset)
+            forward_wraps++;
+        else if (unwrapper.offset < old_offset)
+            backward_wraps++;
+    }
+
+    TEST_ASSERT_EQUAL_INT(expected_forward_wraps, forward_wraps);
+    TEST_ASSERT_EQUAL_INT(expected_backward_wraps, backward_wraps);
+}
+
+void
+test_reordered_pts_crosses_wrap_in_both_directions(void)
+{
+    const int64_t m = MPEGTS_WRAP_MODULUS;
+    const int64_t raw[] = {m - 4, 3, m - 1, 0};
+    const int64_t expected[] = {m - 4, m + 3, m - 1, m};
+
+    /*
+     * A post-wrap reference frame is decoded before pre-wrap B-frames:
+     * forward wrap, backward wrap for the B-frame, then forward again.
+     */
+    assert_sequence(raw, expected, 4, 2, 1);
+}
+
+void
+test_non_mpegts_does_not_enable_custom_unwrap(void)
+{
+    coderctx_t ctx;
+
+    TEST_ASSERT_EQUAL_INT(0, make_unwrap_context(
+        &ctx, &test_non_mpegts_input_format, 32, (AVRational){1, 1000}));
+    TEST_ASSERT_EQUAL_INT(0, pts_unwrap_init(&ctx));
+    TEST_ASSERT_EQUAL_INT64(0, ctx.pts_unwrapper[0].wrap_modulus);
+    TEST_ASSERT_EQUAL_INT64(0, ctx.dts_unwrapper[0].wrap_modulus);
+    free_unwrap_context(&ctx);
+}
+
+void
+test_mpegts_rejects_unexpected_wrap_bits(void)
+{
+    coderctx_t ctx;
+
+    TEST_ASSERT_EQUAL_INT(0, make_unwrap_context(
+        &ctx, &test_mpegts_input_format, 32, MPEGTS_TIME_BASE));
+    TEST_ASSERT_EQUAL_INT(-1, pts_unwrap_init(&ctx));
+    free_unwrap_context(&ctx);
+}
+
+void
+test_mpegts_rejects_unexpected_time_base(void)
+{
+    coderctx_t ctx;
+
+    TEST_ASSERT_EQUAL_INT(0, make_unwrap_context(
+        &ctx, &test_mpegts_input_format, 33, (AVRational){1, 1000}));
+    TEST_ASSERT_EQUAL_INT(-1, pts_unwrap_init(&ctx));
+    free_unwrap_context(&ctx);
+}
+
+void
+test_reordered_pts_crosses_a_later_wrap(void)
+{
+    const int64_t m = MPEGTS_WRAP_MODULUS;
+    const int64_t raw[] = {m - 4, 3, m - 1, 0};
+    const int64_t expected[] = {2 * m - 4, 2 * m + 3, 2 * m - 1, 2 * m};
+    pts_unwrapper_t unwrapper;
+
+    memset(&unwrapper, 0, sizeof(unwrapper));
+    unwrapper.wrap_modulus = m;
+    unwrapper.has_last = 1;
+    unwrapper.last = m - 8;
+    unwrapper.offset = m;
+
+    for (int i = 0; i < 4; i++)
+        TEST_ASSERT_EQUAL_INT64(expected[i], pts_unwrap(&unwrapper, raw[i]));
+}
+
+void
+test_generated_ts_wrap_after_first_display_frame(void)
+{
+    assert_generated_wrap_case(0);
+}
+
+void
+test_generated_ts_wrap_after_second_display_frame(void)
+{
+    assert_generated_wrap_case(-1);
+}
+
+void
+test_generated_ts_wrap_later_in_bframe_gop(void)
+{
+    assert_generated_wrap_case(-3);
+}
+
+int
+main(void)
+{
+    av_log_set_level(AV_LOG_ERROR);
+    elv_logger_open("out", "test_pts_unwrap", 1, 1024 * 1024, elv_log_file);
+
+    UNITY_BEGIN();
+
+    RUN_TEST(test_non_mpegts_does_not_enable_custom_unwrap);
+    RUN_TEST(test_mpegts_rejects_unexpected_wrap_bits);
+    RUN_TEST(test_mpegts_rejects_unexpected_time_base);
+    RUN_TEST(test_reordered_pts_crosses_wrap_in_both_directions);
+    RUN_TEST(test_reordered_pts_crosses_a_later_wrap);
+    RUN_TEST(test_generated_ts_wrap_after_first_display_frame);
+    RUN_TEST(test_generated_ts_wrap_after_second_display_frame);
+    RUN_TEST(test_generated_ts_wrap_later_in_bframe_gop);
+
+    return UNITY_END();
+}

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -16,6 +16,9 @@ if [ ! -d "$REPO_ROOT/media" ]; then
     exit 1
 fi
 
+# C-level tests (Unity - always short)
+make -C libavpipe/test
+
 # First run all the tests that complete in under 5 seconds (total ~2 minutes)
 echo "=== Short tests ==="
 if ! go test -v -short --timeout 30m ./...; then


### PR DESCRIPTION
Add a simple unwrapper (largely like the Go version in common-go)

Disable ffmpeg unwrapping which doesn't work properly - only unwraps the first time.

https://github.com/eluv-io/avpipe/issues/197