### PR TITLE
Fix more avpipe unit tests

### DIFF
--- a/avpipe_xc_job_test.go
+++ b/avpipe_xc_job_test.go
@@ -24,16 +24,16 @@ func TestXcFiniRemovesJobAndURLHandlers(t *testing.T) {
 
 	putXCJob(handle, &xcJob{url: url})
 
-	require.Same(t, inputOpener, goavpipe.GetInputOpener(url))
-	require.Same(t, outputOpener, goavpipe.GetOutputOpener(url))
+	require.Same(t, inputOpener, goavpipe.GetURLInputOpener(url))
+	require.Same(t, outputOpener, goavpipe.GetURLOutputOpener(url))
 	require.NoError(t, XcFini(handle))
 
 	xcJobsMu.Lock()
 	_, jobExists := xcJobs[handle]
 	xcJobsMu.Unlock()
 	require.False(t, jobExists)
-	require.NotSame(t, inputOpener, goavpipe.GetInputOpener(url))
-	require.NotSame(t, outputOpener, goavpipe.GetOutputOpener(url))
+	require.Nil(t, goavpipe.GetURLInputOpener(url))
+	require.Nil(t, goavpipe.GetURLOutputOpener(url))
 	require.ErrorIs(t, XcFini(handle), EAV_BAD_HANDLE)
 }
 
@@ -59,8 +59,9 @@ func TestXcInitFailureRollsBackURLHandlersAndDoesNotCreateJob(t *testing.T) {
 
 	require.Error(t, err)
 	require.Equal(t, int32(-1), handle)
-	require.NotSame(t, inputOpener, goavpipe.GetInputOpener(url))
-	require.NotSame(t, outputOpener, goavpipe.GetOutputOpener(url))
+
+	require.Nil(t, goavpipe.GetURLInputOpener(url))
+	require.Nil(t, goavpipe.GetURLOutputOpener(url))
 
 	xcJobsMu.Lock()
 	jobsAfter := len(xcJobs)

--- a/avpipe_xc_job_test.go
+++ b/avpipe_xc_job_test.go
@@ -47,6 +47,10 @@ func TestXcInitFailureRollsBackURLHandlersAndDoesNotCreateJob(t *testing.T) {
 		goavpipe.Globals.RemoveURLHandlers(url)
 	})
 
+	// verify registration before cleanup
+	require.Same(t, inputOpener, goavpipe.GetURLInputOpener(url))
+	require.Same(t, outputOpener, goavpipe.GetURLOutputOpener(url))
+
 	xcJobsMu.Lock()
 	jobsBefore := len(xcJobs)
 	xcJobsMu.Unlock()

--- a/goavpipe/handlers.go
+++ b/goavpipe/handlers.go
@@ -301,6 +301,15 @@ func GetGlobalInputOpener() InputOpener {
 	return gInputOpener
 }
 
+// GetURLInputOpener returns the input opener registered for url by
+// InitUrlIOHandler, or nil if none is registered. Does not fall back to
+// the global opener
+func GetURLInputOpener(url string) InputOpener {
+	gMutex.Lock()
+	defer gMutex.Unlock()
+	return gURLInputOpeners[url]
+}
+
 func GetOutputOpener(url string) OutputOpener {
 	gMutex.Lock()
 	defer gMutex.Unlock()
@@ -308,6 +317,21 @@ func GetOutputOpener(url string) OutputOpener {
 		return outputOpener
 	}
 
+	return gOutputOpener
+}
+
+// GetURLOutputOpener returns the output opener registered for url by
+// InitUrlIOHandler, or nil if none is registered. Does not fall back
+// to the global opener
+func GetURLOutputOpener(url string) OutputOpener {
+	gMutex.Lock()
+	defer gMutex.Unlock()
+	return gURLOutputOpeners[url]
+}
+
+func GetGlobalOutputOpener() OutputOpener {
+	gMutex.Lock()
+	defer gMutex.Unlock()
 	return gOutputOpener
 }
 

--- a/goavpipe/handlers.go
+++ b/goavpipe/handlers.go
@@ -303,7 +303,7 @@ func GetGlobalInputOpener() InputOpener {
 
 // GetURLInputOpener returns the input opener registered for url by
 // InitUrlIOHandler, or nil if none is registered. Does not fall back to
-// the global opener
+// the global opener.
 func GetURLInputOpener(url string) InputOpener {
 	gMutex.Lock()
 	defer gMutex.Unlock()
@@ -322,13 +322,15 @@ func GetOutputOpener(url string) OutputOpener {
 
 // GetURLOutputOpener returns the output opener registered for url by
 // InitUrlIOHandler, or nil if none is registered. Does not fall back
-// to the global opener
+// to the global opener.
 func GetURLOutputOpener(url string) OutputOpener {
 	gMutex.Lock()
 	defer gMutex.Unlock()
 	return gURLOutputOpeners[url]
 }
 
+// GetGlobalOutputOpener returns the global output opener set by InitIOHandler,
+// or nil if none is set.
 func GetGlobalOutputOpener() OutputOpener {
 	gMutex.Lock()
 	defer gMutex.Unlock()

--- a/live/live_probe_test.go
+++ b/live/live_probe_test.go
@@ -83,21 +83,22 @@ func TestProbeRTMPListen(t *testing.T) {
 
 	done := make(chan bool, 1)
 	var probeInfo *goavpipe.ProbeInfo
-	var err error
+	var probeErr error
 
 	go func() {
 		tlog.Info("Probing RTMP stream start", "params", fmt.Sprintf("%+v", *XCParams))
-		probeInfo, err = avpipe.Probe(XCParams)
+		probeInfo, probeErr = avpipe.Probe(XCParams)
 		done <- true
 	}()
 
-	err = liveSource.Start("rtmp_connect")
+	time.Sleep(1 * time.Second)
+	err := liveSource.Start("rtmp_connect")
 	if err != nil {
 		t.Error(err)
 	}
 
 	<-done
-	assert.NoError(t, err)
+	assert.NoError(t, probeErr)
 	tlog.Info("Probe done", "probeInfo", fmt.Sprintf("%+v", *probeInfo))
 	assert.Equal(t, "h264", probeInfo.Streams[0].CodecName)
 	assert.Equal(t, 1920, probeInfo.Streams[0].Width)
@@ -213,22 +214,22 @@ func TestProbeUDPListen(t *testing.T) {
 
 	done := make(chan bool, 1)
 	var probeInfo *goavpipe.ProbeInfo
-	var err error
+	var probeErr error
 
 	go func() {
 		tlog.Info("Probing MPEGTS stream start", "params", fmt.Sprintf("%+v", *XCParams))
-		probeInfo, err = avpipe.Probe(XCParams)
+		probeInfo, probeErr = avpipe.Probe(XCParams)
 		done <- true
 	}()
 
 	// Start ffmpeg UDP MPEGTS
-	err = liveSource.Start("udp")
+	err := liveSource.Start("udp")
 	if err != nil {
 		t.Error(err)
 	}
 
 	<-done
-	assert.NoError(t, err)
+	assert.NoError(t, probeErr)
 	assert.Equal(t, "h264", probeInfo.Streams[0].CodecName)
 	assert.Equal(t, 1280, probeInfo.Streams[0].Width)
 	assert.Equal(t, 720, probeInfo.Streams[0].Height)

--- a/live/ts_recorder_test.go
+++ b/live/ts_recorder_test.go
@@ -205,8 +205,8 @@ func TestMultiAudioUdpToMp4(t *testing.T) {
 			"frames", result.FrameCount, "timescale", result.Timescale,
 			"sample_dur", result.SampleDur, "dts_start", result.DtsStart,
 			"dts_end", result.DtsEnd, "last", isLast)
-		assert.Equal(t, 0, result.DtsProblems, "DTS problems in %s", f)
-		assert.Equal(t, 0, result.DurProblems, "duration problems in %s", f)
+		assert.Equal(t, 0, result.DtsProblems, "DTS problems in %s: %v", f, result.Errors)
+		assert.Equal(t, 0, result.DurProblems, "duration problems in %s: %v", f, result.Errors)
 		if !isLast {
 			// All non-last parts should have the expected duration
 			expectedDurTs := uint64(xcParams.VideoSegDurationTs)
@@ -235,8 +235,8 @@ func TestMultiAudioUdpToMp4(t *testing.T) {
 				"frames", result.FrameCount, "timescale", result.Timescale,
 				"sample_dur", result.SampleDur, "dts_start", result.DtsStart,
 				"dts_end", result.DtsEnd, "last", isLast)
-			assert.Equal(t, 0, result.DtsProblems, "DTS problems in %s", f)
-			assert.Equal(t, 0, result.DurProblems, "duration problems in %s", f)
+			assert.Equal(t, 0, result.DtsProblems, "DTS problems in %s: %v", f, result.Errors)
+			assert.Equal(t, 0, result.DurProblems, "duration problems in %s: %v", f, result.Errors)
 			if !isLast {
 				expectedDurTs := uint64(xcParams.AudioSegDurationTs)
 				actualDurTs := result.DtsEnd - result.DtsStart

--- a/xc/raw_only_test.go
+++ b/xc/raw_only_test.go
@@ -64,7 +64,7 @@ func initRawOnlyTest(t *testing.T, processor *rawOnlyTestProcessor, input *rawOn
 	t.Helper()
 
 	prevIn := goavpipe.GetGlobalInputOpener()
-	prevOut := goavpipe.GetOutputOpener("")
+	prevOut := goavpipe.GetGlobalOutputOpener()
 	goavpipe.InitIOHandler(nil, nil)
 	t.Cleanup(func() { goavpipe.InitIOHandler(prevIn, prevOut) })
 


### PR DESCRIPTION
Passes full test suite on CI
-Added explicit opener handlers to help with unit test cleanup (fix avpipe_xc_job_test)
-Cleanup of live_probe_test and ts_recorder_test to catch possible intermittent CI failures