### PR TITLE
Fix unit tests

### DIFF
--- a/testdata/avprobe_dovi_81.jsonc
+++ b/testdata/avprobe_dovi_81.jsonc
@@ -48,7 +48,6 @@
         "fourcc": "dvh1"
       },
       "mastering_display": "G(13250,34500)B(7500,3000)R(34000,16000)WP(15635,16450)L(40000000,50)",
-      "max_cll": "0,0",
       "mp4": {
         "codec_tag_string": "hvc1",
         "mime_codec_string": "hvc1.2.4.L93.90",


### PR DESCRIPTION
@elv-serban more failing tests:
```
--- FAIL: TestXcFiniRemovesJobAndURLHandlers (0.00s)
--- FAIL: TestXcInitFailureRollsBackURLHandlersAndDoesNotCreateJob (0.00s)
--- FAIL: TestXcRunRawOnlyReturnsTerminalErrorAndClosesInput (0.00s)
--- FAIL: TestXcRunRawOnlyClosesInputWhenStartFails (0.00s)
--- FAIL: TestXcRunRawOnlyReturnsInputCloseError (0.00s)
```

Are you planning to fix these or should I look at them?